### PR TITLE
Fix pyds9 import (somtimes)

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -5,6 +5,7 @@ A class to represent a 3-d position-position-velocity spectral cube.
 import warnings
 from functools import wraps
 import operator
+import sys
 
 from astropy import units as u
 from astropy.extern import six
@@ -2111,7 +2112,10 @@ class SpectralCube(object):
         newframe: bool
             Send the cube to a new frame or to the current frame?
         """
-        import ds9
+        try:
+            import ds9
+        except ImportError:
+            import pyds9 as ds9
 
         if ds9id is None:
             dd = ds9.ds9(start=True)


### PR DESCRIPTION
On my system, I have pyds9 installed as ds9, but that seems to be nonstandard.  I don't fully understand the issue, but trying to import both seems to work.

Note that pyds9 is not python3-compatible!

Any recommendations on how to test this?  I guess we'd need to install ds9 and
then ensure that it has the cube in memory.  Probably doable, but I don't have
time now.