### PR TITLE
Improved __repr__

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -366,22 +366,22 @@ class SpectralCube(object):
     @property
     @cached
     def spectral_extrema(self):
-        self._spectral_min = self.spectral_axis.min()
-        self._spectral_max = self.spectral_axis.max()
+        _spectral_min = self.spectral_axis.min()
+        _spectral_max = self.spectral_axis.max()
 
-        return self._spectral_min, self._spectral_max
+        return _spectral_min, _spectral_max
 
     @property
     @cached
     def world_extrema(self):
         lat,lon = self.spatial_coordinate_map
-        self._lon_min = lon.min()
-        self._lon_max = lon.max()
-        self._lat_min = lat.min()
-        self._lat_max = lat.max()
+        _lon_min = lon.min()
+        _lon_max = lon.max()
+        _lat_min = lat.min()
+        _lat_max = lat.max()
 
-        return ((self._lon_min, self._lon_max),
-                (self._lat_min, self._lat_max))
+        return ((_lon_min, _lon_max),
+                (_lat_min, _lat_max))
 
     @property
     @cached

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -363,6 +363,7 @@ class SpectralCube(object):
                                              ))
         return s
 
+    @property
     @cached
     def spectral_extrema(self):
         self._spectral_min = self.spectral_axis.min()
@@ -370,6 +371,7 @@ class SpectralCube(object):
 
         return self._spectral_min, self._spectral_max
 
+    @property
     @cached
     def world_extrema(self):
         lat,lon = self.spatial_coordinate_map
@@ -381,11 +383,13 @@ class SpectralCube(object):
         return ((self._lon_min, self._lon_max),
                 (self._lat_min, self._lat_max))
 
+    @property
     @cached
     def longitude_extrema(self):
         return self.world_extrema[0]
 
     @property
+    @cached
     def latitude_extrema(self):
         return self.world_extrema[1]
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -340,10 +340,63 @@ class SpectralCube(object):
             s += ":\n"
         else:
             s += " and unit={0}:\n".format(self.unit)
-        s += " n_x: {0}  type_x: {1:8s}  unit_x: {2}\n".format(self.shape[2], self.wcs.wcs.ctype[0], self.wcs.wcs.cunit[0])
-        s += " n_y: {0}  type_y: {1:8s}  unit_y: {2}\n".format(self.shape[1], self.wcs.wcs.ctype[1], self.wcs.wcs.cunit[1])
-        s += " n_s: {0}  type_s: {1:8s}  unit_s: {2}".format(self.shape[0], self.wcs.wcs.ctype[2], self.wcs.wcs.cunit[2])
+        s += (" n_x: {0:6d}  type_x: {1:8s}  unit_x: {2:5s}"
+              "  range: {3:8s}:{4:8s}\n".format(self.shape[2],
+                                                self.wcs.wcs.ctype[0],
+                                                self.wcs.wcs.cunit[0],
+                                                self.longitude_extrema[0],
+                                                self.longitude_extrema[1],
+                                               ))
+        s += (" n_y: {0:6d}  type_y: {1:8s}  unit_y: {2:5s}"
+              "  range: {3:8s}:{4:8s}\n".format(self.shape[1],
+                                                self.wcs.wcs.ctype[1],
+                                                self.wcs.wcs.cunit[1],
+                                                self.latitude_extrema[0],
+                                                self.latitude_extrema[1],
+                                               ))
+        s += (" n_s: {0:6d}  type_s: {1:8s}  unit_s: {2:5s}"
+              "  range: {3:8s}:{4:8s}".format(self.shape[0],
+                                              self.wcs.wcs.ctype[2],
+                                              self.wcs.wcs.cunit[2],
+                                              self.spectral_extrema[0],
+                                              self.spectral_extrema[1],
+                                             ))
         return s
