### PR TITLE
BUGFIX: cube._data cannot be a quantity

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -151,10 +151,13 @@ class SpectralCube(object):
                     self._unit = None
         elif hasattr(data, 'unit'):
             self._unit = data.unit
-            # strip the unit so that it can be treated as cube metadata
-            data = data.value
         else:
             self._unit = None
+
+        # data must not be a quantity when stored in self._data
+        if hasattr(data, 'unit'):
+            # strip the unit so that it can be treated as cube metadata
+            data = data.value
 
         # TODO: mask should be oriented? Or should we assume correctly oriented here?
         self._data, self._wcs = cube_utils._orient(data, wcs)
@@ -697,7 +700,7 @@ class SpectralCube(object):
                                    self.unit, copy=False),
                         *args)
 
-        return self._new_cube_with(data=data.value, unit=data.unit)
+        return self._new_cube_with(data=data, unit=data.unit)
 
     @warn_slow
     def _cube_on_cube_operation(self, function, cube, equivalencies=[]):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -697,7 +697,7 @@ class SpectralCube(object):
                                    self.unit, copy=False),
                         *args)
 
-        return self._new_cube_with(data=data, unit=data.unit)
+        return self._new_cube_with(data=data.value, unit=data.unit)
 
     @warn_slow
     def _cube_on_cube_operation(self, function, cube, equivalencies=[]):

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -302,12 +302,18 @@ class TestArithmetic(object):
         assert np.all(d2 == c2.filled_data[:].value)
         assert c2.unit == u.K
 
+        # regression test: the _data attribute must not be a quantity
+        assert not hasattr(c2._data, 'unit')
+
     def test_subtract_cubes(self):
         d2 = self.d1 - self.d1
         c2 = self.c1 - self.c1
         assert np.all(d2 == c2.filled_data[:].value)
         assert np.all(c2.filled_data[:].value == 0)
         assert c2.unit == u.K
+
+        # regression test: the _data attribute must not be a quantity
+        assert not hasattr(c2._data, 'unit')
 
     @pytest.mark.parametrize(('value'),(1,1.0,2,2.0))
     def test_mul(self, value):

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -302,7 +302,7 @@ class TestArithmetic(object):
         assert np.all(d2 == c2.filled_data[:].value)
         assert c2.unit == u.K
 
-        # regression test: the _data attribute must not be a quantity
+        # regression test #251: the _data attribute must not be a quantity
         assert not hasattr(c2._data, 'unit')
 
     def test_subtract_cubes(self):
@@ -312,7 +312,7 @@ class TestArithmetic(object):
         assert np.all(c2.filled_data[:].value == 0)
         assert c2.unit == u.K
 
-        # regression test: the _data attribute must not be a quantity
+        # regression test #251: the _data attribute must not be a quantity
         assert not hasattr(c2._data, 'unit')
 
     @pytest.mark.parametrize(('value'),(1,1.0,2,2.0))


### PR DESCRIPTION
If cube._data is a quantity, comparisons fail because the 'value' needs to be extracted recursively.