### PR TITLE
add __eq__ and __ne__ comparisons (which yield lazy masks)

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1596,6 +1596,9 @@ class SpectralCube(object):
     def __eq__(self, value):
         return LazyMask(lambda data: data == value, data=self._data, wcs=self._wcs)
 
+    def __hash__(self):
+        return id(self)
+
     def __ne__(self, value):
         return LazyMask(lambda data: data != value, data=self._data, wcs=self._wcs)
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1593,6 +1593,12 @@ class SpectralCube(object):
     def __lt__(self, value):
         return LazyMask(lambda data: data < value, data=self._data, wcs=self._wcs)
 
+    def __eq__(self, value):
+        return LazyMask(lambda data: data == value, data=self._data, wcs=self._wcs)
+
+    def __ne__(self, value):
+        return LazyMask(lambda data: data != value, data=self._data, wcs=self._wcs)
+
     @classmethod
     def read(cls, filename, format=None, hdu=None, **kwargs):
         """


### PR DESCRIPTION
These were just overlooked, I think.  Previously, `__eq__` and `__ne__` would use `object`'s equality, which I think is identical to `is`, e.g.:

```
x = object()
x == x
x is x
```
those comparisons should be the same, afaik

cc @astrofrog - this is a nearly trivial change; can you think of any reason not to incorporate it?