### PR TITLE
ix FITS reading bug

### DIFF
--- a/spectral_cube/io/core.py
+++ b/spectral_cube/io/core.py
@@ -27,7 +27,7 @@ def read(filename, format=None, hdu=None, **kwargs):
 
     if format == 'fits':
         from .fits import load_fits_cube
-        return load_fits_cube(filename)
+        return load_fits_cube(filename, hdu=hdu, **kwargs)
     elif format == 'casa_image':
         from .casa_image import load_casa_image
         return load_casa_image(filename)


### PR DESCRIPTION
The `hdu` parameter and `**kwargs` weren't being passed to the FITS reader

(sorry about the fake post earlier if you're subscribed; keyboard did something of its own accord...)
