### PR TITLE
Consistent abort traps if cube is sliced before memmap is loaded

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -771,6 +771,7 @@ class SpectralCube(object):
                                 
             # only one element, so drop an axis
             newwcs = wcs_utils.drop_axis(self._wcs, intslices[0])
+            log.info("")
             return Slice(value=self.filled_data[view],
                          wcs=newwcs,
                          copy=False,


### PR DESCRIPTION
If I try reading a cube then very simply slicing it, I consistently get abort trap hard crashes:

```
In [5]: cube[82,:,:]
/Users/adam/anaconda/envs/astropy27/bin/python.app: line 3: 15278 Abort trap: 6           /Users/adam/anaconda/envs/astropy27/python.app/Contents/MacOS/python "$@"
```

By contrast, if I have read the cube into memory first, there is no such error:
```
In [1]: cube = SpectralCube.read('ALMA_Outflow_b6_12M_12CO.fits')

In [2]: scube = cube.minimal_subcube()

In [3]: cube[82,:,:]
Out[3]:
<Slice [[ nan, nan, nan,...,  nan, nan, nan],
        [ nan, nan, nan,...,  nan, nan, nan],
        [ nan, nan, nan,...,  nan, nan, nan],
        ...,
        [ nan, nan, nan,...,  nan, nan, nan],
        [ nan, nan, nan,...,  nan, nan, nan],
        [ nan, nan, nan,...,  nan, nan, nan]] Jy>
```

or 
```
In [1]: cube = SpectralCube.read('ALMA_Outflow_b6_12M_12CO.fits')

In [2]: cube.filled_data[82,:,:]
Out[2]:
<Quantity [[ nan, nan, nan,...,  nan, nan, nan],
           [ nan, nan, nan,...,  nan, nan, nan],
           [ nan, nan, nan,...,  nan, nan, nan],
           ...,
           [ nan, nan, nan,...,  nan, nan, nan],
           [ nan, nan, nan,...,  nan, nan, nan],
           [ nan, nan, nan,...,  nan, nan, nan]] Jy>

In [3]: cube[82,:,:]
Out[3]:
<Slice [[ nan, nan, nan,...,  nan, nan, nan],
        [ nan, nan, nan,...,  nan, nan, nan],
        [ nan, nan, nan,...,  nan, nan, nan],
        ...,
        [ nan, nan, nan,...,  nan, nan, nan],
        [ nan, nan, nan,...,  nan, nan, nan],
        [ nan, nan, nan,...,  nan, nan, nan]] Jy>
```

I suspect this is an error related to lazy masks, but I can't pin it down easily.