### PR TITLE
travis doc builds are failing with no changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ install:
     # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
     # this matplotlib will *not* work with py 3.x, but our sphinx build is
     # currently 2.7, so that's fine
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
+    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx=1.2 matplotlib; fi
 
     # COVERAGE DEPENDENCIES
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi


### PR DESCRIPTION
e.g., https://travis-ci.org/radio-astro-tools/spectral-cube/jobs/61342410, and see https://github.com/radio-astro-tools/spectral-cube/pull/198#issuecomment-99136420

```
  File "<stdin>", line 38
    print(darkred('reST markup error:'), file=sys.stderr)
                                             ^
SyntaxError: invalid syntax
The build_sphinx travis build FAILED because sphinx issued documentation warnings (scroll up to see the warnings).
Sphinx Documentation subprocess failed with return code 1
```
perhaps this is related to sphinx versions?