### PR TITLE
Make sure median preserves units

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
 
 python:
-    - 2.6
     - 2.7
-    - 3.3
     - 3.4
+    - 3.5
     # This is just for "egg_info".  All other builds are explicitly given in the matrix
 env:
     global:
@@ -42,31 +41,29 @@ matrix:
           env: ASTROPY_VERSION=development SETUP_CMD='test' YT=no
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='test' APLPY=yes PVEXTRACTOR=yes
-        - python: 3.3
-          env: ASTROPY_VERSION=development SETUP_CMD='test'
         - python: 3.4
           env: ASTROPY_VERSION=development SETUP_CMD='test'
-        - python: 3.4
+        - python: 3.5
+          env: ASTROPY_VERSION=development SETUP_CMD='test'
+        - python: 3.5
           env: ASTROPY_VERSION=development SETUP_CMD='test' APLPY=yes PVEXTRACTOR=yes
 
         # Try all python versions with the latest numpy
-        - python: 2.6
-          env: SETUP_CMD='test'
         - python: 2.7
           env: SETUP_CMD='test' YT=yes
         - python: 2.7
           env: SETUP_CMD='test' YT=no
         - python: 2.7
           env: SETUP_CMD='test' APLPY=yes PVEXTRACTOR=yes
-        - python: 3.3
-          env: SETUP_CMD='test'
         - python: 3.4
           env: SETUP_CMD='test'
-        - python: 3.4
+        - python: 3.5
+          env: SETUP_CMD='test'
+        - python: 3.5
           env: SETUP_CMD='test' APLPY=yes PVEXTRACTOR=yes
 
         # Try older numpy versions
-        - python: 3.4
+        - python: 3.5
           env: NUMPY_VERSION=1.9 SETUP_CMD='test'
         - python: 2.7
           env: NUMPY_VERSION=1.9 SETUP_CMD='test'
@@ -80,11 +77,11 @@ matrix:
         # Test with bottleneck
         - python: 2.7
           env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.9
-        - python: 3.4
+        - python: 3.5
           env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.9
         - python: 2.7
           env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.10
-        - python: 3.4
+        - python: 3.5
           env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.10
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,8 @@ matrix:
           env: SETUP_CMD='test' APLPY=yes PVEXTRACTOR=yes
 
         # Try older numpy versions
-        - python: 3.5
-          env: NUMPY_VERSION=1.9 SETUP_CMD='test'
+        # drop support for 1.9+3.5 because travis can't test it - python: 3.5
+        # drop support for 1.9+3.5 because travis can't test it   env: NUMPY_VERSION=1.9 SETUP_CMD='test'
         - python: 2.7
           env: NUMPY_VERSION=1.9 SETUP_CMD='test'
         #- python: 2.7
@@ -77,8 +77,8 @@ matrix:
         # Test with bottleneck
         - python: 2.7
           env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.9
-        - python: 3.5
-          env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.9
+        # drop support for 1.9+3.5 because travis can't test it - python: 3.5
+        # drop support for 1.9+3.5 because travis can't test it   env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.9
         - python: 2.7
           env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.10
         - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ install:
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL https://github.com/radio-astro-tools/radio_beam/archive/master.zip; fi
 
     # Bottleneck
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $BOTTLENECK == yes ]] && [[ $NUMPY_VERSION == 1.10 ]]; then $CONDA_INSTALL --channel https://conda.binstar.org/asmeurer bottleneck; fi
+    - if [[ $SETUP_CMD != egg_info ]] && [[ $BOTTLENECK == yes ]] && [[ $NUMPY_VERSION == 1.10  || $NUMPY_VERSION == 1.9 ]]; then $CONDA_INSTALL --channel https://conda.binstar.org/asmeurer bottleneck; fi
 
     # OPTIONAL DEPENDENCIES
     # Here you can add any dependencies your package may have. You can use

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.9
+        - NUMPY_VERSION=1.10
         - ASTROPY_VERSION=stable
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
@@ -67,9 +67,9 @@ matrix:
 
         # Try older numpy versions
         - python: 3.4
