### PR TITLE
For comparison operations, check units

### DIFF
--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -493,7 +493,7 @@ class LazyComparisonMask(LazyMask):
                                   self._comparison_value)
 
     def __getitem__(self, view):
-        if hasattr(comparison_value, 'shape'):
+        if hasattr(self._comparison_value, 'shape'):
             cv_view = view_of_subset(self._comparison_value.shape,
                                      self._data.shape, view)
             return LazyComparisonMask(self._function, data=self._data[view],

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -481,18 +481,28 @@ class LazyComparisonMask(LazyMask):
     def _include(self, data=None, wcs=None, view=()):
         self._validate_wcs(data, wcs)
 
-        cv_view = view_of_subset(self._comparison_value.shape,
-                                 self._data.shape, view)
+        if hasattr(self._comparison_value, 'shape'):
+            cv_view = view_of_subset(self._comparison_value.shape,
+                                     self._data.shape, view)
 
-        return self._function(self._data[view],
-                              self._comparison_value[cv_view])
+            return self._function(self._data[view],
+                                  self._comparison_value[cv_view])
+        
+        else:
+            return self._function(self._data[view],
+                                  self._comparison_value)
 
     def __getitem__(self, view):
-        cv_view = view_of_subset(self._comparison_value.shape,
-                                 self._data.shape, view)
-        return LazyComparisonMask(self._function, data=self._data[view],
-                                  comparison_value=self._comparison_value[cv_view],
-                                  wcs=wcs_utils.slice_wcs(self._wcs, view))
+        if hasattr(comparison_value, 'shape'):
+            cv_view = view_of_subset(self._comparison_value.shape,
+                                     self._data.shape, view)
+            return LazyComparisonMask(self._function, data=self._data[view],
+                                      comparison_value=self._comparison_value[cv_view],
+                                      wcs=wcs_utils.slice_wcs(self._wcs, view))
+        else:
+            return LazyComparisonMask(self._function, data=self._data[view],
+                                      comparison_value=self._comparison_value,
+                                      wcs=wcs_utils.slice_wcs(self._wcs, view))
 
     def with_spectral_unit(self, unit, velocity_convention=None, rest_value=None):
         """

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -6,7 +6,7 @@ from numpy.lib.stride_tricks import as_strided
 from . import wcs_utils
 
 __all__ = ['InvertedMask', 'CompositeMask', 'BooleanArrayMask',
-           'LazyMask', 'FunctionMask']
+           'LazyMask', 'LazyComparisonMask', 'FunctionMask']
 
 # Global version of the with_spectral_unit docs to avoid duplicating them
 with_spectral_unit_docs = """

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -218,7 +218,8 @@ class CompositeMask(MaskBase):
             raise ValueError("Operation '{0}' not supported".format(self._operation))
 
     def __getitem__(self, view):
-        return CompositeMask(self._mask1[view], self._mask2[view], operation=self._operation)
+        return CompositeMask(self._mask1[view], self._mask2[view],
+                             operation=self._operation)
 
     def with_spectral_unit(self, unit, velocity_convention=None, rest_value=None):
         """

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1536,6 +1536,17 @@ class SpectralCube(object):
 
         return world[::-1]  # reverse WCS -> numpy order
 
+    def _val_to_own_unit(self, value):
+        """
+        Given a value, check if it has a unit.  If it does, convert to the
+        cube's unit.  If it doesn't, raise an exception.
+        """
+        if hasattr(value, 'unit'):
+            return value.to(self.unit).value
+        else:
+            raise ValueError("Can only compare cube objects to Quantities"
+                             " with a unit attribute.")
+
     def __gt__(self, value):
         """
         Return a LazyMask representing the inequality
@@ -1545,24 +1556,30 @@ class SpectralCube(object):
         value : number
             The threshold
         """
+        value = self._val_to_own_unit(value)
         return LazyMask(lambda data: data > value, data=self._data, wcs=self._wcs)
 
     def __ge__(self, value):
+        value = self._val_to_own_unit(value)
         return LazyMask(lambda data: data >= value, data=self._data, wcs=self._wcs)
 
     def __le__(self, value):
+        value = self._val_to_own_unit(value)
         return LazyMask(lambda data: data <= value, data=self._data, wcs=self._wcs)
 
     def __lt__(self, value):
+        value = self._val_to_own_unit(value)
         return LazyMask(lambda data: data < value, data=self._data, wcs=self._wcs)
 
     def __eq__(self, value):
+        value = self._val_to_own_unit(value)
         return LazyMask(lambda data: data == value, data=self._data, wcs=self._wcs)
 
     def __hash__(self):
         return id(self)
 
     def __ne__(self, value):
+        value = self._val_to_own_unit(value)
         return LazyMask(lambda data: data != value, data=self._data, wcs=self._wcs)
 
     @classmethod

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -89,8 +89,6 @@ def aggregation_docstring(func):
 # conventions between WCS and numpy
 np2wcs = {2: 0, 1: 1, 0: 2}
 
-
-
 class SpectralCube(object):
 
     def __init__(self, data, wcs, mask=None, meta=None, fill_value=np.nan,

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -4,6 +4,7 @@ A class to represent a 3-d position-position-velocity spectral cube.
 
 import warnings
 from functools import wraps
+import operator
 
 from astropy import units as u
 from astropy.extern import six
@@ -1557,30 +1558,30 @@ class SpectralCube(object):
             The threshold
         """
         value = self._val_to_own_unit(value)
-        return LazyMask(lambda data: data > value, data=self._data, wcs=self._wcs)
+        return LazyComparisonMask(operator.gt, value, data=self._data, wcs=self._wcs)
 
     def __ge__(self, value):
         value = self._val_to_own_unit(value)
-        return LazyMask(lambda data: data >= value, data=self._data, wcs=self._wcs)
+        return LazyComparisonMask(operator.ge, value, data=self._data, wcs=self._wcs)
 
     def __le__(self, value):
         value = self._val_to_own_unit(value)
-        return LazyMask(lambda data: data <= value, data=self._data, wcs=self._wcs)
+        return LazyComparisonMask(operator.le, value, data=self._data, wcs=self._wcs)
 
     def __lt__(self, value):
         value = self._val_to_own_unit(value)
-        return LazyMask(lambda data: data < value, data=self._data, wcs=self._wcs)
+        return LazyComparisonMask(operator.lt, value, data=self._data, wcs=self._wcs)
 
     def __eq__(self, value):
         value = self._val_to_own_unit(value)
-        return LazyMask(lambda data: data == value, data=self._data, wcs=self._wcs)
+        return LazyComparisonMask(operator.eq, value, data=self._data, wcs=self._wcs)
 
     def __hash__(self):
         return id(self)
 
     def __ne__(self, value):
         value = self._val_to_own_unit(value)
-        return LazyMask(lambda data: data != value, data=self._data, wcs=self._wcs)
+        return LazyComparisonMask(operator.ne, value, data=self._data, wcs=self._wcs)
 
     @classmethod
     def read(cls, filename, format=None, hdu=None, **kwargs):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -17,7 +17,8 @@ import numpy as np
 from . import cube_utils
 from . import wcs_utils
 from . import spectral_axis
-from .masks import LazyMask, BooleanArrayMask, MaskBase, is_broadcastable_and_smaller
+from .masks import (LazyMask, LazyComparisonMask, BooleanArrayMask, MaskBase,
+                    is_broadcastable_and_smaller)
 from .io.core import determine_format
 from .ytcube import ytCube
 from .lower_dimensional_structures import Projection, Slice, OneDSpectrum

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -299,7 +299,8 @@ def test_flat_mask_spectral():
     # Broadcast the 2D mask to 3D
     cubemask = (np.ones(4,dtype='bool')[:,None,None] & mask_array[None,:,:])
     # Check that spectral masking works too
-    assert np.all((data*cubemask).sum(axis=(1,2)) == mcube.sum(axis=(1,2)).value)
+    assert np.all((data*cubemask).sum(axis=(1,2)) ==
+                  mcube.sum(axis=(1,2)).value)
 
 def test_include():
     cube, data = cube_and_raw('adv.fits')

--- a/spectral_cube/tests/test_moments.py
+++ b/spectral_cube/tests/test_moments.py
@@ -98,7 +98,7 @@ def test_reference(order, axis, how):
 def test_consistent_mask_handling(axis, order):
     mc_hdu = moment_cube()
     sc = SpectralCube.read(mc_hdu)
-    sc._mask = sc > 4
+    sc._mask = sc > 4*u.K
 
     cwise = sc.moment(axis=axis, order=order, how='cube')
     swise = sc.moment(axis=axis, order=order, how='slice')

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -456,7 +456,7 @@ class TestMasks(BaseTest):
 
         # choose thresh to exercise proper equality tests
         thresh = self.d.ravel()[0]
-        m = op(self.c, thresh)
+        m = op(self.c, thresh*u.K)
         self.c._mask = m
 
         expected = self.d[op(self.d, thresh)]

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -173,11 +173,12 @@ class TestFilters(BaseTest):
         expected = np.where(d > .5, d, 0)
         assert_allclose(c._get_filled_data(fill=0), expected)
 
-    def test_mask_comparison(self):
+    @pytest.mark.parametrize('operation', (operator.lt, operator.gt, operator.le, operator.ge))
+    def test_mask_comparison(self, operation):
         c, d = self.c, self.d
-        dmask = d > 0.5
-        cmask = c > 0.5*u.K
-        assert cmask.include().sum() == dmask.sum()
+        dmask = operation(d, 0.6) & self.c.mask.include()
+        cmask = operation(c, 0.6*u.K)
+        assert (self.c.mask.include() & cmask.include()).sum() == dmask.sum()
         np.testing.assert_almost_equal(c.with_mask(cmask).sum().value,
                                        d[dmask].sum())
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -173,6 +173,14 @@ class TestFilters(BaseTest):
         expected = np.where(d > .5, d, 0)
         assert_allclose(c._get_filled_data(fill=0), expected)
 
+    def test_mask_comparison(self):
+        c, d = self.c, self.d
+        dmask = d > 0.5
+        cmask = c > 0.5*u.K
+        assert cmask.include().sum() == dmask.sum()
+        np.testing.assert_almost_equal(c.with_mask(cmask).sum().value,
+                                       d[dmask].sum())
+
     def test_flatten(self):
         c, d = self.c, self.d
         expected = d[d > 0.5]


### PR DESCRIPTION
When comparing to a value, if it's a quantity, convert to the cube's unit
first.  Needed to be done for all comparison operations.

NOTE that there is an outstanding bug: the "value" placed into the lamda function
does not get sliced when the rest of the SpectralCube gets sliced.