### PR TITLE
Fix air wavelength conversion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - Output mask as a CASA image https://github.com/radio-astro-tools/spectral-cube/pull/171
 - ytcube exports to .obj and .ply too
   https://github.com/radio-astro-tools/spectral-cube/pull/173
+- Fix air wavelengths, which were mistreated (https://github.com/radio-astro-tools/spectral-cube/pull/186)
 
 0.2.1 (2014-12-03)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@
 - Output mask as a CASA image https://github.com/radio-astro-tools/spectral-cube/pull/171
 - ytcube exports to .obj and .ply too
   https://github.com/radio-astro-tools/spectral-cube/pull/173
-- Fix air wavelengths, which were mistreated (https://github.com/radio-astro-tools/spectral-cube/pull/186)
+- Fix air wavelengths, which were mistreated
+  (https://github.com/radio-astro-tools/spectral-cube/pull/186)
 
 0.2.1 (2014-12-03)
 ------------------

--- a/spectral_cube/spectral_axis.py
+++ b/spectral_cube/spectral_axis.py
@@ -404,5 +404,5 @@ def air_to_vac_deriv(wavelength):
     Eqn 66
     """
     wlum = wavelength.to(u.um).value
-    return (1+1e-6*(287.6155 - 1.62877/wlum**2 - 0.04080/wlum**4))
+    return (1+1e-6*(287.6155 - 1.62887/wlum**2 - 0.04080/wlum**4))
 

--- a/spectral_cube/spectral_axis.py
+++ b/spectral_cube/spectral_axis.py
@@ -253,12 +253,12 @@ def convert_spectral_axis(mywcs, outunit, out_ctype, rest_value=None):
     crval_in = (mywcs.wcs.crval[mywcs.wcs.spec] * inunit)
     cdelt_in = (mywcs.wcs.cdelt[mywcs.wcs.spec] * inunit)
 
-    if in_spec_ctype == 'air wavelength':
+    if in_spec_ctype == 'AWAV':
         warnings.warn("Support for air wavelengths is experimental and only "
                       "works in the forward direction (air->vac, not vac->air).")
         cdelt_in = air_to_vac_deriv(crval_in) * cdelt_in
         crval_in = air_to_vac(crval_in)
-        in_spec_ctype = 'wavelength'
+        in_spec_ctype = 'WAVE'
 
     # 1. Convert input to input, linear
     if in_vcequiv is not None and ref_value is not None:
@@ -362,7 +362,9 @@ def cdelt_derivative(crval, cdelt, intype, outtype, linear=False, rest=None):
             return (-numer/denom).to(PHYS_UNIT_DICT[outtype], u.spectral())
         else:
             return (numer/denom).to(PHYS_UNIT_DICT[outtype], u.spectral())
-    elif intype == 'air wavelength': # Redundant: not used
+    elif intype == 'air wavelength':
+        raise ValueError("Air wavelength should be converted to vacuum earlier.")
+        # Convert to vacuum wavelength, then continue
         return cdelt_derivative(air_to_vac(crval),
                                 air_to_vac_deriv(crval)*cdelt,
                                 intype='length',
@@ -370,6 +372,8 @@ def cdelt_derivative(crval, cdelt, intype, outtype, linear=False, rest=None):
                                 linear=linear,
                                 rest=rest)
     elif outtype == 'air wavelength':
+        # I thought this wasn't supported?
+        raise ValueError("Conversion to air wavelength not supported.")
         cdelt2 = cdelt_derivative(crval,
                                   cdelt,
                                   intype=intype,

--- a/spectral_cube/spectral_axis.py
+++ b/spectral_cube/spectral_axis.py
@@ -65,28 +65,6 @@ def wcs_unit_scale(unit):
         if wu.is_equivalent(unit):
             return wu.to(unit)
 
-def _get_linear_equivalency(unit1, unit2):
-    """
-    Determin the default / "natural" convention
-    Radio <-> freq
-    Optical <-> wavelength
-    """
-
-    if unit1.is_equivalent(unit2):
-        # Only a change of units is needed
-        return lambda *args: []
-    elif unit1.is_equivalent(unit2, u.spectral()):
-        # wavelength <-> frequency
-        # this is NOT a linear transformation (w = 1/v)
-        return None
-    elif (unit1.physical_type in ('frequency','speed') and
-          unit2.physical_type in ('frequency','speed')):
-        # top 'if' statement rules out both being the same
-        return u.doppler_radio
-    elif (unit1.physical_type in ('length','speed') and
-          unit2.physical_type in ('length','speed')):
-        return u.doppler_optical
-
 def determine_vconv_from_ctype(ctype):
     """
     Given a CTYPE, say what velocity convention it is associated with,
@@ -363,25 +341,9 @@ def cdelt_derivative(crval, cdelt, intype, outtype, linear=False, rest=None):
         else:
             return (numer/denom).to(PHYS_UNIT_DICT[outtype], u.spectral())
     elif intype == 'air wavelength':
-        raise ValueError("Air wavelength should be converted to vacuum earlier.")
-        # Convert to vacuum wavelength, then continue
-        return cdelt_derivative(air_to_vac(crval),
-                                air_to_vac_deriv(crval)*cdelt,
-                                intype='length',
-                                outtype=outtype,
-                                linear=linear,
-                                rest=rest)
+        raise TypeError("Air wavelength should be converted to vacuum earlier.")
     elif outtype == 'air wavelength':
-        # I thought this wasn't supported?
-        raise ValueError("Conversion to air wavelength not supported.")
-        cdelt2 = cdelt_derivative(crval,
-                                  cdelt,
-                                  intype=intype,
-                                  outtype='length',
-                                  linear=linear,
-                                  rest=rest)
-        return air_to_vac_deriv(crval) * cdelt2
-                                
+        raise TypeError("Conversion to air wavelength not supported.")
     else:
         raise ValueError("Invalid in/out frames")
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -892,8 +892,15 @@ class SpectralCube(object):
         from .spectral_axis import (convert_spectral_axis,
                                     determine_ctype_from_vconv)
 
+        # Velocity conventions: required for frq <-> velo
+        # convert_spectral_axis will handle the case of no velocity
+        # convention specified & one is required
         if velocity_convention in DOPPLER_CONVENTIONS:
             velocity_convention = DOPPLER_CONVENTIONS[velocity_convention]
+        elif (velocity_convention is not None and
+              velocity_convention not in DOPPLER_CONVENTIONS.values()):
+            raise ValueError("Velocity convention must be radio, optical, "
+                             "or relativistic.")
 
         # Shorter versions to keep lines under 80
         ctype_from_vconv = determine_ctype_from_vconv

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -885,6 +885,9 @@ class SpectralCube(object):
             already if the *input* type is velocity, but the WCS's rest
             wavelength/frequency can be overridden with this parameter.
 
+            .. note: This must be the rest frequency/wavelength *in vacuum*,
+                     even if your cube has air wavelength units
+
         """
         from .spectral_axis import (convert_spectral_axis,
                                     determine_ctype_from_vconv)

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -902,6 +902,13 @@ class SpectralCube(object):
             raise ValueError("Velocity convention must be radio, optical, "
                              "or relativistic.")
 
+        # If rest value is specified, it must be a quantity
+        if (rest_value is not None and
+            (not hasattr(rest_value, 'unit') or
+             not rest_value.unit.is_equivalent(u.m, u.spectral()))):
+            raise ValueError("Rest value must be specified as an astropy "
+                             "quantity with spectral equivalence.")
+
         # Shorter versions to keep lines under 80
         ctype_from_vconv = determine_ctype_from_vconv
         vc = velocity_convention

--- a/spectral_cube/tests/test_spectral_axis.py
+++ b/spectral_cube/tests/test_spectral_axis.py
@@ -477,3 +477,14 @@ def test_byhand_awav2vel():
     np.testing.assert_almost_equal(newwcs.wcs.cdelt, CDELT3V.to(u.m/u.s).value)
     # Check that the reference wavelength is 2.81 angstroms up
     np.testing.assert_almost_equal(newwcs.wcs_pix2world((2.81,), 0), 0.0, decimal=3)
+
+
+    # Go through a full-on sanity check:
+    vline = 100*u.km/u.s
+    wave_line_vac = vline.to(u.AA, u.doppler_optical(restwl))
+    wave_line_air = vac_to_air(wave_line_vac)
+
+    pix_line_input = mywcs.wcs_world2pix((wave_line_air.to(u.m).value,), 0)
+    pix_line_output = newwcs.wcs_world2pix((vline.to(u.m/u.s).value,), 0)
+
+    np.testing.assert_almost_equal(pix_line_output, pix_line_input, decimal=4)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -621,3 +621,16 @@ def test_spectral_unit_conventions():
     assert cube_opt.spectral_axis[1] != cube_rad.spectral_axis[1]
     assert cube_rel.spectral_axis[1] != cube_opt.spectral_axis[1]
 
+    assert cube_rel.velocity_convention == u.doppler_relativistic
+    assert cube_rad.velocity_convention == u.doppler_radio
+    assert cube_opt.velocity_convention == u.doppler_optical
+
+def test_invalid_spectral_unit_conventions():
+
+    cube, data = cube_and_raw('advs.fits')
+
+    with pytest.raises(ValueError) as exc:
+        cube.with_spectral_unit(u.km/u.s,
+                                velocity_convention='invalid velocity convention')
+    assert exc.value.args[0] == ("Velocity convention must be radio, optical, "
+                                 "or relativistic.")

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -634,3 +634,15 @@ def test_invalid_spectral_unit_conventions():
                                 velocity_convention='invalid velocity convention')
     assert exc.value.args[0] == ("Velocity convention must be radio, optical, "
                                  "or relativistic.")
+
+@pytest.mark.parametrize('rest', (50, 50*u.K))
+def test_invalid_rest(rest):
+
+    cube, data = cube_and_raw('advs.fits')
+
+    with pytest.raises(ValueError) as exc:
+        cube.with_spectral_unit(u.km/u.s,
+                                velocity_convention='radio',
+                                rest_value=rest)
+    assert exc.value.args[0] == ("Rest value must be specified as an astropy "
+                                 "quantity with spectral equivalence.")

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -597,3 +597,27 @@ def test_header_units_consistent():
     cube_freq_GHz = cube.with_spectral_unit(u.GHz)
 
     assert cube_freq_GHz.header['CUNIT3'] == 'GHz'
+
+def test_spectral_unit_conventions():
+
+    cube, data = cube_and_raw('advs.fits')
+    cube_frq = cube.with_spectral_unit(u.Hz)
+
+    cube_opt = cube.with_spectral_unit(u.km/u.s,
+                                       rest_value=cube_frq.spectral_axis[0],
+                                       velocity_convention='optical')
+    cube_rad = cube.with_spectral_unit(u.km/u.s,
+                                       rest_value=cube_frq.spectral_axis[0],
+                                       velocity_convention='radio')
+    cube_rel = cube.with_spectral_unit(u.km/u.s,
+                                       rest_value=cube_frq.spectral_axis[0],
+                                       velocity_convention='relativistic')
+
+    # should all be exactly 0 km/s
+    for x in (cube_rel.spectral_axis[0], cube_rad.spectral_axis[0],
+              cube_opt.spectral_axis[0]):
+        np.testing.assert_almost_equal(0,x.value)
+    assert cube_rel.spectral_axis[1] != cube_rad.spectral_axis[1]
+    assert cube_opt.spectral_axis[1] != cube_rad.spectral_axis[1]
+    assert cube_rel.spectral_axis[1] != cube_opt.spectral_axis[1]
+


### PR DESCRIPTION
Air wavelengths were being treated incorrectly due to mishandling of the CTYPE keywords.