### PR TITLE
Bugfix: Can't index _mask if it is None

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -544,9 +544,11 @@ class SpectralCube(object):
                          #mask=self._mask[view],
                          meta=meta)
 
+        newmask = self._mask[view] if self._mask is not None else None
+
         return self._new_cube_with(data=self._data[view],
                                    wcs=wcs_utils.slice_wcs(self._wcs, view),
-                                   mask=self._mask[view],
+                                   mask=newmask,
                                    meta=meta)
 
     @property


### PR DESCRIPTION
It is possible for `cube._mask` to be `None`, which leads to an error when using `__getitem__`.

I'll merge this as soon as it passes.
