### PR TITLE
Add Stokes axis at specific position

### DIFF
--- a/spectral_cube/wcs_utils.py
+++ b/spectral_cube/wcs_utils.py
@@ -72,7 +72,7 @@ def add_stokes_axis_to_wcs(wcs, add_before_ind):
     outwcs.wcs.crpix = append_to_posn(1, add_before_ind, wcs.wcs.crpix)
     outwcs.wcs.cdelt = append_to_posn(1, add_before_ind, wcs.wcs.get_cdelt())
     outwcs.wcs.crval = append_to_posn(1, add_before_ind, wcs.wcs.crval)
-    outwcs.wcs.cunit = append_to_posn("a", add_before_ind, wcs.wcs.cunit)
+    outwcs.wcs.cunit = append_to_posn("", add_before_ind, wcs.wcs.cunit)
     outwcs.wcs.ctype = append_to_posn("STOKES", add_before_ind, wcs.wcs.ctype)
     outwcs.wcs.cname = append_to_posn("STOKES", add_before_ind, wcs.wcs.cname)
     outwcs.wcs.pc = pc


### PR DESCRIPTION
Previously it was always appending to the end. This fixes one of the issues from #171 , where clean would crash from the outputted mask.