+
+    @property
+    def spectral_extrema(self):
+        if not hasattr(self, '_spectral_min'):
+            self._spectral_min = self.spectral_axis.min()
+        if not hasattr(self, '_spectral_max'):
+            self._spectral_max = self.spectral_axis.max()
+
+        return self._spectral_min, self._spectral_max
+
+    @property
+    def world_extrema(self):
+        if not all((hasattr(self, '_{0}_{1}'.format(xy, extr))
+                    for xy in ('lon','lat')
+                    for extr in ('min','max'))):
+            lat,lon = self.spatial_coordinate_map
+        if not hasattr(self, '_lon_min'):
+            self._lon_min = lon.min()
+        if not hasattr(self, '_lon_max'):
+            self._lon_max = lon.max()
+        if not hasattr(self, '_lat_min'):
+            self._lat_min = lat.min()
+        if not hasattr(self, '_lat_max'):
+            self._lat_max = lat.max()
+
+        return ((self._lon_min, self._lon_max),
+                (self._lat_min, self._lat_max))
+
+    @property
+    def longitude_extrema(self):
+        return self.world_extrema[0]
+
+    @property
+    def latitude_extrema(self):
+        return self.world_extrema[1]
 
     def apply_numpy_function(self, function, fill=np.nan,
                              reduce=True, how='auto',

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -341,21 +341,21 @@ class SpectralCube(object):
         else:
             s += " and unit={0}:\n".format(self.unit)
         s += (" n_x: {0:6d}  type_x: {1:8s}  unit_x: {2:5s}"
-              "  range: {3:8s}:{4:8s}\n".format(self.shape[2],
+              "  range: {3:12.6f}:{4:12.6f}\n".format(self.shape[2],
                                                 self.wcs.wcs.ctype[0],
                                                 self.wcs.wcs.cunit[0],
                                                 self.longitude_extrema[0],
                                                 self.longitude_extrema[1],
                                                ))
         s += (" n_y: {0:6d}  type_y: {1:8s}  unit_y: {2:5s}"
-              "  range: {3:8s}:{4:8s}\n".format(self.shape[1],
+              "  range: {3:12.6f}:{4:12.6f}\n".format(self.shape[1],
                                                 self.wcs.wcs.ctype[1],
                                                 self.wcs.wcs.cunit[1],
                                                 self.latitude_extrema[0],
                                                 self.latitude_extrema[1],
                                                ))
         s += (" n_s: {0:6d}  type_s: {1:8s}  unit_s: {2:5s}"
-              "  range: {3:8s}:{4:8s}".format(self.shape[0],
+              "  range: {3:12.3f}:{4:12.3f}".format(self.shape[0],
                                               self.wcs.wcs.ctype[2],
                                               self.wcs.wcs.cunit[2],
                                               self.spectral_extrema[0],

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -363,34 +363,25 @@ class SpectralCube(object):
                                              ))
         return s
 
-    @property
+    @cached
     def spectral_extrema(self):
-        if not hasattr(self, '_spectral_min'):
-            self._spectral_min = self.spectral_axis.min()
-        if not hasattr(self, '_spectral_max'):
-            self._spectral_max = self.spectral_axis.max()
+        self._spectral_min = self.spectral_axis.min()
+        self._spectral_max = self.spectral_axis.max()
 
         return self._spectral_min, self._spectral_max
 
-    @property
+    @cached
     def world_extrema(self):
-        if not all((hasattr(self, '_{0}_{1}'.format(xy, extr))
-                    for xy in ('lon','lat')
-                    for extr in ('min','max'))):
-            lat,lon = self.spatial_coordinate_map
-        if not hasattr(self, '_lon_min'):
-            self._lon_min = lon.min()
-        if not hasattr(self, '_lon_max'):
-            self._lon_max = lon.max()
-        if not hasattr(self, '_lat_min'):
-            self._lat_min = lat.min()
-        if not hasattr(self, '_lat_max'):
-            self._lat_max = lat.max()
+        lat,lon = self.spatial_coordinate_map
+        self._lon_min = lon.min()
+        self._lon_max = lon.max()
+        self._lat_min = lat.min()
+        self._lat_max = lat.max()
 
         return ((self._lon_min, self._lon_max),
                 (self._lat_min, self._lat_max))
 
-    @property
+    @cached
     def longitude_extrema(self):
         return self.world_extrema[0]
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -294,18 +294,18 @@ class TestRepr(BaseTest):
     def test_repr(self):
         assert repr(self.c) == """
 SpectralCube with shape=(4, 3, 2):
- n_x:      2  type_x: RA---SIN  unit_x: deg    range: 24.0626983633 deg:24.0633492988 deg
- n_y:      3  type_y: DEC--SIN  unit_y: deg    range: 29.9340936322 deg:29.9352091173 deg
- n_s:      4  type_s: VOPT      unit_s: m / s  range: -321214.698632 m / s:-317350.053726 m / s
+ n_x:      2  type_x: RA---SIN  unit_x: deg    range:    24.062698 deg:   24.063349 deg
+ n_y:      3  type_y: DEC--SIN  unit_y: deg    range:    29.934094 deg:   29.935209 deg
+ n_s:      4  type_s: VOPT      unit_s: m / s  range:  -321214.699 m / s: -317350.054 m / s
         """.strip()
 
     def test_repr_withunit(self):
         self.c._unit = u.Jy
         assert repr(self.c) == """
 SpectralCube with shape=(4, 3, 2) and unit=Jy:
- n_x:      2  type_x: RA---SIN  unit_x: deg    range: 24.0626983633 deg:24.0633492988 deg
- n_y:      3  type_y: DEC--SIN  unit_y: deg    range: 29.9340936322 deg:29.9352091173 deg
- n_s:      4  type_s: VOPT      unit_s: m / s  range: -321214.698632 m / s:-317350.053726 m / s
+ n_x:      2  type_x: RA---SIN  unit_x: deg    range:    24.062698 deg:   24.063349 deg
+ n_y:      3  type_y: DEC--SIN  unit_y: deg    range:    29.934094 deg:   29.935209 deg
+ n_s:      4  type_s: VOPT      unit_s: m / s  range:  -321214.699 m / s: -317350.054 m / s
         """.strip()
 
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -294,18 +294,18 @@ class TestRepr(BaseTest):
     def test_repr(self):
         assert repr(self.c) == """
 SpectralCube with shape=(4, 3, 2):
- n_x: 2  type_x: RA---SIN  unit_x: deg
- n_y: 3  type_y: DEC--SIN  unit_y: deg
- n_s: 4  type_s: VOPT      unit_s: m / s
+ n_x:      2  type_x: RA---SIN  unit_x: deg    range: 24.0626983633 deg:24.0633492988 deg
+ n_y:      3  type_y: DEC--SIN  unit_y: deg    range: 29.9340936322 deg:29.9352091173 deg
+ n_s:      4  type_s: VOPT      unit_s: m / s  range: -321214.698632 m / s:-317350.053726 m / s
         """.strip()
 
     def test_repr_withunit(self):
         self.c._unit = u.Jy
         assert repr(self.c) == """
 SpectralCube with shape=(4, 3, 2) and unit=Jy:
- n_x: 2  type_x: RA---SIN  unit_x: deg
- n_y: 3  type_y: DEC--SIN  unit_y: deg
- n_s: 4  type_s: VOPT      unit_s: m / s
+ n_x:      2  type_x: RA---SIN  unit_x: deg    range: 24.0626983633 deg:24.0633492988 deg
+ n_y:      3  type_y: DEC--SIN  unit_y: deg    range: 29.9340936322 deg:29.9352091173 deg
+ n_s:      4  type_s: VOPT      unit_s: m / s  range: -321214.698632 m / s:-317350.053726 m / s
         """.strip()
 
 


### PR DESCRIPTION
Improve the cube `__repr__` by showing the extrema in values.  This involves caching the min/max of each dimension the first time it is called.  Since we have treated cubes as immutable, this should be the right approach.

@ChrisBeaumont - not sure you'll have time to check this, but could you lay out somewhere what you had in mind for `world_spines`?  That would be a more efficient way to check the extrema

@astrofrog, @ChrisBeaumont - any concerns about performance here?  I think it's safe to assume that each axis is small enough for this process in general, though it might *not* be safe to assume that a full plane is cheap, hence the need for `world_spines`.