### PR TITLE
Set WCS each time a new WCS is created

### DIFF
--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -200,6 +200,7 @@ class MaskBase(object):
 
         newwcs = convert_spectral_axis(self._wcs, unit, out_ctype,
                                        rest_value=rest_value)
+        newwcs.wcs.set()
 
         return newwcs
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -400,20 +400,22 @@ class SpectralCube(object):
                 # if operation is over two spatial dims
                 if set(axis) == set((1,2)):
                     new_wcs = self._wcs.sub([wcs.WCSSUB_SPECTRAL])
+                    header = self._nowcs_header
                     return OneDSpectrum(value=out,
                                         wcs=new_wcs,
                                         copy=False,
                                         unit=unit,
-                                        header=self._nowcs_header,
+                                        header=header,
                                         meta=meta)
                 else:
                     return out
 
             else:
                 new_wcs = wcs_utils.drop_axis(self._wcs, np2wcs[axis])
+                header = self._nowcs_header
 
                 return Projection(out, copy=False, wcs=new_wcs, meta=meta,
-                                  unit=unit, header=self._nowcs_header)
+                                  unit=unit, header=header)
         else:
             return out
 
@@ -949,11 +951,12 @@ class SpectralCube(object):
                                 
             # only one element, so drop an axis
             newwcs = wcs_utils.drop_axis(self._wcs, intslices[0])
+            header = self._nowcs_header
             return Slice(value=self.filled_data[view],
                          wcs=newwcs,
                          copy=False,
                          unit=self.unit,
-                         header=self._nowcs_header,
+                         header=header,
                          meta=meta)
 
         newmask = self._mask[view] if self._mask is not None else None
@@ -1069,6 +1072,7 @@ class SpectralCube(object):
                                                 rest_value=rest_value)
         newmask._wcs = newwcs
 
+        newwcs.wcs.set()
         cube = self._new_cube_with(wcs=newwcs, mask=newmask, meta=meta,
                                    spectral_unit=unit)
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -217,6 +217,59 @@ class TestSpectralCube(object):
         # allclose fails on identical data?
         #assert_allclose(d1o, c1o.filled_data[:])
 
+    @pytest.mark.parametrize(('name', 'trans'), (
+                             ('advs', [0, 1, 2, 3]),
+                             ('dvsa', [2, 3, 0, 1]),
+                             ('sdav', [0, 2, 1, 3]),
+                             ('sadv', [0, 1, 2, 3]),
+                             ('vsad', [3, 0, 1, 2]),
+                             ('vad', [2, 0, 1]),
+                             ('vda', [0, 2, 1]),
+                             ('adv', [0, 1, 2]),
+                             ))
+    def test_getitem(self, name, trans):
+        c, d = cube_and_raw(name + '.fits')
+
+        expected = np.squeeze(d.transpose(trans))
+
+        assert_allclose(c[0,:,:].value, expected[0,:,:])
+        assert_allclose(c[:,:,0].value, expected[:,:,0])
+        assert_allclose(c[:,0,:].value, expected[:,0,:])
+
+        # Not implemented:
+        #assert_allclose(c[0,0,:].value, expected[0,0,:])
+        #assert_allclose(c[0,:,0].value, expected[0,:,0])
+        assert_allclose(c[:,0,0].value, expected[:,0,0])
+
+        assert_allclose(c[1,:,:].value, expected[1,:,:])
+        assert_allclose(c[:,:,1].value, expected[:,:,1])
+        assert_allclose(c[:,1,:].value, expected[:,1,:])
+
+        # Not implemented:
+        #assert_allclose(c[1,1,:].value, expected[1,1,:])
+        #assert_allclose(c[1,:,1].value, expected[1,:,1])
+        assert_allclose(c[:,1,1].value, expected[:,1,1])
+
+        c2 = c.with_spectral_unit(u.km/u.s, velocity_convention='radio')
+
+        assert_allclose(c2[0,:,:].value, expected[0,:,:])
+        assert_allclose(c2[:,:,0].value, expected[:,:,0])
+        assert_allclose(c2[:,0,:].value, expected[:,0,:])
+
+        # Not implemented:
+        #assert_allclose(c2[0,0,:].value, expected[0,0,:])
+        #assert_allclose(c2[0,:,0].value, expected[0,:,0])
+        assert_allclose(c2[:,0,0].value, expected[:,0,0])
+
+        assert_allclose(c2[1,:,:].value, expected[1,:,:])
+        assert_allclose(c2[:,:,1].value, expected[:,:,1])
+        assert_allclose(c2[:,1,:].value, expected[:,1,:])
+
+        # Not implemented:
+        #assert_allclose(c2[1,1,:].value, expected[1,1,:])
+        #assert_allclose(c2[1,:,1].value, expected[1,:,1])
+        assert_allclose(c2[:,1,1].value, expected[:,1,1])
+
 class TestArithmetic(object):
 
     def setup_method(self, method):


### PR DESCRIPTION
set the WCS in masks when they are created to avoid mismatches between the
cube and mask WCSes.  Otherwise, mask wcs != cube wcs errors can arise