### PR TITLE
Apply everywhere: applying functions to whole cube

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@
    (https://github.com/radio-astro-tools/spectral-cube/pull/210)
  - Bugfixes (211,212,217)
  - Add arithmetic operations (add, subtract, divide, multiply, power)
-   (https://github.com/radio-astro-tools/spectral-cube/pull/220)
+   (https://github.com/radio-astro-tools/spectral-cube/pull/220).
+   These operations will not be permitted on large cubes by default, but will
+   require the user to specify that they are allowed using the attribute
+   ``allow_huge_operations``
 
 0.2.2 (2015-03-12)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
  - Add experimental line-finding tool using astroquery.splatalogue
    (https://github.com/radio-astro-tools/spectral-cube/pull/210)
  - Bugfixes (211,212,217)
+ - Add arithmetic operations (add, subtract, divide, multiply, power)
+   (https://github.com/radio-astro-tools/spectral-cube/pull/220)
 
 0.2.2 (2015-03-12)
 ------------------

--- a/docs/arithmetic.rst
+++ b/docs/arithmetic.rst
@@ -1,0 +1,19 @@
+Spectral Cube Arithmetic
+========================
+
+Simple arithmetic operations between cubes and scalars, broadcastable numpy
+arrays, and other cubes are possible.  However, such operations should be
+performed with caution because they require loading the whole cube into memory
+and will generally create a new cube in memory.
+
+Examples::
+
+    >>> import astropy.units as u
+    >>> from spectral_cube import SpectralCube
+    >>> cube = SpectralCube.read('adv.fits')  # doctest: +SKIP
+    >>> cube2 = cube * 2  # doctest: +SKIP
+    >>> cube3 = cube + 1.5*u.K # doctest: +SKIP
+    >>> cube4 = cube2 + cube3 # doctest: +SKIP
+
+Each of these cubes is a new cube in memory.  Note that for addition and
+subtraction, the units must be equivalent to those of the cube.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,12 +23,12 @@ Here's a simple script demonstrating ``spectral-cube``::
 
     >>> import astropy.units as u
     >>> from spectral_cube import SpectralCube
-    >>> cube = SpectralCube.read('data.fits')  # doctest: +SKIP
+    >>> cube = SpectralCube.read('adv.fits')  # doctest: +SKIP
     >>> print cube  # doctest: +SKIP
-    SpectralCube with shape=(563, 640, 640) and unit=K:
-    n_x: 640  type_x: RA---SIN  unit_x: deg
-    n_y: 640  type_y: DEC--SIN  unit_y: deg
-    n_s: 563  type_s: FREQ      unit_s: Hz
+    SpectralCube with shape=(4, 3, 2) and unit=K:
+    n_x:      2  type_x: RA---SIN  unit_x: deg    range:    24.062698 deg:   24.063349 deg
+    n_y:      3  type_y: DEC--SIN  unit_y: deg    range:    29.934094 deg:   29.935209 deg
+    n_s:      4  type_s: VOPT      unit_s: m / s  range:  -321214.699 m / s: -317350.054 m / s
 
     # extract the subcube between 98 and 100 GHz
     >>> slab = cube.spectral_slab(98 * u.GHz, 100 * u.GHz)  # doctest: +SKIP
@@ -59,6 +59,7 @@ Getting started
    creating_reading.rst
    accessing.rst
    masking.rst
+   arithmetic.rst
    manipulating.rst
    writing.rst
    moments.rst

--- a/docs/masking.rst
+++ b/docs/masking.rst
@@ -13,6 +13,7 @@ data should be used, and the value ``False`` when the data should be ignored
 (though it is also possible to flip the convention around). To create a
 boolean mask from a boolean array ``mask_array``, you can for example use::
 
+    >>> from astropy import units as u
     >>> from spectral_cube import BooleanArrayMask
     >>> mask = BooleanArrayMask(mask=mask_array, wcs=cube.wcs)  # doctest: +SKIP
 
@@ -22,14 +23,14 @@ because it may require a large amount of memory.
 You can also create a mask using simple conditions directly on the cube
 values themselves, for example::
 
-    >>> mask = cube > 1.3  # doctest: +SKIP
+    >>> mask = cube > 1.3*u.K  # doctest: +SKIP
 
-This is more efficient, because the condition is actually evaluated
-on-the-fly as needed.
+This is more efficient, because the condition is actually evaluated on-the-fly
+as needed.  Note that units equivalent to the cube's units must be used.
 
 Masks can be combined using standard boolean comparison operators::
 
-   >>> new_mask = (cube > 1.3) & (cube < 100.)  # doctest: +SKIP
+   >>> new_mask = (cube > 1.3*u.K) & (cube < 100.*u.K)  # doctest: +SKIP
 
 The available operators are ``&`` (and), ``|`` (or), and ``~`` (not).
 
@@ -132,8 +133,8 @@ As shown in `Getting Started`_, :class:`~spectral_cube.LazyMask` instances
 can also be defined directly by specifying conditions on
 :class:`~spectral_cube.SpectralCube` objects:
 
-   >>> cube > 5  # doctest: +SKIP
-       LazyMask(...)
+   >>> cube > 5*u.K  # doctest: +SKIP
+       LazyComparisonMask(...)
 
 .. TODO: add example for FunctionalMask
 

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -191,6 +191,12 @@ class SliceIndexer(object):
         raise Exception("You need to specify a slice (e.g. ``[:]`` or "
                         "``[0,:,:]`` in order to access this property.")
 
+def is_huge(cube, threshold=1e8):
+    if cube.size < threshold:  # smallish
+        return False
+    else:
+        return True
+
 
 def iterator_strategy(cube, axis=None):
     """
@@ -214,6 +220,6 @@ def iterator_strategy(cube, axis=None):
         *ray*  recommends working with one ray at a time
     """
     # pretty simple for now
-    if np.product(cube.shape) < 1e8:  # smallish
+    if cube.size < 1e8:  # smallish
         return 'cube'
     return 'slice'

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1711,11 +1711,14 @@ class SpectralCube(object):
         else:
             return self._apply_everywhere(operator.mul, value)
 
+    def __truediv__(self, value):
+        return self.__div__(value)
+
     def __div__(self, value):
         if isinstance(value, SpectralCube):
-            return self._cube_on_cube_operation(operator.div, value)
+            return self._cube_on_cube_operation(operator.truediv, value)
         else:
-            return self._apply_everywhere(operator.div, value)
+            return self._apply_everywhere(operator.truediv, value)
 
     def __pow__(self, value):
         if isinstance(value, SpectralCube):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -542,15 +542,26 @@ class SpectralCube(object):
         return nx, ny
 
     @warn_slow
-    def apply_everywhere(self, function):
+    def apply_everywhere(self, function, *args):
         """
         Return a new cube with ``function`` applied to all pixels
+
+        Examples
+        --------
+        >>> newcube = cube.apply_everywhere(np.add(0.5*u.Jy))
         """
 
-        # First, check that function returns same # of dims?
-        assert function(np.ones([1,1,1])).shape == (1,1,1)
+        try:
+            test_result = function(np.ones([1,1,1])*self.unit, *args)
+            # First, check that function returns same # of dims?
+            assert test_result.shape == (1,1,1)
+        except Exception as ex:
+            raise AssertionError("Function could not be applied to a simple "
+                                 "cube.  The error was: {0}".format(ex))
 
-        return self._new_cube_with(data=function(self._data))
+        data = function(self._get_filled_data(fill=self._fill_value), *args)
+
+        return self._new_cube_with(data=data)
 
     def apply_function(self, function, axis=None, weights=None, unit=None,
                        projection=False, **kwargs):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1712,16 +1712,13 @@ class SpectralCube(object):
             return self._apply_everywhere(operator.mul, value)
 
     def __truediv__(self, value):
+        return self.__div__(value)
+
+    def __div__(self, value):
         if isinstance(value, SpectralCube):
             return self._cube_on_cube_operation(operator.truediv, value)
         else:
             return self._apply_everywhere(operator.truediv, value)
-
-    def __div__(self, value):
-        if isinstance(value, SpectralCube):
-            return self._cube_on_cube_operation(operator.floordiv, value)
-        else:
-            return self._apply_everywhere(operator.floordiv, value)
 
     def __pow__(self, value):
         if isinstance(value, SpectralCube):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1712,13 +1712,16 @@ class SpectralCube(object):
             return self._apply_everywhere(operator.mul, value)
 
     def __truediv__(self, value):
-        return self.__div__(value)
-
-    def __div__(self, value):
         if isinstance(value, SpectralCube):
             return self._cube_on_cube_operation(operator.truediv, value)
         else:
             return self._apply_everywhere(operator.truediv, value)
+
+    def __div__(self, value):
+        if isinstance(value, SpectralCube):
+            return self._cube_on_cube_operation(operator.floordiv, value)
+        else:
+            return self._apply_everywhere(operator.floordiv, value)
 
     def __pow__(self, value):
         if isinstance(value, SpectralCube):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -63,8 +63,9 @@ def cached(func):
 
 def warn_slow(function):
     # TODO: add check for whether cube has been loaded into memory
-    warnings.warn("This function requires loading the entire cube into memory "
-                  "and may therefore be slow.")
+    warnings.warn("This function ({0}) requires loading the entire cube into "
+                  "memory "
+                  "and may therefore be slow.".format(str(function)))
     return function
 
 _NP_DOC = """

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -61,6 +61,11 @@ def cached(func):
 
     return wrapper
 
+def warn_slow(function):
+    warnings.warn("This function requires loading the entire cube into memory "
+                  "and may therefore be slow.")
+    return function
+
 _NP_DOC = """
 Ignores excluded mask elements.
 
@@ -535,6 +540,7 @@ class SpectralCube(object):
         ny = self.shape[iteraxes[1]]
         return nx, ny
 
+    @warn_slow
     def apply_everywhere(self, function):
         """
         Return a new cube with ``function`` applied to all pixels

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -535,8 +535,21 @@ class SpectralCube(object):
         ny = self.shape[iteraxes[1]]
         return nx, ny
 
+    def apply_everywhere(self, function):
+        """
+        Return a new cube with ``function`` applied to all pixels
+        """
+
+        # First, check that function returns same # of dims?
+        assert function(np.ones([1,1,1])).shape == (1,1,1)
+
+        return self._new_cube_with(data=function(self._data))
+
     def apply_function(self, function, axis=None, weights=None, unit=None,
                        projection=False, **kwargs):
+    # not clear if this should be removed?
+    # def _apply_along_axes(self, function, axis=None, weights=None, wcs=False,
+    #                       **kwargs):
         """
         Apply a function to valid data along the specified axis or to the whole
         cube, optionally using a weight array that is the same shape (or at

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -553,9 +553,6 @@ class SpectralCube(object):
 
     def apply_function(self, function, axis=None, weights=None, unit=None,
                        projection=False, **kwargs):
-    # not clear if this should be removed?
-    # def _apply_along_axes(self, function, axis=None, weights=None, wcs=False,
-    #                       **kwargs):
         """
         Apply a function to valid data along the specified axis or to the whole
         cube, optionally using a weight array that is the same shape (or at

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -586,7 +586,7 @@ class SpectralCube(object):
         try:
             test_result = function(np.ones([1,1,1])*self.unit, *args)
             # First, check that function returns same # of dims?
-            assert test_result.shape == (1,1,1)
+            assert test_result.ndim == 3,"Output is not 3-dimensional"
         except Exception as ex:
             raise AssertionError("Function could not be applied to a simple "
                                  "cube.  The error was: {0}".format(ex))

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -700,8 +700,8 @@ class SpectralCube(object):
         try:
             from bottleneck import nanmedian
             result = self.apply_numpy_function(nanmedian, axis=axis,
-                                                projection=True,
-                                                check_endian=True, **kwargs)
+                                               projection=True,
+                                               check_endian=True, **kwargs)
         except ImportError:
             result = self.apply_function(np.median, axis=axis, **kwargs)
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -27,7 +27,8 @@ from distutils.version import StrictVersion
 
 __all__ = ['SpectralCube']
 
-__doctest_skip__ = ['SpectralCube.world']
+# apply_everywhere, world: do not have a valid cube to test on
+__doctest_skip__ = ['SpectralCube.world', 'SpectralCube.apply_everywhere']
 
 try:  # TODO replace with six.py
     xrange
@@ -549,7 +550,8 @@ class SpectralCube(object):
 
         Examples
         --------
-        >>> newcube = cube.apply_everywhere(np.add(0.5*u.Jy))
+        >>> cube = SpectralCube.read('xyv.fits')
+        >>> newcube = cube.apply_everywhere(np.add, 0.5*u.Jy)
         """
 
         try:

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -62,6 +62,7 @@ def cached(func):
     return wrapper
 
 def warn_slow(function):
+    # TODO: add check for whether cube has been loaded into memory
     warnings.warn("This function requires loading the entire cube into memory "
                   "and may therefore be slow.")
     return function

--- a/spectral_cube/tests/test_moments.py
+++ b/spectral_cube/tests/test_moments.py
@@ -1,12 +1,15 @@
 import pytest
 import numpy as np
 
+import astropy
 from astropy.wcs import WCS
 from astropy import units as u
 from astropy.io import fits
 
 from ..spectral_cube import SpectralCube
 from .helpers import assert_allclose
+
+from distutils.version import StrictVersion
 
 # the back of the book
 dv = 3e-2 * u.Unit('m/s')
@@ -69,6 +72,15 @@ axis_order = pytest.mark.parametrize(('axis', 'order'),
                                      (1, 0), (1, 1), (1, 2),
                                      (2, 0), (2, 1), (2, 2)))
 
+if StrictVersion(astropy.__version__[:3]) > StrictVersion('1.0'):
+    # The relative error is slightly larger on astropy-dev
+    # There is no obvious reason for this.
+    rtol = 2e-7
+    atol = 1e-40
+else:
+    rtol = 1e-7
+    atol = 0.0
+
 
 @axis_order
 def test_strategies_consistent(axis, order):
@@ -78,8 +90,8 @@ def test_strategies_consistent(axis, order):
     cwise = sc.moment(axis=axis, order=order, how='cube')
     swise = sc.moment(axis=axis, order=order, how='slice')
     rwise = sc.moment(axis=axis, order=order, how='ray')
-    assert_allclose(cwise, swise)
-    assert_allclose(cwise, rwise)
+    assert_allclose(cwise, swise, rtol=rtol, atol=atol)
+    assert_allclose(cwise, rwise, rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize(('order', 'axis', 'how'),
@@ -103,8 +115,8 @@ def test_consistent_mask_handling(axis, order):
     cwise = sc.moment(axis=axis, order=order, how='cube')
     swise = sc.moment(axis=axis, order=order, how='slice')
     rwise = sc.moment(axis=axis, order=order, how='ray')
-    assert_allclose(cwise, swise)
-    assert_allclose(cwise, rwise)
+    assert_allclose(cwise, swise, rtol=rtol, atol=atol)
+    assert_allclose(cwise, rwise, rtol=rtol, atol=atol)
 
 
 def test_convenience_methods():

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -172,12 +172,52 @@ class TestSpectralCube(object):
         c1, d1 = cube_and_raw('advs.fits')
 
         # append 'o' to indicate that it has been operated on
-        c1o = c1.apply_everywhere(operation, value)
+        c1o = c1._apply_everywhere(operation, value)
         d1o = operation(u.Quantity(d1, u.K), value)
 
         assert np.all(d1o == c1o.filled_data[:])
         # allclose fails on identical data?
         #assert_allclose(d1o, c1o.filled_data[:])
+
+class TestArithmetic(BaseTest):
+
+    def __init__(self):
+        self.c1, self.d1 = cube_and_raw('adv.fits')
+
+        # make nice easy-to-test numbers
+        self.d1.flat[:] = np.arange(self.d1.size)
+        self.c1._data.flat[:] = np.arange(self.d1.size)
+
+    def test_add(self):
+        d2 = self.d1 + 1*u.K
+        c2 = self.c1 + 1*u.K
+        assert np.all(d2 == c2.filled_data[:])
+        assert c2.unit == u.K
+
+    def test_subtract(self):
+        d2 = self.d1 - 1*u.K
+        c2 = self.c1 - 1*u.K
+        assert np.all(d2 == c2.filled_data[:])
+        assert c2.unit == u.K
+
+    def test_mul(self):
+        d2 = self.d1 * 2
+        c2 = self.c1 * 2
+        assert np.all(d2 == c2.filled_data[:])
+        assert c2.unit == u.K
+
+    def test_div(self):
+        d2 = self.d1 / 2
+        c2 = self.c1 / 2
+        assert np.all(d2 == c2.filled_data[:])
+        assert c2.unit == u.K
+
+    def test_pow(self):
+        d2 = self.d1 ** 2
+        c2 = self.c1 ** 2
+        assert np.all(d2 == c2.filled_data[:])
+        assert c2.unit == u.K**2
+
 
 
 class TestFilters(BaseTest):

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -10,6 +10,7 @@ warnings.simplefilter('always', UserWarning)
 from astropy.io import fits
 from astropy import units as u
 from astropy.wcs import WCS
+from astropy.wcs import _wcs
 import numpy as np
 
 from .. import (SpectralCube, BooleanArrayMask, FunctionMask, LazyMask,
@@ -540,7 +541,11 @@ def test_read_write_rountrip(tmpdir):
 
     assert cube.shape == cube.shape
     assert_allclose(cube._data, cube2._data)
-    assert cube._wcs.to_header_string() == cube2._wcs.to_header_string()
+    if StrictVersion(_wcs.__version__) != StrictVersion('5.9'):
+        # see https://github.com/astropy/astropy/pull/3992 for reasons:
+        # we should upgrade this for 5.10 when the absolute accuracy is
+        # maximized
+        assert cube._wcs.to_header_string() == cube2._wcs.to_header_string()
 
 
 def _dummy_cube():

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -168,7 +168,7 @@ class TestSpectralCube(object):
                               (operator.sub, 0.5*u.K),
                               (operator.mul, 0.5*u.K),
                               (operator.truediv, 0.5*u.K),
-                              (operator.div, 0.5*u.K),
+                              (operator.div if hasattr(operator,'div') else operator.floordiv, 0.5*u.K),
                              ))
     def test_apply_everywhere(self, operation, value):
         c1, d1 = cube_and_raw('advs.fits')

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -541,7 +541,8 @@ def test_read_write_rountrip(tmpdir):
 
     assert cube.shape == cube.shape
     assert_allclose(cube._data, cube2._data)
-    if StrictVersion(_wcs.__version__) != StrictVersion('5.9'):
+    if ((hasattr(_wcs, '__version__') and StrictVersion(_wcs.__version__) != StrictVersion('5.9'))
+        or not hasattr(_wcs, '__version__')):
         # see https://github.com/astropy/astropy/pull/3992 for reasons:
         # we should upgrade this for 5.10 when the absolute accuracy is
         # maximized

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -195,11 +195,24 @@ class TestArithmetic(object):
         assert np.all(d2 == c2.filled_data[:].value)
         assert c2.unit == u.K
 
+    def test_add_cubes(self):
+        d2 = self.d1 + self.d1
+        c2 = self.c1 + self.c1
+        assert np.all(d2 == c2.filled_data[:].value)
+        assert c2.unit == u.K
+
     @pytest.mark.parametrize(('value'),(1,1.0,2,2.0))
     def test_subtract(self, value):
         d2 = self.d1 - value
         c2 = self.c1 - value*u.K
         assert np.all(d2 == c2.filled_data[:].value)
+        assert c2.unit == u.K
+
+    def test_subtract_cubes(self):
+        d2 = self.d1 - self.d1
+        c2 = self.c1 - self.c1
+        assert np.all(d2 == c2.filled_data[:].value)
+        assert np.all(c2.filled_data[:].value == 0)
         assert c2.unit == u.K
 
     @pytest.mark.parametrize(('value'),(1,1.0,2,2.0))
@@ -209,12 +222,25 @@ class TestArithmetic(object):
         assert np.all(d2 == c2.filled_data[:].value)
         assert c2.unit == u.K
 
+    def test_mul_cubes(self):
+        d2 = self.d1 * self.d1
+        c2 = self.c1 * self.c1
+        assert np.all(d2 == c2.filled_data[:].value)
+        assert c2.unit == u.K**2
+
     @pytest.mark.parametrize(('value'),(1,1.0,2,2.0))
     def test_div(self, value):
         d2 = self.d1 / value
         c2 = self.c1 / value
         assert np.all(d2 == c2.filled_data[:].value)
         assert c2.unit == u.K
+
+    def test_div_cubes(self):
+        d2 = self.d1 / self.d1
+        c2 = self.c1 / self.c1
+        assert np.all((d2 == c2.filled_data[:].value) | (np.isnan(c2.filled_data[:])))
+        assert np.all((c2.filled_data[:] == 1) | (np.isnan(c2.filled_data[:])))
+        assert c2.unit == u.dimensionless_unscaled
 
     @pytest.mark.parametrize(('value'),
                              (1,1.0,2,2.0))
@@ -223,6 +249,12 @@ class TestArithmetic(object):
         c2 = self.c1 ** value
         assert np.all(d2 == c2.filled_data[:].value)
         assert c2.unit == u.K**value
+
+    def test_cube_add(self):
+        c2 = self.c1 + self.c1
+        d2 = self.d1 + self.d1
+        assert np.all(d2 == c2.filled_data[:].value)
+        assert c2.unit == u.K
 
 
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -167,7 +167,9 @@ class TestSpectralCube(object):
                              ((operator.add, 0.5*u.K),
                               (operator.sub, 0.5*u.K),
                               (operator.mul, 0.5*u.K),
-                              (operator.div, 0.5*u.K),))
+                              (operator.truediv, 0.5*u.K),
+                              (operator.div, 0.5*u.K),
+                             ))
     def test_apply_everywhere(self, operation, value):
         c1, d1 = cube_and_raw('advs.fits')
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -179,44 +179,50 @@ class TestSpectralCube(object):
         # allclose fails on identical data?
         #assert_allclose(d1o, c1o.filled_data[:])
 
-class TestArithmetic(BaseTest):
+class TestArithmetic(object):
 
-    def __init__(self):
+    def setup_method(self, method):
         self.c1, self.d1 = cube_and_raw('adv.fits')
 
         # make nice easy-to-test numbers
         self.d1.flat[:] = np.arange(self.d1.size)
         self.c1._data.flat[:] = np.arange(self.d1.size)
 
-    def test_add(self):
-        d2 = self.d1 + 1*u.K
-        c2 = self.c1 + 1*u.K
-        assert np.all(d2 == c2.filled_data[:])
+    @pytest.mark.parametrize(('value'),(1,1.0,2,2.0))
+    def test_add(self,value):
+        d2 = self.d1 + value
+        c2 = self.c1 + value*u.K
+        assert np.all(d2 == c2.filled_data[:].value)
         assert c2.unit == u.K
 
-    def test_subtract(self):
-        d2 = self.d1 - 1*u.K
-        c2 = self.c1 - 1*u.K
-        assert np.all(d2 == c2.filled_data[:])
+    @pytest.mark.parametrize(('value'),(1,1.0,2,2.0))
+    def test_subtract(self, value):
+        d2 = self.d1 - value
+        c2 = self.c1 - value*u.K
+        assert np.all(d2 == c2.filled_data[:].value)
         assert c2.unit == u.K
 
-    def test_mul(self):
-        d2 = self.d1 * 2
-        c2 = self.c1 * 2
-        assert np.all(d2 == c2.filled_data[:])
+    @pytest.mark.parametrize(('value'),(1,1.0,2,2.0))
+    def test_mul(self, value):
+        d2 = self.d1 * value
+        c2 = self.c1 * value
+        assert np.all(d2 == c2.filled_data[:].value)
         assert c2.unit == u.K
 
-    def test_div(self):
-        d2 = self.d1 / 2
-        c2 = self.c1 / 2
-        assert np.all(d2 == c2.filled_data[:])
+    @pytest.mark.parametrize(('value'),(1,1.0,2,2.0))
+    def test_div(self, value):
+        d2 = self.d1 / value
+        c2 = self.c1 / value
+        assert np.all(d2 == c2.filled_data[:].value)
         assert c2.unit == u.K
 
-    def test_pow(self):
-        d2 = self.d1 ** 2
-        c2 = self.c1 ** 2
-        assert np.all(d2 == c2.filled_data[:])
-        assert c2.unit == u.K**2
+    @pytest.mark.parametrize(('value'),
+                             (1,1.0,2,2.0))
+    def test_pow(self, value):
+        d2 = self.d1 ** value
+        c2 = self.c1 ** value
+        assert np.all(d2 == c2.filled_data[:].value)
+        assert c2.unit == u.K**value
 
 
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -163,6 +163,23 @@ class TestSpectralCube(object):
                         outcv.to(u.Hz).value)
 
 
+    @pytest.mark.parametrize(('operation', 'value'),
+                             ((operator.add, 0.5*u.K),
+                              (operator.sub, 0.5*u.K),
+                              (operator.mul, 0.5*u.K),
+                              (operator.div, 0.5*u.K),))
+    def test_apply_everywhere(self, operation, value):
+        c1, d1 = cube_and_raw('advs.fits')
+
+        # append 'o' to indicate that it has been operated on
+        c1o = c1.apply_everywhere(operation, value)
+        d1o = operation(u.Quantity(d1, u.K), value)
+
+        assert np.all(d1o == c1o.filled_data[:])
+        # allclose fails on identical data?
+        #assert_allclose(d1o, c1o.filled_data[:])
+
+
 class TestFilters(BaseTest):
 
     def test_mask_data(self):


### PR DESCRIPTION
This PR resumes #101 and follows #100.  It is intended as a first step to addressing a problem noted on the python in astronomy facebook group:
```
I'm trying to apply simple arithmetic operations to spectral cubes using SpectralCube, how can I do this to the data cube itself without extracting the data into numpy arrays? I'd like to maintain the data cube format.
```

Todo:
 * [x] Add tests
 * [x] Implement basic arithmetic functions (`add`, `subtract`, `product`, `divide`, `pow`)
 * [x] Add documentation