### PR TITLE
Add a `to_ds9` feature

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1744,9 +1744,9 @@ class SpectralCube(object):
         ds9id: None or string
             The DS9 session ID.  If 'None', a new one will be created.
             To find your ds9 session ID, open the ds9 menu option
-            File:XPA:Information and look for the XPA_METHOD string, e.g.:
-                XPA_METHOD:	86ab2314:60063
-            You would then calll this function as ``cube.to_ds9('86ab2314:60063')``
+            File:XPA:Information and look for the XPA_METHOD string, e.g.
+            ``XPA_METHOD:  86ab2314:60063``.  You would then calll this
+            function as ``cube.to_ds9('86ab2314:60063')``
         newframe: bool
             Send the cube to a new frame or to the current frame?
         """


### PR DESCRIPTION
Another in the line of viewers I like to use.  This one necessarily creates a copy in memory.

I think it will make sense to abstract this out as an inheritable ABC:

```
class Ds9Viewable(ABC):
    @abs.abstractmethod
    def hdu(self):
          # the only requirement is that there is a valid hdu method
          pass

    def to_ds9(...):
         # see the PR'd code for this function
```

Similar things could be done with `to_glue`, but maybe not `to_yt` (or even if we could, it wouldn't make sense for yt)
