### PR TITLE
metadata persists to new SpectralCube?

### DIFF
--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -96,7 +96,7 @@ def read_data_fits(input, hdu=None, **kwargs):
     return array_hdu.data, array_hdu.header
 
 
-def load_fits_cube(input, hdu=0, meta={}, **kwargs):
+def load_fits_cube(input, hdu=0, meta=None, **kwargs):
     """
     Read in a cube from a FITS file using astropy.
 
@@ -111,6 +111,9 @@ def load_fits_cube(input, hdu=0, meta={}, **kwargs):
     """
 
     data, header = read_data_fits(input, hdu=hdu, **kwargs)
+
+    if meta is None:
+        meta = {}
 
     if 'BUNIT' in header:
         meta['BUNIT'] = header['BUNIT']


### PR DESCRIPTION
If I read in a cube and look at the metadata:

```
 cube = SpectralCube.read('VLA_Data/AT0206/imaging/M33_206_b_c_HI.fits')
cube._meta
# {'BUNIT': 'Jy/beam',
 'beam': Beam: BMAJ=6.354 arcsec BMIN=5.86296 arcsec BPA=87.9 deg}
```
and then read in another cube:
```
cube_2 = SpectralCube.read('Arecibo/M33only.fits')
cube_2._meta
# {'BUNIT': 'K',
 'beam': Beam: BMAJ=227.99988 arcsec BMIN=198.0 arcsec BPA=0.0 deg}
```
the metadata in ```cube``` is now the metadata of ```cube_2```:
```
cube._meta
# {'BUNIT': 'K',
 'beam': Beam: BMAJ=227.99988 arcsec BMIN=198.0 arcsec BPA=0.0 deg}
```

Is this related to issues with caching (#204)?