### PR TITLE
Quicklook: Do something (not something smart) if there are unmatched celestial axes

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -146,13 +146,20 @@ class Projection(u.Quantity):
         """
         Use aplpy to make a quick-look image of the projection.  This will make
         the `FITSFigure` attribute available.
-        """
-        if not hasattr(self, 'FITSFigure'):
-            import aplpy
-            self.FITSFigure = aplpy.FITSFigure(self.hdu)
 
-        self.FITSFigure.show_grayscale()
-        self.FITSFigure.add_colorbar()
+        If there are unmatched celestial axes, this will instead show an image
+        without axis labels.
+        """
+        try:
+            if not hasattr(self, 'FITSFigure'):
+                import aplpy
+                self.FITSFigure = aplpy.FITSFigure(self.hdu)
+
+            self.FITSFigure.show_grayscale()
+            self.FITSFigure.add_colorbar()
+        except wcs.InconsistentAxisTypesError:
+            from matplotlib import pyplot
+            self.figure = pyplot.imshow(self.value)
 
 # A slice is just like a projection in every way
 class Slice(Projection):


### PR DESCRIPTION
Plotting a PV diagram resulted in this traceback:

```
>>> sl.quicklook()
Traceback (most recent call last):
  File "<ipython-input-10-9f97ea5fa0be>", line 1, in <module>
    sl.quicklook()
  File "/Users/adam/repos/spectral-cube/spectral_cube/spectral_cube.py", line 152, in quicklook
    self.FITSFigure = aplpy.FITSFigure(self.hdu)
  File "/Users/adam/repos/spectral-cube/spectral_cube/spectral_cube.py", line 120, in hdu
    hdu = fits.PrimaryHDU(self.value, header=self.wcs.to_header())
  File "/Users/adam/repos/astropy/astropy/wcs/wcs.py", line 2379, in to_header
    header_string = self.wcs.to_header(relax)
InconsistentAxisTypesError: ERROR 4 in wcs_types() at line 2136 of file cextern/wcslib/C/wcs.c:
Unmatched celestial axes.
```

so instead let's use `imshow` for now.

This is an outstanding bug, though - there needs to be a sensible way to plot a celestial axis.   In this particular case, we need smarter slicing: the axis needs to be marked as a celestial axis that doesn't need a partner.  In the more general case, we just need the pixel scale and should revert to the `OFFSET` WCS type used in pvextractor.
