### PR TITLE
Preserve metadata when making projections

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -425,6 +425,7 @@ class SpectralCube(object):
                 return out
         elif projection and reduce:
             meta = {'collapse_axis': axis}
+            meta.update(self._meta)
 
             if hasattr(axis, '__len__') and len(axis) == 2:
                 # if operation is over two spatial dims
@@ -536,8 +537,10 @@ class SpectralCube(object):
             out = ttl / counts
             if projection:
                 new_wcs = wcs_utils.drop_axis(self._wcs, np2wcs[axis])
+                meta = {'collapse_axis': axis}
+                meta.update(self._meta)
                 return Projection(out, copy=False, wcs=new_wcs,
-                                  meta={'collapse_axis': axis},
+                                  meta=meta,
                                   unit=self.unit, header=self._nowcs_header)
             else:
                 return out
@@ -589,8 +592,10 @@ class SpectralCube(object):
 
             if projection:
                 new_wcs = wcs_utils.drop_axis(self._wcs, np2wcs[axis])
+                meta = {'collapse_axis': axis}
+                meta.update(self._meta)
                 return Projection(out, copy=False, wcs=new_wcs,
-                                  meta={'collapse_axis': axis},
+                                  meta=meta,
                                   unit=self.unit, header=self._nowcs_header)
             else:
                 return out
@@ -793,6 +798,7 @@ class SpectralCube(object):
             new_wcs = wcs_utils.drop_axis(self._wcs, np2wcs[axis])
 
             meta = {'collapse_axis': axis}
+            meta.update(self._meta)
 
             return Projection(out, copy=False, wcs=new_wcs, meta=meta,
                               unit=unit, header=self._nowcs_header)

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1372,6 +1372,7 @@ class SpectralCube(object):
         meta = {'moment_order': order,
                 'moment_axis': axis,
                 'moment_method': how}
+        meta.update(self._meta)
 
         return Projection(out, copy=False, wcs=new_wcs, meta=meta,
                           header=self._nowcs_header)

--- a/spectral_cube/tests/test_moments.py
+++ b/spectral_cube/tests/test_moments.py
@@ -175,8 +175,5 @@ def test_how_withfluxunit(order, axis, how):
 
     assert sc.unit == u.K
     assert sc.filled_data[:].unit == u.K
-    # regression test for #250
-    assert 'beam' in mom_sc.meta
-    assert 'beam' in mom_sc.hdu.header
 
     assert_allclose(mom_sc, MOMENTSu[order][axis])

--- a/spectral_cube/tests/test_moments.py
+++ b/spectral_cube/tests/test_moments.py
@@ -175,5 +175,7 @@ def test_how_withfluxunit(order, axis, how):
 
     assert sc.unit == u.K
     assert sc.filled_data[:].unit == u.K
+    assert 'beam' in sc.meta
+    assert 'beam' in sc.hdu.header
 
     assert_allclose(mom_sc, MOMENTSu[order][axis])

--- a/spectral_cube/tests/test_moments.py
+++ b/spectral_cube/tests/test_moments.py
@@ -176,7 +176,7 @@ def test_how_withfluxunit(order, axis, how):
     assert sc.unit == u.K
     assert sc.filled_data[:].unit == u.K
     # regression test for #250
-    assert 'beam' in sc.meta
-    assert 'beam' in sc.hdu.header
+    assert 'beam' in mom_sc.meta
+    assert 'beam' in mom_sc.hdu.header
 
     assert_allclose(mom_sc, MOMENTSu[order][axis])

--- a/spectral_cube/tests/test_moments.py
+++ b/spectral_cube/tests/test_moments.py
@@ -175,6 +175,7 @@ def test_how_withfluxunit(order, axis, how):
 
     assert sc.unit == u.K
     assert sc.filled_data[:].unit == u.K
+    # regression test for #250
     assert 'beam' in sc.meta
     assert 'beam' in sc.hdu.header
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -980,7 +980,7 @@ def test_beam_proj_meta():
 
     # regression test for #250
     assert 'beam' in moment.meta
-    assert 'beam' in moment.hdu.header
+    assert 'BMAJ' in moment.hdu.header
 
     slc = cube[0,:,:]
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -985,11 +985,9 @@ def test_beam_proj_meta():
     slc = cube[0,:,:]
 
     assert 'beam' in slc.meta
-    assert 'beam' in slc.meta
 
     proj = cube.max(axis=0)
 
-    assert 'beam' in proj.meta
     assert 'beam' in proj.meta
 
 def test_proj_meta():

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -980,17 +980,17 @@ def test_beam_proj_meta():
 
     # regression test for #250
     assert 'beam' in moment.meta
-    assert 'BMAJ' in moment.hdu.header
+    assert 'beam' in moment.hdu.header
 
     slc = cube[0,:,:]
 
     assert 'beam' in slc.meta
-    assert 'BMAJ' in slc.meta
+    assert 'beam' in slc.meta
 
     proj = cube.max(axis=0)
 
     assert 'beam' in proj.meta
-    assert 'BMAJ' in proj.meta
+    assert 'beam' in proj.meta
 
 def test_proj_meta():
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -970,3 +970,43 @@ def test_jybeam_lower():
         assert hasattr(cube, 'beam')
         np.testing.assert_almost_equal(cube.beam.sr.value,
                                        (((1*u.arcsec/np.sqrt(8*np.log(2)))**2).to(u.sr)*2*np.pi).value)
+        
+@pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
+def test_beam_proj_meta():
+
+    cube, data = cube_and_raw('advs.fits')
+
+    moment = cube.moment0(axis=0)
+
+    # regression test for #250
+    assert 'beam' in moment.meta
+    assert 'BMAJ' in moment.hdu.header
+
+    slc = cube[0,:,:]
+
+    assert 'beam' in slc.meta
+    assert 'BMAJ' in slc.meta
+
+    proj = cube.max(axis=0)
+
+    assert 'beam' in proj.meta
+    assert 'BMAJ' in proj.meta
+
+def test_proj_meta():
+
+    cube, data = cube_and_raw('advs.fits')
+
+    moment = cube.moment0(axis=0)
+
+    assert 'BUNIT' in moment.meta
+    assert moment.meta['BUNIT'] == 'K'
+
+    slc = cube[0,:,:]
+
+    assert 'BUNIT' in slc.meta
+    assert slc.meta['BUNIT'] == 'K'
+
+    proj = cube.max(axis=0)
+
+    assert 'BUNIT' in proj.meta
+    assert proj.meta['BUNIT'] == 'K'


### PR DESCRIPTION
metadata should be passed to projections so that information like the beam
shape is preserved