### PR TITLE
Feature Request: Overload arithmetic operations & ufuncs

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -225,6 +225,7 @@ class SpectralCube(object):
         s += " n_s: {0}  type_s: {1:8s}  unit_s: {2}".format(self.shape[0], self.wcs.wcs.ctype[2], self.wcs.wcs.cunit[2])
         return s
 
+    @warn_slow
     def apply_numpy_function(self, function, fill=np.nan,
                               reduce=True, how='auto',
                               projection=False,
@@ -406,6 +407,7 @@ class SpectralCube(object):
         ny = self.shape[iteraxes[1]]
         return nx, ny
 
+    @warn_slow
     def apply_function(self, function, axis=None, weights=None, unit=None,
                        **kwargs):
         """
@@ -526,7 +528,7 @@ class SpectralCube(object):
         """
         try:
             from bottleneck import nanmedian
-            result = self._apply_numpy_function(nanmedian, axis=axis,
+            result = self.apply_numpy_function(nanmedian, axis=axis,
                                                 projection=True,
                                                 check_endian=True, **kwargs)
         except ImportError:


### PR DESCRIPTION
Possibly lazily?

It makes sense to do things like `cube*5` and perhaps evaluate them lazily.  Right now, you could do

```
data = cube.filled_data[:] + 5
```

or 

```
cube._data += 5
```

but there's no obvious way to do arithmetic while staying the context of `SpectralCube`, unless I'm being daft which is exceedingly likely.
