### PR TITLE
Add beam info onto the header, if it is defined

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -23,6 +23,12 @@ from .io.core import determine_format
 from .ytcube import ytCube
 from .lower_dimensional_structures import Projection, Slice, OneDSpectrum
 
+try:
+    from radio_beam import Beam
+    beam_available = True
+except ImportError:
+    beam_available = False
+
 from distutils.version import StrictVersion
 
 __all__ = ['SpectralCube']
@@ -111,7 +117,7 @@ np2wcs = {2: 0, 1: 1, 0: 2}
 class SpectralCube(object):
 
     def __init__(self, data, wcs, mask=None, meta=None, fill_value=np.nan,
-                 header=None, allow_huge_operations=False):
+                 header=None, allow_huge_operations=False, read_beam=True):
 
         # Deal with metadata first because it can affect data reading
         self._meta = meta or {}

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -127,8 +127,7 @@ class SpectralCube(object):
             if self._meta['BUNIT'].lower() == 'jy/beam':
                 self._unit = u.Jy
                 try:
-                    import radio_beam
-                    self.beam = radio_beam.Beam.from_fits_header(header)
+                    self.beam = Beam.from_fits_header(header)
                     self._meta['beam'] = self.beam
                     warnings.warn("Units were JY/BEAM.  The 'beam' is now "
                                   "stored in the .beam attribute, and the "

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -23,12 +23,6 @@ from .io.core import determine_format
 from .ytcube import ytCube
 from .lower_dimensional_structures import Projection, Slice, OneDSpectrum
 
-try:
-    from radio_beam import Beam
-    BEAM_AVAILABLE = True
-except ImportError:
-    BEAM_AVAILABLE = False
-
 from distutils.version import StrictVersion
 
 __all__ = ['SpectralCube']
@@ -123,10 +117,6 @@ class SpectralCube(object):
         self._meta = meta or {}
 
         if read_beam:
-            if not BEAM_AVAILABLE:
-                raise ImportError("radio_beam is not installed. No beam "
-                                  "can be created.")
-
             self._try_load_beam(header)
 
         if 'BUNIT' in self._meta:
@@ -246,6 +236,12 @@ class SpectralCube(object):
         return cube
 
     def _try_load_beam(self, header):
+
+        try:
+            from radio_beam import Beam
+        except ImportError:
+            warnings.warn("radio_beam is not installed. No beam "
+                          "can be created.")
 
         try:
             self.beam = Beam.from_fits_header(header)

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -946,7 +946,7 @@ class SpectralCube(object):
                                     copy=False,
                                     unit=self.unit,
                                     meta=meta)
-                                
+
             # only one element, so drop an axis
             newwcs = wcs_utils.drop_axis(self._wcs, intslices[0])
             return Slice(value=self.filled_data[view],
@@ -1982,8 +1982,8 @@ class SpectralCube(object):
                     return self._glue_app
 
             glue_app.add_datasets(self._glue_app.data_collection, result)
-        
-        
+
+
     def to_pvextractor(self):
         """
         Open the cube in a quick viewer written in matplotlib that allows you
@@ -2052,6 +2052,9 @@ class SpectralCube(object):
             header['CRVAL3'] *= self._spectral_scale
             header['CUNIT3'] = self._spectral_unit.to_string(format='FITS')
 
+        if 'beam' in self._meta:
+            header = self._meta['beam'].attach_to_header(header)
+
         # TODO: incorporate other relevant metadata here
         return header
 
@@ -2068,7 +2071,7 @@ class SpectralCube(object):
         Return the cube converted to the given unit (assuming it is equivalent).
         If conversion was required, this will be a copy, otherwise it will
         """
-        
+
         if not isinstance(unit, u.Unit):
             unit = u.Unit(unit)
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -856,7 +856,7 @@ def test_preserve_beam():
 
     cube, data = cube_and_raw('advs.fits')
 
-    beam = Beam.from_fits_header("advs.fits")
+    beam = Beam.from_fits_header(path("advs.fits"))
 
     assert cube.beam == beam
 
@@ -865,7 +865,7 @@ def test_append_beam_to_hdr():
 
     cube, data = cube_and_raw('advs.fits')
 
-    orig_hdr = fits.getheader('advs.fits')
+    orig_hdr = fits.getheader(path('advs.fits'))
 
     assert cube.header['BMAJ'] == orig_hdr['BMAJ']
     assert cube.header['BMIN'] == orig_hdr['BMIN']

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -41,7 +41,7 @@ except ImportError:
     bottleneckOK = False
 
 try:
-    import radio_beam
+    from radio_beam import Beam
     RADIO_BEAM_INSTALLED = True
 except ImportError:
     RADIO_BEAM_INSTALLED = False
@@ -644,7 +644,7 @@ def test_endians():
     mywcs.wcs.ctype[0] = 'RA'
     mywcs.wcs.ctype[1] = 'DEC'
     mywcs.wcs.ctype[2] = 'VELO'
-    
+
     bigcube = SpectralCube(data=big, wcs=mywcs)
     xbig = bigcube._get_filled_data(check_endian=True)
 
@@ -679,7 +679,7 @@ def test_slicing():
 
     sl = cube[:,1,:]
     assert sl.shape == (2,4)
-    
+
     v = cube[1:2,:,:]
     assert v.shape == (1,3,4)
 
@@ -850,6 +850,26 @@ def test_preserve_bunit():
 
     assert cube.unit == u.Jy
     assert cube.header['BUNIT'] == 'Jy'
+
+@pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
+def test_preserve_beam():
+
+    cube, data = cube_and_raw('advs.fits')
+
+    beam = Beam.from_fits_header("advs.fits")
+
+    assert cube.beam == beam
+
+@pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
+def test_append_beam_to_hdr():
+
+    cube, data = cube_and_raw('advs.fits')
+
+    orig_hdr = fits.getheader('advs.fits')
+
+    assert cube.header['BMAJ'] == orig_hdr['BMAJ']
+    assert cube.header['BMIN'] == orig_hdr['BMIN']
+    assert cube.header['BMPA'] == orig_hdr['BMPA']
 
 def test_cube_with_swapped_axes():
     """

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -869,7 +869,7 @@ def test_append_beam_to_hdr():
 
     assert cube.header['BMAJ'] == orig_hdr['BMAJ']
     assert cube.header['BMIN'] == orig_hdr['BMIN']
-    assert cube.header['BMPA'] == orig_hdr['BMPA']
+    assert cube.header['BPA'] == orig_hdr['BPA']
 
 def test_cube_with_swapped_axes():
     """


### PR DESCRIPTION
Use [Beam.attach_to_header](https://github.com/radio-astro-tools/radio_beam/pull/18) to add the beam information to ```SpectralCube.header``` -- @keflavich 

Missing tests.