### PR TITLE
Add link to docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ About
 =====
 
 This package aims to facilitate the reading, writing, manipulation, and
-analysis of spectral data cubes.
+analysis of spectral data cubes.  More information is available in the documentation, avaliable [online at readthedocs.org](http://spectral-cube.rtfd.org).
 
 Credits
 =======


### PR DESCRIPTION
This just adds a bit of text and a link to the RTD documentation page.  Makes it a bit easier to fine.