### PR TITLE
Beam information lost in moment maps

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -98,13 +98,22 @@ class LowerDimensionalObject(u.Quantity):
         return self._meta
 
     @property
+    def header(self):
+        header = self._header
+        # This inplace update is OK; it's not bad to overwrite WCS in this
+        # header
+        if self.wcs is not None:
+            header.update(self.wcs.to_header())
+        header['BUNIT'] = self.unit.to_string(format='fits')
+        header.insert(2, Card(keyword='NAXIS', value=self.ndim))
+        for ind,sh in enumerate(self.shape[::-1]):
+            header.insert(3+ind, Card(keyword='NAXIS{0:1d}'.format(ind+1),
+                                      value=sh))
+        return header
+
+    @property
     def hdu(self):
-        from astropy.io import fits
-        if self.wcs is None:
-            hdu = fits.PrimaryHDU(self.value)
-        else:
-            hdu = fits.PrimaryHDU(self.value, header=self.wcs.to_header())
-        hdu.header['BUNIT'] = self.unit.to_string(format='fits')
+        hdu = PrimaryHDU(self.value, header=self.header)
         return hdu
 
     def write(self, filename, format=None, overwrite=False):
@@ -131,7 +140,7 @@ class LowerDimensionalObject(u.Quantity):
 class Projection(LowerDimensionalObject):
 
     def __new__(cls, value, unit=None, dtype=None, copy=True, wcs=None,
-                meta=None, mask=None):
+                meta=None, mask=None, header=None):
 
         if np.asarray(value).ndim != 2:
             raise ValueError("value should be a 2-d array")
@@ -144,6 +153,10 @@ class Projection(LowerDimensionalObject):
         self._wcs = wcs
         self._meta = meta
         self._mask = mask
+        if header is None:
+            self._header = header
+        else:
+            self._header = Header()
 
         return self
 
@@ -184,7 +197,7 @@ class Slice(Projection):
 class OneDSpectrum(LowerDimensionalObject):
 
     def __new__(cls, value, unit=None, dtype=None, copy=True, wcs=None,
-                meta=None, mask=None):
+                meta=None, mask=None, header=None):
 
         if np.asarray(value).ndim != 1:
             raise ValueError("value should be a 1-d array")
@@ -197,6 +210,10 @@ class OneDSpectrum(LowerDimensionalObject):
         self._wcs = wcs
         self._meta = meta
         self._mask = mask
+        if header is None:
+            self._header = header
+        else:
+            self._header = Header()
 
         return self
 
@@ -424,6 +441,7 @@ class SpectralCube(object):
                                         wcs=new_wcs,
                                         copy=False,
                                         unit=unit,
+                                        header=self._nowcs_header,
                                         meta=meta)
                 else:
                     return out
@@ -431,7 +449,8 @@ class SpectralCube(object):
             else:
                 new_wcs = wcs_utils.drop_axis(self._wcs, np2wcs[axis])
 
-                return Projection(out, copy=False, wcs=new_wcs, meta=meta, unit=unit)
+                return Projection(out, copy=False, wcs=new_wcs, meta=meta,
+                                  unit=unit, header=self._nowcs_header)
         else:
             return out
 
@@ -652,7 +671,8 @@ class SpectralCube(object):
 
             meta = {'collapse_axis': axis}
 
-            return Projection(out, copy=False, wcs=new_wcs, meta=meta, unit=unit)
+            return Projection(out, copy=False, wcs=new_wcs, meta=meta,
+                              unit=unit, header=self._nowcs_header)
         else:
             return out
 
@@ -830,6 +850,7 @@ class SpectralCube(object):
                          wcs=newwcs,
                          copy=False,
                          unit=self.unit,
+                         header=self._nowcs_header,
                          meta=meta)
 
         newmask = self._mask[view] if self._mask is not None else None
@@ -1205,7 +1226,8 @@ class SpectralCube(object):
                 'moment_axis': axis,
                 'moment_method': how}
 
