### PR TITLE
Incorrect results from cube.std(axis=0) with 'slice' iteration strategy

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -431,13 +431,17 @@ class SpectralCube(object):
 
         projection = self._naxes_dropped(axis) in (1,2)
 
+        if how == 'slice':
+            raise NotImplementedError("Standard deviation cannot be computed "
+                                      "in a slicewise manner.  Please use a "
+                                      "different strategy.")
+
         # standard deviation cannot be computed as a trivial step-by-step
         # process.  There IS a one-pass algorithm for std dev, but it is not
-        # implemented, so we must force cube here by specifying reduce=False.  We could and should also
+        # implemented, so we must force cube here.  We could and should also
         # implement raywise reduction
         return self.apply_numpy_function(np.nanstd, fill=np.nan, how=how,
                                          axis=axis, unit=self.unit,
-                                         reduce=False,
                                          projection=projection)
 
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -253,7 +253,7 @@ class SpectralCube(object):
         reduce : bool
             reduce indicates whether this is a reduce-like operation,
             that can be accumulated one slice at a time.
-            sum/max/min are like this. argmax/argmin are not
+            sum/max/min are like this. argmax/argmin/stddev are not
         how : cube | slice | ray | auto
            How to compute the moment. All strategies give the same
            result, but certain strategies are more efficient depending
@@ -306,8 +306,7 @@ class SpectralCube(object):
                                               **kwargs)
             except NotImplementedError:
                 pass
-
-        if how not in ['auto', 'cube']:
+        elif how not in ['auto', 'cube']:
             warnings.warn("Cannot use how=%s. Using how=cube" % how)
 
         if out is None:
@@ -425,15 +424,20 @@ class SpectralCube(object):
                                          projection=projection)
 
     @aggregation_docstring
-    def std(self, axis=None, how='auto'):
+    def std(self, axis=None, how='cube'):
         """
         Return the standard deviation of the cube, optionally over an axis.
         """
 
         projection = self._naxes_dropped(axis) in (1,2)
 
+        # standard deviation cannot be computed as a trivial step-by-step
+        # process.  There IS a one-pass algorithm for std dev, but it is not
+        # implemented, so we must force cube here by specifying reduce=False.  We could and should also
+        # implement raywise reduction
         return self.apply_numpy_function(np.nanstd, fill=np.nan, how=how,
                                          axis=axis, unit=self.unit,
+                                         reduce=False,
                                          projection=projection)
 
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -412,12 +412,17 @@ class SpectralCube(object):
                                          projection=projection)
 
     @aggregation_docstring
-    def mean(self, axis=None, how='auto'):
+    def mean(self, axis=None, how='cube'):
         """
         Return the mean of the cube, optionally over an axis.
         """
 
         projection = self._naxes_dropped(axis) in (1,2)
+
+        if how == 'slice':
+            raise NotImplementedError("Mean cannot be computed "
+                                      "in a slicewise manner.  Please use a "
+                                      "different strategy.")
 
         return self.apply_numpy_function(np.nanmean, fill=np.nan, how=how,
                                          axis=axis, unit=self.unit,

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -679,9 +679,14 @@ def test_twod_numpy(func, how, axis):
     cube._meta['BUNIT'] = 'K'
     cube._unit = u.K
 
-    proj = getattr(cube,func)(axis=axis, how=how)
+    if func in ('mean','std') and how == 'slice':
+        with pytest.raises(NotImplementedError) as ex:
+            proj = getattr(cube,func)(axis=axis, how=how)
+        return
+    else:
+        proj = getattr(cube,func)(axis=axis, how=how)
     # data has a redundant 1st axis
-    dproj = getattr(data,func)(axis=(0,axis)).squeeze()
+    dproj = getattr(data,func)(axis=(0,axis+1)).squeeze()
     assert isinstance(proj, Projection)
     np.testing.assert_equal(proj.value, dproj)
     assert cube.unit == proj.unit

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from .. import (SpectralCube, BooleanArrayMask, FunctionMask, LazyMask,
                 CompositeMask)
-from ..spectral_cube import OneDSpectrum
+from ..spectral_cube import OneDSpectrum, Projection
 from ..np_compat import allbadtonan
 from .. import spectral_axis
 
@@ -664,6 +664,23 @@ def test_airwave_to_wave():
     ax2 = cube.with_spectral_unit(u.m).spectral_axis
     np.testing.assert_almost_equal(spectral_axis.air_to_vac(ax1).value,
                                    ax2.value)
+
+@pytest.mark.parametrize('func',('sum','std','max','min','mean'))
+def test_twod_numpy(func):
+    # Check that a numpy function returns the correct result when applied along
+    # one axis
+    # This is partly a regression test for #211
+
+    cube, data = cube_and_raw('advs.fits')
+    cube._meta['BUNIT'] = 'K'
+    cube._unit = u.K
+
+    proj = getattr(cube,func)(axis=0)
+    # data has a redundant 1st axis
+    dproj = getattr(data,func)(axis=(0,1)).squeeze()
+    assert isinstance(proj, Projection)
+    np.testing.assert_equal(proj.value, dproj)
+    assert cube.unit == proj.unit
 
 @pytest.mark.parametrize('func',('sum','std','max','min','mean'))
 def test_oned_numpy(func):

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -665,8 +665,12 @@ def test_airwave_to_wave():
     np.testing.assert_almost_equal(spectral_axis.air_to_vac(ax1).value,
                                    ax2.value)
 
-@pytest.mark.parametrize('func',('sum','std','max','min','mean'))
-def test_twod_numpy(func):
+@pytest.mark.parametrize(('func','how','axis'),
+                         itertools.product(('sum','std','max','min','mean'),
+                                           ('slice','cube','auto'),
+                                           (0,1,2)
+                                          ))
+def test_twod_numpy(func, how, axis):
     # Check that a numpy function returns the correct result when applied along
     # one axis
     # This is partly a regression test for #211
@@ -675,9 +679,9 @@ def test_twod_numpy(func):
     cube._meta['BUNIT'] = 'K'
     cube._unit = u.K
 
-    proj = getattr(cube,func)(axis=0)
+    proj = getattr(cube,func)(axis=axis, how=how)
     # data has a redundant 1st axis
-    dproj = getattr(data,func)(axis=(0,1)).squeeze()
+    dproj = getattr(data,func)(axis=(0,axis)).squeeze()
     assert isinstance(proj, Projection)
     np.testing.assert_equal(proj.value, dproj)
     assert cube.unit == proj.unit


### PR DESCRIPTION
See https://github.com/jpinedaf/GAS/issues/34#issuecomment-111629067 for details.

This would only affect large cubes because of the automatic iterator strategy selected.  It also raises a 'todo' item, which is to implement a one-pass slice-by-slice standard deviation.  That's not difficult but requires testing, and it might not be much faster.

Also, we never implemented ray-iteration strategies for numpy functions, which might be faster for sparse cubes like this.  We should cache the 1-dimensional mask include...