### PR TITLE
Improve __repr__ for SpectralCube

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -354,7 +354,11 @@ class SpectralCube(object):
         return self._data.ndim
 
     def __repr__(self):
-        s = "SpectralCube with shape={0}:\n".format(self.shape)
+        s = "SpectralCube with shape={0}".format(self.shape)
+        if self.unit is u.dimensionless_unscaled:
+            s += ":\n"
+        else:
+            s +=  " and unit={0}:\n".format(self.unit)
         s += " n_x: {0}  type_x: {1:8s}  unit_x: {2}\n".format(self.shape[2], self.wcs.wcs.ctype[0], self.wcs.wcs.cunit[0])
         s += " n_y: {0}  type_y: {1:8s}  unit_y: {2}\n".format(self.shape[1], self.wcs.wcs.ctype[1], self.wcs.wcs.cunit[1])
         s += " n_s: {0}  type_s: {1:8s}  unit_s: {2}".format(self.shape[0], self.wcs.wcs.ctype[2], self.wcs.wcs.cunit[2])

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -233,6 +233,15 @@ SpectralCube with shape=(4, 3, 2):
  n_s: 4  type_s: VOPT      unit_s: m / s
         """.strip()
 
+    def test_repr_withunit(self):
+        self.c._unit = u.Jy
+        assert repr(self.c) == """
+SpectralCube with shape=(4, 3, 2) and unit=Jy:
+ n_x: 2  type_x: RA---SIN  unit_x: deg
+ n_y: 3  type_y: DEC--SIN  unit_y: deg
+ n_s: 4  type_s: VOPT      unit_s: m / s
+        """.strip()
+
 def test_read_write_rountrip(tmpdir):
     cube = read(path('adv.fits'))
     tmp_file = str(tmpdir.join('test.fits'))


### PR DESCRIPTION
Just a suggestion, but at the moment the repr is not very useful, it gives the shape without saying what it is, and the preview of the data can be quite large. With this repr, there is more information and less clutter:

```
SpectralCube with shape=(602, 107, 107):
 n_x: 107  type_x: RA---SFL  unit_x: deg
 n_y: 107  type_y: DEC--SFL  unit_y: deg
 n_s: 602  type_s: VOPT      unit_s: m / s
```

This also make is immediately clear which dimension corresponds to what.
