### PR TITLE
closest_spectral_channel error message can be confusing

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -626,15 +626,18 @@ class SpectralCube(object):
         try:
             value = value.to(spectral_axis.unit, equivalencies=u.spectral())
         except u.UnitsError:
-            if rest_frequency is None:
-                raise u.UnitsError("{0} cannot be converted to {1} without a "
-                                   "rest frequency".format(value.unit, spectral_axis.unit))
+            if value.unit.is_equivalent(spectral_axis.unit, equivalencies=u.doppler_radio(None)):
+                if rest_frequency is None:
+                    raise u.UnitsError("{0} cannot be converted to {1} without a "
+                                       "rest frequency".format(value.unit, spectral_axis.unit))
+                else:
+                    try:
+                        value = value.to(spectral_axis.unit,
+                                         equivalencies=u.doppler_radio(rest_frequency))
+                    except u.UnitsError:
+                        raise u.UnitsError("{0} cannot be converted to {1}".format(value.unit, spectral_axis.unit))
             else:
-                try:
-                    value = value.to(spectral_axis.unit,
-                                     equivalencies=u.doppler_radio(rest_frequency))
-                except u.UnitsError:
-                    raise u.UnitsError("{0} cannot be converted to {1}".format(value.unit, spectral_axis.unit))
+                raise u.UnitsError("'value' should be in frequency equivalent or velocity units (got {0})".format(value.unit))
 
         # TODO: optimize the next line - just brute force for now
         return np.argmin(np.abs(spectral_axis - value))

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -197,11 +197,14 @@ class TestSlab(BaseTest):
         assert c.closest_spectral_channel(0 * ms) == 3
 
     def test_spectral_channel_bad_units(self):
-        with pytest.raises(u.UnitsError):
-            self.c.closest_spectral_channel(0 * u.s, rest_frequency=1 / u.s)
 
-        with pytest.raises(u.UnitsError):
-            self.c.closest_spectral_channel(0 * u.s)
+        with pytest.raises(u.UnitsError) as exc:
+            self.c.closest_spectral_channel(1 * u.s, rest_frequency=1 / u.s)
+        assert exc.value.args[0] == "'value' should be in frequency equivalent or velocity units (got s)"
+
+        with pytest.raises(u.UnitsError) as exc:
+            self.c.closest_spectral_channel(1. * u.Hz)
+        assert exc.value.args[0] == "Hz cannot be converted to m / s without a rest frequency"
 
     def test_slab(self):
         ms = u.m / u.s


### PR DESCRIPTION
This message:

```
raise u.UnitsError("{0} cannot be converted to {1} without a " 
                            "rest frequency".format(value.unit, spectral_axis.unit)) 
```

is confusing if the user makes an error besides forgetting about rest frequency (e.g. providing a bad unit like seconds)
