### PR TITLE
Documentation front page improvements

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,5 @@
+API Documentation
+=================
+
+.. automodapi:: spectral_cube
+   :no-inheritance-diagram:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,11 +3,41 @@ Spectral Cube documentation
 
 The ``spectral_cube`` package provides an easy way to read, manipulate,
 analyze, and write data cubes with two positional dimensions and one
-spectral dimension, optionally with Stokes parameters. The spectral cube
-reader is designed to be robust to the wide range of conventions of axis
-order, spatial projections, and spectral units that exist, and provides a
-uniform interface to all spectral cubes. The package is designed to work with
-large files, including files larger than the available memory on a computer.
+spectral dimension, optionally with Stokes parameters.
+
+Here's a simple script demonstrating ``spectral_cube``::
+
+    >>> from spectral_cube import read
+    >>> import astropy.units as u
+    >>> cube = read('data.fits')
+    >>> print cube
+    SpectralCube with shape=(563, 640, 640) and unit=K:
+    n_x: 640  type_x: RA---SIN  unit_x: deg
+    n_y: 640  type_y: DEC--SIN  unit_y: deg
+    n_s: 563  type_s: FREQ      unit_s: Hz
+
+    # extract the subcube between 98 and 100 GHz
+    >>> slab = cube.spectral_slab(98 * u.GHz, 100 * u.GHz)
+
+    # Ignore elements fainter than 1K
+    >>> thresh = slab > 1
+    >>> thresh
+    <spectral_cube.masks.LazyMask at 0x104ddab50>
+    >>> masked_slab = slab.with_mask(thresh)
+
+    # Compute the first moment
+    >>> m1 = masked_slab.moment1(axis=0)
+
+``spectral_cube`` aims to be a versatile data container for building
+custom analysis routines. It provides the following main features:
+
+- A uniform interface to spectral cubes, robust to the
+  wide range of conventions of axis order, spatial projections,
+  and spectral units that exist in the wild.
+- Easy extraction of cube sub-regions using physical coordinates.
+- Ability to easily create, combine, and apply masks to datasets.
+- Basic summary statistic methods like moments and array aggregates.
+- Designed to work with datasets too large to load into memory.
 
 Using ``spectral_cube``
 -----------------------
@@ -28,6 +58,4 @@ cubes to files.
    moments.rst
    stokes.rst
    big_data.rst
-
-.. automodapi:: spectral_cube
-   :no-inheritance-diagram:
+   api.rst


### PR DESCRIPTION
- Code example on documentation front page
- Move API documentation off the front page
