### PR TITLE
allow cube to have a blank mask when converting units

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1165,10 +1165,13 @@ class SpectralCube(object):
         newwcs = convert_spectral_axis(self._wcs, unit, out_ctype,
                                        rest_value=rest_value)
 
-        newmask = self._mask.with_spectral_unit(unit,
-                                                velocity_convention=vc,
-                                                rest_value=rest_value)
-        newmask._wcs = newwcs
+        if self._mask is not None:
+            newmask = self._mask.with_spectral_unit(unit,
+                                                    velocity_convention=vc,
+                                                    rest_value=rest_value)
+            newmask._wcs = newwcs
+        else:
+            newmask = None
 
         newwcs.wcs.set()
         cube = self._new_cube_with(wcs=newwcs, mask=newmask, meta=meta,


### PR DESCRIPTION
right now a cube without a mask will result in:

```
  File "/Users/adam/repos/spectral-cube/spectral_cube/spectral_cube.py", line 1104, in with_spectral_unit
      newmask = self._mask.with_spectral_unit(unit,
      AttributeError: 'NoneType' object has no attribute 'with_spectral_unit'
  ```