-        return Projection(out, copy=False, wcs=new_wcs, meta=meta)
+        return Projection(out, copy=False, wcs=new_wcs, meta=meta,
+                          header=self._nowcs_header)
 
     def moment0(self, axis=0, how='auto'):
         """Compute the zeroth moment along an axis.
@@ -1673,11 +1695,10 @@ class SpectralCube(object):
             StrictVersion(yt.__version__) >= StrictVersion('3.0')):
 
             from yt.frontends.fits.api import FITSDataset
-            from astropy.io import fits
             from yt.units.unit_object import UnitParseError
 
-            hdu = fits.PrimaryHDU(self._get_filled_data(fill=0.),
-                                  header=self.wcs.to_header())
+            hdu = PrimaryHDU(self._get_filled_data(fill=0.),
+                             header=self.wcs.to_header())
 
             units = str(self.unit.to_string())
 
@@ -1818,9 +1839,16 @@ class SpectralCube(object):
 
 
     @property
+    def _nowcs_header(self):
+        """
+        Return a copy of the header with no WCS information attached
+        """
+        return wcs_utils.strip_wcs_from_header(self._header)
+
+    @property
     def header(self):
         # Preserve non-WCS information from previous header iteration
-        header = wcs_utils.strip_wcs_from_header(self._header)
+        header = self._nowcs_header
         header.update(self.wcs.to_header())
         header['BUNIT'] = self.unit.to_string(format='fits')
         header.insert(2, Card(keyword='NAXIS', value=self._data.ndim))
@@ -1842,8 +1870,7 @@ class SpectralCube(object):
         """
         HDU version of self
         """
-        from astropy.io import fits
-        hdu = fits.PrimaryHDU(self.filled_data[:].value, header=self.header)
+        hdu = PrimaryHDU(self.filled_data[:].value, header=self.header)
         return hdu
 
 class StokesSpectralCube(SpectralCube):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -153,7 +153,7 @@ class Projection(LowerDimensionalObject):
         self._wcs = wcs
         self._meta = meta
         self._mask = mask
-        if header is None:
+        if header is not None:
             self._header = header
         else:
             self._header = Header()
@@ -210,7 +210,7 @@ class OneDSpectrum(LowerDimensionalObject):
         self._wcs = wcs
         self._meta = meta
         self._mask = mask
-        if header is None:
+        if header is not None:
             self._header = header
         else:
             self._header = Header()


### PR DESCRIPTION
Hi,

I am calculating the integrated intensity map in a cube:
```file_in='NGC1333_ABCDEFGH_NH3_11_all.fits'
cube_raw = SpectralCube.read(file_in)
cube = cube_raw.with_spectral_unit(u.km / u.s,velocity_convention='radio')
mom=cube.moment(order=0)
mom.write( 'NGC1333_test_Tdv.fits')
```
that has the following beam information in the raw cube
```
print repr(cube.header)
SIMPLE  =                    T / Written by IDL:  Sat Feb  7 00:02:58 2015      
BITPIX  =                  -32 / Number of bits per data pixel                  
NAXIS   =                    3                                                  
NAXIS1  =                  192                                                  
NAXIS2  =                  336                                                  
NAXIS3  =                  801                                                                   
----- snip
BMAJ    =           0.00870000 /                                                
BMIN    =           0.00870000 /                                                
BPA     =        0.00000000000 /                                                
----- snip                                               
```
while the full header if the integrated intensity map does not have the beam information (it lost a few keywords):
```
In [27]: print repr(hdulist[0].header)
SIMPLE  =                    T / conforms to FITS standard                      
BITPIX  =                  -64 / array data type                                
NAXIS   =                    2 / number of array dimensions                     
NAXIS1  =                  192                                                  
NAXIS2  =                  336                                                  
WCSAXES =                    2 / Number of coordinate axes                      
CRPIX1  =                107.0 / Pixel coordinate of reference point            
CRPIX2  =                168.0 / Pixel coordinate of reference point            
CDELT1  =              -0.0029 / [deg] Coordinate increment at reference point  
CDELT2  =               0.0029 / [deg] Coordinate increment at reference point  
CUNIT1  = 'deg'                / Units of coordinate increment and value        
CUNIT2  = 'deg'                / Units of coordinate increment and value        
CTYPE1  = 'RA---TAN'           / Right ascension, gnomonic projection           
CTYPE2  = 'DEC--TAN'           / Declination, gnomonic projection               
CRVAL1  =        52.2893333435 / [deg] Coordinate value at reference point      
CRVAL2  =        31.3283596039 / [deg] Coordinate value at reference point      
LONPOLE =                180.0 / [deg] Native longitude of celestial pole       
LATPOLE =        31.3283596039 / [deg] Native latitude of celestial pole        
RESTFRQ =        23694495500.0 / [Hz] Line rest frequency                       
WCSNAME = 'LSRK-Freq'          / Coordinate system title                        
RADESYS = 'FK5'                / Equatorial coordinate system                   
EQUINOX =               2000.0 / [yr] Equinox of equatorial coordinates         
SPECSYS = 'LSRK'               / Reference frame of spectral coordinates        
BUNIT   = 'K km s-1'         
```

Do I really have to restore the beam information manually after the moment map is calculated?