-          env: NUMPY_VERSION=1.8 SETUP_CMD='test'
+          env: NUMPY_VERSION=1.9 SETUP_CMD='test'
         - python: 2.7
-          env: NUMPY_VERSION=1.8 SETUP_CMD='test'
+          env: NUMPY_VERSION=1.9 SETUP_CMD='test'
         #- python: 2.7
         #  env: NUMPY_VERSION=1.7 SETUP_CMD='test'
         #- python: 2.7
@@ -79,13 +79,13 @@ matrix:
 
         # Test with bottleneck
         - python: 2.7
-          env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.8
+          env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.9
         - python: 3.4
-          env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.8
+          env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.9
         - python: 2.7
-          env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.9
+          env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.10
         - python: 3.4
-          env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.9
+          env: ASTROPY_VERSION=stable SETUP_CMD='test' bottleneck=yes NUMPY_VERSION=1.10
 
 before_install:
 
@@ -129,7 +129,7 @@ install:
     - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
 
     # YT
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $TRAVIS_PYTHON_VERSION == 2.7 ]] && [[ $NUMPY_VERSION == 1.9 ]] && [[ $YT == yes ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION yt; fi
+    - if [[ $SETUP_CMD != egg_info ]] && [[ $TRAVIS_PYTHON_VERSION == 2.7 ]] && [[ $NUMPY_VERSION == 1.10 ]] && [[ $YT == yes ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION yt; fi
 
     # matplotlib
     - if [[ $SETUP_CMD != egg_info ]] && [[ $MATPLOTLIB == yes ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION matplotlib; fi
@@ -146,7 +146,7 @@ install:
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL https://github.com/radio-astro-tools/radio_beam/archive/master.zip; fi
 
     # Bottleneck
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $BOTTLENECK == yes ]] && [[ $NUMPY_VERSION == 1.9 ]]; then $CONDA_INSTALL --channel https://conda.binstar.org/asmeurer bottleneck; fi
+    - if [[ $SETUP_CMD != egg_info ]] && [[ $BOTTLENECK == yes ]] && [[ $NUMPY_VERSION == 1.10 ]]; then $CONDA_INSTALL --channel https://conda.binstar.org/asmeurer bottleneck; fi
 
     # OPTIONAL DEPENDENCIES
     # Here you can add any dependencies your package may have. You can use

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -903,7 +903,8 @@ class SpectralCube(object):
                                                projection=True,
                                                check_endian=True, **kwargs)
         except ImportError:
-            result = self.apply_function(np.median, axis=axis, **kwargs)
+            result = self.apply_function(np.median, projection=True, axis=axis,
+                                         **kwargs)
 
         return result
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -923,7 +923,7 @@ class SpectralCube(object):
             Which axis to compute percentiles over
         """
         return self.apply_function(np.percentile, q=q, axis=axis,
-                                   unit=self.unit, **kwargs)
+                                   projection=True, unit=self.unit, **kwargs)
 
     def with_mask(self, mask, inherit_mask=True):
         """

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -905,9 +905,16 @@ class SpectralCube(object):
                                                unit=self.unit,
                                                check_endian=True, **kwargs)
         except ImportError:
-            log.debug("Using numpy nanmedian")
-            result = self.apply_function(np.nanmedian, projection=True, axis=axis,
-                                         unit=self.unit, **kwargs)
+            if hasattr(np, 'nanmedian'):
+                log.debug("Using numpy nanmedian")
+                result = self.apply_numpy_function(np.nanmedian, axis=axis,
+                                                   projection=True,
+                                                   unit=self.unit,
+                                                   **kwargs)
+            else:
+                log.debug("Using numpy median iterating over slices")
+                result = self.apply_function(np.median, projection=True, axis=axis,
+                                             unit=self.unit, **kwargs)
 
         return result
 
@@ -922,8 +929,17 @@ class SpectralCube(object):
         axis : int, or None
             Which axis to compute percentiles over
         """
-        return self.apply_function(np.percentile, q=q, axis=axis,
-                                   projection=True, unit=self.unit, **kwargs)
+        if hasattr(np, 'nanpercentile'):
+            result = self.apply_numpy_function(np.nanpercentile, q=q,
+                                               axis=axis, projection=True,
+                                               unit=self.unit,
+                                               **kwargs)
+        else:
+            result = self.apply_function(np.percentile, q=q, axis=axis,
+                                         projection=True, unit=self.unit,
+                                         **kwargs)
+
+        return result
 
     def with_mask(self, mask, inherit_mask=True):
         """

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -899,11 +899,13 @@ class SpectralCube(object):
         """
         try:
             from bottleneck import nanmedian
+            log.debug("Using bottleneck nanmedian")
             result = self.apply_numpy_function(nanmedian, axis=axis,
                                                projection=True,
                                                unit=self.unit,
                                                check_endian=True, **kwargs)
         except ImportError:
+            log.debug("Using numpy nanmedian")
             result = self.apply_function(np.nanmedian, projection=True, axis=axis,
                                          unit=self.unit, **kwargs)
 
@@ -920,7 +922,8 @@ class SpectralCube(object):
         axis : int, or None
             Which axis to compute percentiles over
         """
-        return self.apply_function(np.percentile, q=q, axis=axis, **kwargs)
+        return self.apply_function(np.percentile, q=q, axis=axis,
+                                   unit=self.unit, **kwargs)
 
     def with_mask(self, mask, inherit_mask=True):
         """

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -347,7 +347,9 @@ class SpectralCube(object):
                              reduce=True, how='auto',
                              projection=False,
                              unit=None,
-                             check_endian=False, **kwargs):
+                             check_endian=False,
+                             progressbar=False,
+                             **kwargs):
         """
         Apply a numpy function to the cube
 
@@ -381,6 +383,9 @@ class SpectralCube(object):
             A flag to check the endianness of the data before applying the
             function.  This is only needed for optimized functions, e.g. those
             in the `bottleneck` package.
+        progressbar : bool
+            Show a progressbar while iterating over the slices through the
+            cube?
         kwargs : dict
             Passed to the numpy function.
 
@@ -408,9 +413,8 @@ class SpectralCube(object):
 
         if strategy == 'slice' and reduce:
             try:
-                out = self._reduce_slicewise(function, fill,
-                                              check_endian,
-                                              **kwargs)
+                out = self._reduce_slicewise(function, fill, check_endian,
+                                             progressbar=progressbar, **kwargs)
             except NotImplementedError:
                 pass
         elif how not in ['auto', 'cube']:

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -901,10 +901,11 @@ class SpectralCube(object):
             from bottleneck import nanmedian
             result = self.apply_numpy_function(nanmedian, axis=axis,
                                                projection=True,
+                                               unit=self.unit,
                                                check_endian=True, **kwargs)
         except ImportError:
-            result = self.apply_function(np.median, projection=True, axis=axis,
-                                         **kwargs)
+            result = self.apply_function(np.nanmedian, projection=True, axis=axis,
+                                         unit=self.unit, **kwargs)
 
         return result
 

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -291,9 +291,13 @@ def is_broadcastable_try(shp1, shp2):
     (this is the try/fail approach, which is guaranteed right.... right?)
     http://stackoverflow.com/questions/24743753/test-if-an-array-is-broadcastable-to-a-shape/24745359#24745359
     """
-    x = np.array([1])
-    a = as_strided(x, shape=shp1, strides=[0] * len(shp1))
-    b = as_strided(x, shape=shp2, strides=[0] * len(shp2))
+    #This variant does not work as of np 1.10: the strided arrays aren't
+    #writable and therefore apparently cannot be broadcast
+    # x = np.array([1])
+    # a = as_strided(x, shape=shp1, strides=[0] * len(shp1))
+    # b = as_strided(x, shape=shp2, strides=[0] * len(shp2))
+    a = np.ones(shp1)
+    b = np.ones(shp2)
     try:
         c = np.broadcast_arrays(a, b)
         # reverse order: compare last dim first (as broadcasting does)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -619,13 +619,13 @@ class TestYt():
         ds1,ds2,ds3 = ytc1.dataset, ytc2.dataset, ytc3.dataset
         yt_coord1 = ds1.domain_left_edge + np.random.random(size=3)*ds1.domain_width
         world_coord1 = ytc1.yt2world(yt_coord1)
-        assert_allclose(ytc1.world2yt(world_coord1), yt_coord1)
+        assert_allclose(ytc1.world2yt(world_coord1), yt_coord1.value)
         yt_coord2 = ds2.domain_left_edge + np.random.random(size=3)*ds2.domain_width
         world_coord2 = ytc2.yt2world(yt_coord2)
-        assert_allclose(ytc2.world2yt(world_coord2), yt_coord2)
+        assert_allclose(ytc2.world2yt(world_coord2), yt_coord2.value)
         yt_coord3 = ds3.domain_left_edge + np.random.random(size=3)*ds3.domain_width
         world_coord3 = ytc3.yt2world(yt_coord3)
-        assert_allclose(ytc3.world2yt(world_coord3), yt_coord3)
+        assert_allclose(ytc3.world2yt(world_coord3), yt_coord3.value)
 
 def test_read_write_rountrip(tmpdir):
     cube = SpectralCube.read(path('adv.fits'))

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -449,10 +449,13 @@ class TestNumpyMethods(BaseTest):
         # from the cube.median method that does "the right thing"
         #
         # for regular median, we expect a failure, which is why we don't use
-        # regular median.  Failure means all 6 pixels are NaN, even though one
-        # should include good data
+        # regular median.  
+
         scmed = self.c.apply_numpy_function(np.median, axis=0)
-        assert np.count_nonzero(np.isnan(scmed)) == 6
+        if StrictVersion(np.__version__) <= StrictVersion('1.9.3'):
+            assert np.count_nonzero(np.isnan(scmed)) == 5
+        else:
+            assert np.count_nonzero(np.isnan(scmed)) == 6
 
         scmed = self.c.apply_numpy_function(np.nanmedian, axis=0)
         assert np.count_nonzero(np.isnan(scmed)) == 0

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -436,7 +436,9 @@ class TestNumpyMethods(BaseTest):
                 ray = self.d[:, y, x]
                 ray = ray[ray > 0.5]
                 m[y, x] = np.median(ray)
-        assert_allclose(self.c.median(axis=0), m)
+        scmed = self.c.median(axis=0)
+        assert_allclose(scmed, m)
+        assert scmed.unit == self.c.unit
 
     def test_percentile(self):
         m = np.empty(self.d.sum(axis=0).shape)
@@ -584,7 +586,6 @@ class TestYt():
         # Now test round-trip conversions between yt and world coordinates
         ytc1,ytc2,ytc3 = self.ytc1,self.ytc2,self.ytc3
         ds1,ds2,ds3 = ytc1.dataset, ytc2.dataset, ytc3.dataset
-        cube = self.cube
         yt_coord1 = ds1.domain_left_edge + np.random.random(size=3)*ds1.domain_width
         world_coord1 = ytc1.yt2world(yt_coord1)
         assert_allclose(ytc1.world2yt(world_coord1), yt_coord1)
@@ -603,8 +604,9 @@ def test_read_write_rountrip(tmpdir):
 
     assert cube.shape == cube.shape
     assert_allclose(cube._data, cube2._data)
-    if ((hasattr(_wcs, '__version__') and StrictVersion(_wcs.__version__) != StrictVersion('5.9'))
-        or not hasattr(_wcs, '__version__')):
+    if (((hasattr(_wcs, '__version__')
+          and StrictVersion(_wcs.__version__) != StrictVersion('5.9'))
+         or not hasattr(_wcs, '__version__'))):
         # see https://github.com/astropy/astropy/pull/3992 for reasons:
         # we should upgrade this for 5.10 when the absolute accuracy is
         # maximized
@@ -767,11 +769,11 @@ def test_slicing():
 
 
 @pytest.mark.parametrize(('view','naxis'),
-                         [( (slice(None), 1, slice(None)), 2 ),
-                          ( (1, slice(None), slice(None)), 2 ),
-                          ( (slice(None), slice(None), 1), 2 ),
-                          ( (slice(None), slice(None), slice(1)), 3 ),
-                          ( (slice(1), slice(1), slice(1)), 3 ),
+                         [((slice(None), 1, slice(None)), 2),
+                          ((1, slice(None), slice(None)), 2),
+                          ((slice(None), slice(None), 1), 2),
+                          ((slice(None), slice(None), slice(1)), 3),
+                          ((slice(1), slice(1), slice(1)), 3),
                          ])
 def test_slice_wcs(view, naxis):
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -635,12 +635,14 @@ def test_read_write_rountrip(tmpdir):
     assert cube.shape == cube.shape
     assert_allclose(cube._data, cube2._data)
     if (((hasattr(_wcs, '__version__')
-          and StrictVersion(_wcs.__version__) != StrictVersion('5.9'))
+          and StrictVersion(_wcs.__version__) < StrictVersion('5.9'))
          or not hasattr(_wcs, '__version__'))):
         # see https://github.com/astropy/astropy/pull/3992 for reasons:
         # we should upgrade this for 5.10 when the absolute accuracy is
         # maximized
         assert cube._wcs.to_header_string() == cube2._wcs.to_header_string()
+        # in 5.11 and maybe even 5.12, the round trip fails.  Maybe
+        # https://github.com/astropy/astropy/issues/4292 will solve it?
 
 @pytest.mark.parametrize(('memmap', 'base'),
                          ((True, mmap.mmap),

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -430,7 +430,7 @@ class TestNumpyMethods(BaseTest):
         self._check_numpy(self.c.argmin, d, np.nanargmin)
 
     def test_median(self):
-        m = np.empty(self.d.sum(axis=0).shape)
+        m = np.empty(self.d.shape[1:])
         for y in range(m.shape[0]):
             for x in range(m.shape[1]):
                 ray = self.d[:, y, x]
@@ -438,7 +438,12 @@ class TestNumpyMethods(BaseTest):
                 m[y, x] = np.median(ray)
         scmed = self.c.median(axis=0)
         assert_allclose(scmed, m)
+        assert not np.any(np.isnan(scmed.value))
         assert scmed.unit == self.c.unit
+
+    def test_bad_median(self):
+        scmed = self.c.apply_numpy_function(np.median, axis=0)
+        assert np.count_nonzero(np.isnan(scmed)) == 5
 
     def test_percentile(self):
         m = np.empty(self.d.sum(axis=0).shape)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -572,10 +572,11 @@ class TestYt():
         ds1,ds2,ds3 = ytc1.dataset, ytc2.dataset, ytc3.dataset
         assert_array_equal(ds1.domain_dimensions, ds2.domain_dimensions)
         assert_array_equal(ds2.domain_dimensions, ds3.domain_dimensions)
-        assert_allclose(ds1.domain_left_edge, ds2.domain_left_edge)
-        assert_allclose(ds2.domain_left_edge, ds3.domain_left_edge)
-        assert_allclose(ds1.domain_width, ds2.domain_width*np.array([1,1,1.0/self.spectral_factor]))
-        assert_allclose(ds1.domain_width, ds3.domain_width)
+        assert_allclose(ds1.domain_left_edge.value, ds2.domain_left_edge.value)
+        assert_allclose(ds2.domain_left_edge.value, ds3.domain_left_edge.value)
+        assert_allclose(ds1.domain_width.value,
+                        ds2.domain_width.value*np.array([1,1,1.0/self.spectral_factor]))
+        assert_allclose(ds1.domain_width.value, ds3.domain_width.value)
         assert self.nprocs == len(ds3.index.grids)
         assert ds1.spec_cube
         assert ds2.spec_cube

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -469,6 +469,7 @@ class TestNumpyMethods(BaseTest):
         scmed = self.c.median(axis=0, iterate_rays=iterate_rays)
         assert np.count_nonzero(np.isnan(scmed)) == 0
 
+        m2 = self.c>0.65*self.c.unit
         scmed = self.c.with_mask(m2).median(axis=0, iterate_rays=iterate_rays)
         assert np.count_nonzero(np.isnan(scmed)) == 1
 


### PR DESCRIPTION
There was a bug in which the median did not preserve units.  It should have
caused test failures too since `np.median` was being used instead of
`np.nanmedian`, but I have not observed any such failures, which is worrisome.