### PR TITLE
spectral-cube cannot read this header

### DIFF
--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -85,9 +85,7 @@ def _split_stokes(array, wcs):
 
     stokes_arrays = {}
 
-    # wcs_slice = wcs_utils.drop_axis(wcs, array.ndim - 1 - stokes_index)
-    wcs_slice = wcs.sub([WCSSUB_CELESTIAL, WCSSUB_SPECTRAL])
-    wcs_slice.to_header()
+    wcs_slice = wcs_utils.drop_axis(wcs, array.ndim - 1 - stokes_index)
 
     for i_stokes in range(array.shape[stokes_index]):
 

--- a/spectral_cube/wcs_utils.py
+++ b/spectral_cube/wcs_utils.py
@@ -135,6 +135,20 @@ def reindex_wcs(wcs, inds):
     outwcs.wcs.cname = [wcs.wcs.cname[i] for i in inds]
     outwcs.wcs.pc = pc[inds[:, None], inds[None, :]]
 
+    pv_cards = []
+    for i, j in enumerate(inds):
+        for k, m, v in wcs.wcs.get_pv():
+            if k == j:
+                pv_cards.append((i, m, v))
+    outwcs.wcs.set_pv(pv_cards)
+
+    ps_cards = []
+    for i, j in enumerate(inds):
+        for k, m, v in wcs.wcs.get_ps():
+            if k == j:
+                ps_cards.append((i, m, v))
+    outwcs.wcs.set_ps(ps_cards)
+
     return outwcs
 
 


### PR DESCRIPTION
This is *not* a valid header, but it is trivially modified to become one by changing `'VELOCITY'` to `'VELO'`:

```
SIMPLE  =                    T         /
BITPIX  =                   32         /
NAXIS   =                    4         /
NAXIS1  =                  107         /
NAXIS2  =                  158         /
NAXIS3  =                  100         /
NAXIS4  =                    1         /
BSCALE  =  0.1019910267352E-08         /
BZERO   =  0.8847990036011E+00         /
BLANK   =           2147483647         / Blanking value
DATAMIN = -0.1305441617966E+01         /
DATAMAX =  0.3075039386749E+01         /
BUNIT   = 'K (Tmb)     '               /
CTYPE1  = 'RA---GLS    '               /
CRVAL1  =  0.2726166666667E+03         /
CDELT1  = -0.2777777779420E-02         /
CRPIX1  =  0.5300648762083E+02         /
CROTA1  =  0.0000000000000E+00         /
CTYPE2  = 'DEC--GLS    '               /
CRVAL2  = -0.1938083333333E+02         /
CDELT2  =  0.2777777779420E-02         /
CRPIX2  =  0.6253897971531E+02         /
CROTA2  =  0.0000000000000E+00         /
CTYPE3  = 'VELOCITY'                   /
CRVAL3  =  0.3000000000000E+05         /
CDELT3  =  0.5000000000000E+03         /
CRPIX3  =  0.5000000000000E+02         /
CROTA3  =  0.0000000000000E+00         /
CTYPE4  = '            '               /
CRVAL4  =  0.1000000000000E+01         /
CDELT4  =  0.1000000000000E+01         /
CRPIX4  =  0.1000000000000E+01         /
CROTA4  =  0.0000000000000E+00         /
RA      =  0.2726166666667E+03         / Right Ascension
DEC     = -0.1938083333333E+02         / Declination
EQUINOX =  0.2000000000000E+04         /
LINE    = 'C18O(2-1)   '
ALTRVAL =  0.3000000000000E+07         /
ALTRPIX =  0.5000000000000E+02         /
RESTFREQ=  0.2195603570000E+12         /
VELREF  =  0.3000000000000E+07         /
BMAJ    =  0.8383879336681E-02         /
BMIN    =  0.8383879336681E-02         /
BPA     =  0.0000000000000E+00         /
ORIGIN  = 'GILDAS Consortium  '        /
DATE    = '2014-03-25T00:00:00.00'     / Date written
END
```

Part of the problem is easily fixed: we change VELOCITY to VELO by default for cubes, we just need to do it for Stokes cubes too.

The other part I cannot understand:
```
cube = SpectralCube.read('G11_C18O_0.5kms.fits')
WARNING: FITSFixedWarning: VELREF = 0.3000000000000E+07 /
Malformed keycomment. [astropy.wcs.wcs]
WARNING: FITSFixedWarning: 'celfix' made the change 'Success'. [astropy.wcs.wcs]
/Users/adam/repos/spectral-cube/spectral_cube/cube_utils.py:22: UserWarning: No spectral axis found; header may be non-compliant.
  warnings.warn("No spectral axis found; header may be non-compliant.")
/Users/adam/repos/spectral-cube/spectral_cube/cube_utils.py:66: UserWarning: FITS file has no STOKES axis, but it has a blank axis type at index {0} that is assumed to be stokes.
  warnings.warn("FITS file has no STOKES axis, but it has a blank"
Traceback (most recent call last):
  File "<ipython-input-1-d767a0345394>", line 1, in <module>
    cube = SpectralCube.read('G11_C18O_0.5kms.fits')
  File "/Users/adam/repos/spectral-cube/spectral_cube/spectral_cube.py", line 1628, in read
    cube = read(filename, format=format, hdu=hdu, **kwargs)
  File "/Users/adam/repos/spectral-cube/spectral_cube/io/core.py", line 30, in read
    return load_fits_cube(filename, hdu=hdu, **kwargs)
  File "/Users/adam/repos/spectral-cube/spectral_cube/io/fits.py", line 133, in load_fits_cube
    data[component], wcs_slice = cube_utils._orient(data[component], wcs)
  File "/Users/adam/repos/spectral-cube/spectral_cube/cube_utils.py", line 120, in _orient
    wcs = _fix_spectral(wcs)
  File "/Users/adam/repos/spectral-cube/spectral_cube/cube_utils.py", line 12, in _fix_spectral
    axtypes = wcs.get_axis_types()
  File "/Users/adam/repos/astropy/astropy/wcs/wcs.py", line 2551, in get_axis_types
    for axis_type in self.wcs.axis_types:
InvalidTransformError: ERROR 7 in wcsset() at line 1760 of file cextern/wcslib/C/wcs.c:
Ill-conditioned coordinate transformation parameters.
ERROR 4 in celset() at line 399 of file cextern/wcslib/C/cel.c:
Ill-conditioned coordinate transformation parameters
No valid solution for latp for these values of phip, phi0, and theta0.
```