### PR TITLE
Fix ds9 region edge behavior: don't allow negative indices

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1418,6 +1418,17 @@ class SpectralCube(object):
             xhi = xhi if xhi > ext.max[0] else ext.max[0]
             yhi = yhi if yhi > ext.max[1] else ext.max[1]
 
+        # Negative indices will do bad things, like wrap around the cube
+        # If xhi/yhi are negative, there is not overlap
+        if (xhi < 0) or (yhi < 0):
+            raise ValueError("Region is outside of cube.")
+
+        # if xlo/ylo are negative, we need to crop
+        if xlo < 0:
+            xlo = 0
+        if ylo < 0:
+            ylo = 0
+
         log.debug("Region boundaries: ")
         log.debug("xlo={xlo}, ylo={ylo}, xhi={xhi}, yhi={yhi}".format(xlo=xlo,
                                                                       ylo=ylo,

--- a/spectral_cube/tests/data/fk5.reg
+++ b/spectral_cube/tests/data/fk5.reg
@@ -1,0 +1,4 @@
+# Region file format: DS9 version 4.1
+global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1
+fk5
+box(24.063014,29.934653,4.61661",2.6001614",0.43894166)

--- a/spectral_cube/tests/data/image.reg
+++ b/spectral_cube/tests/data/image.reg
@@ -1,0 +1,4 @@
+# Region file format: DS9 version 4.1
+global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1
+image
+box(1.5,2,2,1,0)

--- a/spectral_cube/tests/data/no_overlap_fk5.reg
+++ b/spectral_cube/tests/data/no_overlap_fk5.reg
@@ -1,0 +1,4 @@
+# Region file format: DS9 version 4.1
+global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1
+fk5
+box(24.061421,29.934662,4",2",0.43894166)

--- a/spectral_cube/tests/data/no_overlap_image.reg
+++ b/spectral_cube/tests/data/no_overlap_image.reg
@@ -1,0 +1,4 @@
+# Region file format: DS9 version 4.1
+global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1
+image
+box(4.5528417,2,2,1,0)

--- a/spectral_cube/tests/data/partial_overlap_fk5.reg
+++ b/spectral_cube/tests/data/partial_overlap_fk5.reg
@@ -1,0 +1,4 @@
+# Region file format: DS9 version 4.1
+global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1
+fk5
+box(24.062383,29.934656,4",2",0.43894166)

--- a/spectral_cube/tests/data/partial_overlap_image.reg
+++ b/spectral_cube/tests/data/partial_overlap_image.reg
@@ -1,0 +1,4 @@
+# Region file format: DS9 version 4.1
+global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1
+image
+box(2.5,2,2,1,0)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -472,35 +472,6 @@ def test_preserve_spectral_unit():
     new_cube = cube_freq.with_fill_value(fill_value=3.4)
     assert new_cube.spectral_axis.unit is u.GHz
 
-def test_subcube():
-
-    cube, data = cube_and_raw('advs.fits')
-
-    sc1 = cube.subcube(xlo=1, xhi=3)
-    sc2 = cube.subcube(xlo=24.06269*u.deg, xhi=24.06206*u.deg)
-
-    assert sc1.shape == (2,3,2)
-    assert sc2.shape == (2,3,2)
-    assert sc1.wcs.wcs.compare(sc2.wcs.wcs)
-
-    sc3 = cube.subcube()
-
-    assert sc3.shape == cube.shape
-    assert sc3.wcs.wcs.compare(cube.wcs.wcs)
-    assert np.all(sc3._data == cube._data)
-
-def test_ds9region():
-    pass
-
-
-    #region = 'fk5\ncircle(29.9346557, 24.0623827, 0.11111)'
-    #subcube = cube.subcube_from_ds9region(region)
-    # THIS TEST FAILS!
-    # I think the coordinate transformation in ds9 is wrong;
-    # it uses kapteyn?
-    
-    #region = 'circle(2,2,2)'
-    #subcube = cube.subcube_from_ds9region(region)
 
 @pytest.mark.skipif(not bottleneckOK, reason='Bottleneck could not be imported')
 def test_endians():

--- a/spectral_cube/tests/test_subcubes.py
+++ b/spectral_cube/tests/test_subcubes.py
@@ -1,0 +1,78 @@
+import pytest
+import operator
+import itertools
+
+from astropy.io import fits
+from astropy import units as u
+from astropy.wcs import WCS
+import numpy as np
+
+from .. import (SpectralCube, BooleanArrayMask, FunctionMask, LazyMask,
+                CompositeMask)
+from ..spectral_cube import OneDSpectrum, Projection
+from ..np_compat import allbadtonan
+from .. import spectral_axis
+
+from . import path
+from .helpers import assert_allclose, assert_array_equal
+
+from distutils.version import StrictVersion
+
+try:
+    import pyregion
+    pyregionOK = True
+except ImportError:
+    pyregionOK = False
+
+def test_subcube():
+
+    cube, data = cube_and_raw('advs.fits')
+
+    sc1 = cube.subcube(xlo=1, xhi=3)
+    sc2 = cube.subcube(xlo=24.06269*u.deg, xhi=24.06206*u.deg)
+
+    assert sc1.shape == (2,3,2)
+    assert sc2.shape == (2,3,2)
+    assert sc1.wcs.wcs.compare(sc2.wcs.wcs)
+
+    sc3 = cube.subcube()
+
+    assert sc3.shape == cube.shape
+    assert sc3.wcs.wcs.compare(cube.wcs.wcs)
+    assert np.all(sc3._data == cube._data)
+
+#@pytest.mark.skipif(not pyregionOK, reason='Could not import pyregion')
+#@pytest.mark.parametrize(('regfile','result'),
+#                         (('fk5.reg', [slice(None),1,slice(None)]),
+#                          ('image.reg', NotImplementedError),
+#                          ('partial_overlap_image.reg', NotImplementedError),
+#                          ('no_overlap_image.reg', NotImplementedError),
+#                          ('partial_overlap_fk5.reg', [slice(None),1,1]),
+#                          ('no_overlap_fk5.reg', ValueError),
+#                         ))
+#def test_ds9region(regfile, result):
+#    cube, data = cube_and_raw('adv.fits')
+#
+#    regions = pyregion.open(regfile)
+#
+#    if issubclass(result, Exception):
+#        with pytest.raises(result) as exc:
+#            sc = cube.subcube_from_ds9region(regions)
+#    else:
+#        sc = cube.subcube_from_ds9region(regions)
+#        scsum = sc.sum()
+#        dsum = data[result].sum()
+#        assert scsum == dsum
+
+
+
+
+    #region = 'fk5\ncircle(29.9346557, 24.0623827, 0.11111)'
+    #subcube = cube.subcube_from_ds9region(region)
+    # THIS TEST FAILS!
+    # I think the coordinate transformation in ds9 is wrong;
+    # it uses kapteyn?
+    
+    #region = 'circle(2,2,2)'
+    #subcube = cube.subcube_from_ds9region(region)
+

--- a/spectral_cube/tests/test_subcubes.py
+++ b/spectral_cube/tests/test_subcubes.py
@@ -15,6 +15,7 @@ from .. import spectral_axis
 
 from . import path
 from .helpers import assert_allclose, assert_array_equal
+from .test_spectral_cube import cube_and_raw
 
 from distutils.version import StrictVersion
 


### PR DESCRIPTION
There was an error in which *some* regions outside the cube FOV produced
negative indices that would wrap back into the cube, which is never the desired
behavior.

I've added tests, but unfortunately... tragically... they demonstrate that
pyregion does not self-consistently handle regions.  A region that selects 1 or
2 pixels successfully based on where the edges of the regions are then produces
a mask that does not contain those pixels.