### PR TITLE
Make SpectralCube operate more like a numpy array in some ways

### DIFF
--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -96,7 +96,7 @@ def read_data_fits(input, hdu=None, **kwargs):
     return array_hdu.data, array_hdu.header
 
 
-def load_fits_cube(input, hdu=0, meta={}):
+def load_fits_cube(input, hdu=0, meta={}, **kwargs):
     """
     Read in a cube from a FITS file using astropy.
 
@@ -110,7 +110,7 @@ def load_fits_cube(input, hdu=0, meta={}):
         Metadata (can be inherited from other readers, for example)
     """
 
-    data, header = read_data_fits(input, hdu=hdu)
+    data, header = read_data_fits(input, hdu=hdu, **kwargs)
 
     if 'BUNIT' in header:
         meta['BUNIT'] = header['BUNIT']

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -188,7 +188,8 @@ class MaskBase(object):
         return InvertedMask(self)
 
     def __getitem__(self):
-        raise NotImplementedError("Slicing not supported by mask class {0}".format(self.__class__.__name__))
+        raise NotImplementedError("Slicing not supported by mask class {0}"
+                                  .format(self.__class__.__name__))
 
     def quicklook(self, view, wcs=None, filename=None, use_aplpy=True):
         '''

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -242,6 +242,11 @@ class SpectralCube(object):
         """ Number of elements in the cube """
         return self._data.size
 
+    @property
+    def base(self):
+        """ The data type 'base' of the cube - useful for, e.g., joblib """
+        return self._data.base
+
     def __len__(self):
         return self.shape[0]
 
@@ -943,7 +948,7 @@ class SpectralCube(object):
                 newwcs = self._wcs.sub([a
                                         for a in (1,2,3)
                                         if a not in [x+1 for x in intslices]])
-                return OneDSpectrum(value=self.filled_data[view],
+                return OneDSpectrum(value=self._data[view],
                                     wcs=newwcs,
                                     copy=False,
                                     unit=self.unit,

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2,6 +2,7 @@ import pytest
 import operator
 import itertools
 import warnings
+import mmap
 
 # needed to test for warnings later
 warnings.simplefilter('always', UserWarning)
@@ -602,12 +603,19 @@ def test_read_write_rountrip(tmpdir):
         assert cube._wcs.to_header_string() == cube2._wcs.to_header_string()
 
 @pytest.mark.parametrize(('memmap', 'base'),
-                         ((True, np.memmap),
+                         ((True, mmap.mmap),
                           (False, None)))
 def test_read_memmap(memmap, base):
     cube = SpectralCube.read(path('adv.fits'), memmap=memmap)
 
-    assert cube.base == base
+    bb = cube.base
+    while hasattr(bb, 'base'):
+        bb = bb.base
+
+    if base is None:
+        assert bb is None
+    else:
+        assert isinstance(bb, base)
 
 
 def _dummy_cube():

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -601,6 +601,14 @@ def test_read_write_rountrip(tmpdir):
         # maximized
         assert cube._wcs.to_header_string() == cube2._wcs.to_header_string()
 
+@pytest.mark.parametrize(('memmap', 'base'),
+                         ((True, np.memmap),
+                          (False, None)))
+def test_read_memmap(memmap, base):
+    cube = SpectralCube.read(path('adv.fits'), memmap=memmap)
+
+    assert cube.base == base
+
 
 def _dummy_cube():
     data = np.array([[[0, 1, 2, 3, 4]]])


### PR DESCRIPTION
This PR does two things:

 1. Provide the 'base' of self so that things like joblib can operate on
 spectral cubes, understanding that they are memmaps. 
 2. For a related reason, lower dimensional slices should return _data[view],
 not filled_data[view], BUT this doesn't provide the right functionality so we
 want lower dimensional objects to implement their own cubelike masking

The TODO list:

 * [ ] Implement masking for lower-dimensional objects
 * [x] Test the base