### PR TITLE
BUG: cubes with lat,lon ordering would not consistently mask data

### DIFF
--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-from astropy.wcs import WCSSUB_CELESTIAL,WCSSUB_SPECTRAL
+from astropy.wcs import (WCSSUB_SPECTRAL, WCSSUB_LONGITUDE, WCSSUB_LATITUDE)
 from . import wcs_utils
 from astropy import log
 
@@ -140,7 +140,7 @@ def _orient(array, wcs):
     t = [types.index('spectral'), nums.index(1), nums.index(0)]
     result_array = array.transpose(t)
 
-    result_wcs = wcs.sub([WCSSUB_CELESTIAL, WCSSUB_SPECTRAL])
+    result_wcs = wcs.sub([WCSSUB_LONGITUDE, WCSSUB_LATITUDE, WCSSUB_SPECTRAL])
 
     return result_array, result_wcs
 

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -122,7 +122,9 @@ def load_fits_cube(input, hdu=0, meta={}):
         data, wcs = cube_utils._orient(data, wcs)
 
         mask = LazyMask(np.isfinite, data=data, wcs=wcs)
+        assert data.shape == mask._data.shape
         cube = SpectralCube(data, wcs, mask, meta=meta, header=header)
+        assert cube._data.shape == cube._mask._data.shape
 
     elif wcs.wcs.naxis == 4:
 

--- a/spectral_cube/tests/data/make_test_cubes.py
+++ b/spectral_cube/tests/data/make_test_cubes.py
@@ -60,3 +60,6 @@ if __name__ == "__main__":
 
     d, h = transpose(d, h, [2, 0, 1])
     fits.writeto('vad.fits', d, h, clobber=True)
+
+    d, h = transpose(d, h, [2, 1, 0])
+    fits.writeto('vda.fits', d, h, clobber=True)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -64,6 +64,7 @@ class TestSpectralCube(object):
                              ('sadv', [0, 1, 2, 3]),
                              ('vsad', [3, 0, 1, 2]),
                              ('vad', [2, 0, 1]),
+                             ('vda', [2, 1, 0]),
                              ('adv', [0, 1, 2]),
                              ))
     def test_consistent_transposition(self, name, trans):
@@ -704,3 +705,12 @@ def test_preserve_bunit():
 
     assert cube.unit == u.K
     assert cube.header['BUNIT'] == 'K'
+
+def test_cube_with_swapped_axes():
+    """
+    Regression test for ...
+    """
+    cube, data = cube_and_raw('vda.fits')
+
+    # Check that masking works (this should apply a lazy mask)
+    cube.filled_data[:]

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -64,7 +64,7 @@ class TestSpectralCube(object):
                              ('sadv', [0, 1, 2, 3]),
                              ('vsad', [3, 0, 1, 2]),
                              ('vad', [2, 0, 1]),
-                             ('vda', [2, 1, 0]),
+                             ('vda', [0, 2, 1]),
                              ('adv', [0, 1, 2]),
                              ))
     def test_consistent_transposition(self, name, trans):

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -708,7 +708,7 @@ def test_preserve_bunit():
 
 def test_cube_with_swapped_axes():
     """
-    Regression test for ...
+    Regression test for #208
     """
     cube, data = cube_and_raw('vda.fits')
 


### PR DESCRIPTION
If a cube with dec, ra or glat,glon ordering (instead of the usual ra,dec or
glon,glat) was loaded, it would have incorrectly ordered axes, i.e. data that
would not agree with WCS.  This fixes that issue by explicitly selecting lon &
lat.