### PR TITLE
Fixing yt volume rendering script in docs

### DIFF
--- a/docs/yt_example.rst
+++ b/docs/yt_example.rst
@@ -68,12 +68,12 @@ produce a 3-d isocontour visualization using an object returned by
 :meth:`~spectral_cube.SpectralCube.to_yt`::
 
     import numpy as np
-    from spectral_cube import read
+    from spectral_cube import SpectralCube
     from yt.mods import ColorTransferFunction, write_bitmap
     import astropy.units as u
 
     # Read in spectral cube
-    cube = read('L1448_13CO.fits', format='fits')
+    cube = SpectralCube.read('L1448_13CO.fits', format='fits')
 
     # Extract the yt object from the SpectralCube instance
     ytcube = cube.to_yt(spectral_factor=0.75)
@@ -101,8 +101,8 @@ produce a 3-d isocontour visualization using an object returned by
     width = 100.  # pixels
     size = 1024
 
-    camera = ds.h.camera(center, direction, width, size, transfer,
-                         fields=['flux'])
+    camera = ds.camera(center, direction, width, size, transfer,
+                       fields=['flux'])
 
     # Take a snapshot and save to a file
     snapshot = camera.snapshot()


### PR DESCRIPTION
This updates the script in the docs to make a volume rendering with yt to be compatible with current API.

NOTE: This does _not_ fix [Issue 193](https://github.com/radio-astro-tools/spectral-cube/issues/193), that is a bug on the yt side that is fixed [here](https://bitbucket.org/jzuhone/yt/commits/f2357819d9dcbdcdb3cdd830c04dd7bb45a31290), which will be merged into yt today (hopefully) and be included in the next stable release (3.2). 