### PR TITLE
Mask quickview

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -1,6 +1,7 @@
 from astropy import units as u
 from astropy import wcs
 from astropy.io.fits import PrimaryHDU, ImageHDU, Header, Card, HDUList
+from astropy import wcs
 from .io.core import determine_format
 
 import numpy as np

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -193,6 +193,15 @@ class MaskBase(object):
     def quicklook(self, view, wcs=None, filename=None):
         '''
         View a 2D slice of the mask, specified by view.
+
+        Parameters
+        ----------
+        view : tuple
+            Slicing to apply to the mask. Must return a 2D slice.
+        wcs : astropy.wcs.WCS, optional
+            WCS object to use in plotting the mask slice.
+        filename : str, optional
+            Filename of the output image. Enables saving of the plot.
         '''
 
         view_twod = self.include(view=view)

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -4,6 +4,8 @@ import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
 from . import wcs_utils
+from .lower_dimensional_structures import Projection
+
 
 __all__ = ['InvertedMask', 'CompositeMask', 'BooleanArrayMask',
            'LazyMask', 'LazyComparisonMask', 'FunctionMask']
@@ -188,6 +190,17 @@ class MaskBase(object):
     def __getitem__(self):
         raise NotImplementedError("Slicing not supported by mask class {0}".format(self.__class__.__name__))
 
+    def quicklook(self, wcs=None, view=(), filename=None):
+        '''
+        View a 2D slice of the mask, specified by view.
+        '''
+
+        view_twod = self.include(view=view)
+
+        proj = Projection(view_twod, wcs=wcs)
+
+        proj.quicklook(filename=filename)
+
     def _get_new_wcs(self, unit, velocity_convention=None, rest_value=None):
         """
         Returns a new WCS with a different Spectral Axis unit
@@ -216,7 +229,7 @@ class InvertedMask(MaskBase):
 
     def __getitem__(self, view):
         return InvertedMask(self._mask[view])
-    
+
     def with_spectral_unit(self, unit, velocity_convention=None, rest_value=None):
         """
         Get an InvertedMask copy with a WCS in the modified unit
@@ -432,7 +445,7 @@ class LazyComparisonMask(LazyMask):
     """
     A boolean mask defined by the evaluation of a comparison function between a
     fixed dataset and some other value.
-    
+
     This is conceptually similar to the :class:`LazyMask` but it will ensure
     that the comparison value can be compared to the data
 
@@ -487,7 +500,7 @@ class LazyComparisonMask(LazyMask):
 
             return self._function(self._data[view],
                                   self._comparison_value[cv_view])
-        
+
         else:
             return self._function(self._data[view],
                                   self._comparison_value)

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -190,7 +190,7 @@ class MaskBase(object):
     def __getitem__(self):
         raise NotImplementedError("Slicing not supported by mask class {0}".format(self.__class__.__name__))
 
-    def quicklook(self, wcs=None, view=(), filename=None):
+    def quicklook(self, view, wcs=None, filename=None):
         '''
         View a 2D slice of the mask, specified by view.
         '''

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -190,7 +190,7 @@ class MaskBase(object):
     def __getitem__(self):
         raise NotImplementedError("Slicing not supported by mask class {0}".format(self.__class__.__name__))
 
-    def quicklook(self, view, wcs=None, filename=None):
+    def quicklook(self, view, wcs=None, filename=None, use_aplpy=True):
         '''
         View a 2D slice of the mask, specified by view.
 
@@ -208,7 +208,7 @@ class MaskBase(object):
 
         proj = Projection(view_twod, wcs=wcs)
 
-        proj.quicklook(filename=filename)
+        proj.quicklook(filename=filename, use_aplpy=use_aplpy)
 
     def _get_new_wcs(self, unit, velocity_convention=None, rest_value=None):
         """

--- a/spectral_cube/tests/test_visualization.py
+++ b/spectral_cube/tests/test_visualization.py
@@ -50,3 +50,10 @@ def test_projvis():
 
     mom0 = cube.moment0()
     mom0.quicklook(use_aplpy=True)
+
+@pytest.mark.skipif("not APLPY_INSTALLED")
+def test_mask_quicklook():
+
+    cube, data = cube_and_raw('vda_Jybeam_lower.fits')
+
+    cube.mask.quicklook(view=(0, slice(None), slice(None)), use_aplpy=True)


### PR DESCRIPTION
This stemmed from a discussion in [signal-id](https://github.com/radio-astro-tools/signal-id/issues/31) with @keflavich. ```RadioMask``` in signal-id is intended for interactive mask manipulation and would benefit from the ability to quickly look at slices in the mask.

The changes are working, but I need to add some tests and a way to catch views that will not return a 2D slice (though this will be caught in ```Projection```).