### PR TITLE
Preserve BUNIT in header when it cannot be parsed

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1850,7 +1850,12 @@ class SpectralCube(object):
         # Preserve non-WCS information from previous header iteration
         header = self._nowcs_header
         header.update(self.wcs.to_header())
-        header['BUNIT'] = self.unit.to_string(format='fits')
+        if self.unit == u.dimensionless_unscaled and 'BUNIT' in self._meta:
+            # preserve the BUNIT even though it's not technically valid
+            # (Jy/Beam)
+            header['BUNIT'] = self._meta['BUNIT']
+        else:
+            header['BUNIT'] = self.unit.to_string(format='fits')
         header.insert(2, Card(keyword='NAXIS', value=self._data.ndim))
         header.insert(3, Card(keyword='NAXIS1', value=self.shape[2]))
         header.insert(4, Card(keyword='NAXIS2', value=self.shape[1]))

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -697,3 +697,10 @@ def test_preserve_bunit():
     cube, data = cube_and_raw('advs.fits')
 
     assert cube.header['BUNIT'] == 'JY/BEAM'
+
+    hdu = fits.open(path('advs.fits'))[0]
+    hdu.header['BUNIT'] = 'K'
+    cube = SpectralCube.read(hdu)
+
+    assert cube.unit == u.K
+    assert cube.header['BUNIT'] == 'K'

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -691,3 +691,9 @@ def test_oned_slice():
     # data has a redundant 1st axis
     np.testing.assert_equal(spec.value, data[0,:,0,0])
     assert cube.unit == spec.unit
+
+def test_preserve_bunit():
+
+    cube, data = cube_and_raw('advs.fits')
+
+    assert cube.header['BUNIT'] == 'JY/BEAM'


### PR DESCRIPTION
e.g., JY/BEAM should stay in the output header even though there is no appropriate Unit for it