### PR TITLE
Allow with_spectral_unit('string units', ...)

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1064,6 +1064,10 @@ class SpectralCube(object):
         from .spectral_axis import (convert_spectral_axis,
                                     determine_ctype_from_vconv)
 
+        # Allow string specification of units, for example
+        if not isinstance(unit, u.Unit):
+            unit = u.Unit(unit)
+
         # Velocity conventions: required for frq <-> velo
         # convert_spectral_axis will handle the case of no velocity
         # convention specified & one is required

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -161,13 +161,15 @@ class TestSpectralCube(object):
             assert_allclose(w1, w2)
 
 
-    @pytest.mark.parametrize(('name','masktype'),
+    @pytest.mark.parametrize(('name','masktype','unit'),
                              itertools.product(('advs', 'dvsa', 'sdav', 'sadv', 'vsad', 'vad', 'adv',),
-                                               (BooleanArrayMask, LazyMask, FunctionMask, CompositeMask))
+                                               (BooleanArrayMask, LazyMask, FunctionMask, CompositeMask),
+                                               ('Hz', u.Hz),
+                                              )
                             )
-    def test_with_spectral_unit(self, name, masktype):
+    def test_with_spectral_unit(self, name, masktype, unit):
         cube, data = cube_and_raw(name + '.fits')
-        cube_freq = cube.with_spectral_unit(u.Hz)
+        cube_freq = cube.with_spectral_unit(unit)
 
         if masktype == BooleanArrayMask:
             mask = BooleanArrayMask(data>0, wcs=cube._wcs)
@@ -181,7 +183,7 @@ class TestSpectralCube(object):
             mask = CompositeMask(mask1, mask2)
 
         cube2 = cube.with_mask(mask)
-        cube_masked_freq = cube2.with_spectral_unit(u.Hz)
+        cube_masked_freq = cube2.with_spectral_unit(unit)
 
         assert cube_freq._wcs.wcs.ctype[cube_freq._wcs.wcs.spec] == 'FREQ-W2F'
         assert cube_masked_freq._wcs.wcs.ctype[cube_masked_freq._wcs.wcs.spec] == 'FREQ-W2F'


### PR DESCRIPTION
String units can now be passed to `with_spectral_unit`, as there was no reason to exclude them.