### PR TITLE
Strip whitespace from BUNIT

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -124,7 +124,8 @@ class SpectralCube(object):
         if 'BUNIT' in self._meta:
 
             # special case: CASA (sometimes) makes non-FITS-compliant jy/beam headers
-            if self._meta['BUNIT'].lower() == 'jy/beam':
+            bunit = "".join(self._meta['BUNIT'].lower().split())
+            if bunit == 'jy/beam':
                 self._unit = u.Jy
 
                 if not read_beam:

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -6,6 +6,7 @@ import warnings
 from functools import wraps
 import operator
 import sys
+import re
 
 from astropy import units as u
 from astropy.extern import six
@@ -124,7 +125,7 @@ class SpectralCube(object):
         if 'BUNIT' in self._meta:
 
             # special case: CASA (sometimes) makes non-FITS-compliant jy/beam headers
-            bunit = "".join(self._meta['BUNIT'].lower().split())
+            bunit = re.sub("\s", "", self._meta['BUNIT'].lower())
             if bunit == 'jy/beam':
                 self._unit = u.Jy
 

--- a/spectral_cube/tests/data/make_test_cubes.py
+++ b/spectral_cube/tests/data/make_test_cubes.py
@@ -69,3 +69,5 @@ if __name__ == "__main__":
     fits.writeto('vda_JYBEAM_upper.fits', d, h, clobber=True)
     h['BUNIT'] = 'Jy/beam'
     fits.writeto('vda_Jybeam_lower.fits', d, h, clobber=True)
+    h['BUNIT'] = ' Jy / beam '
+    fits.writeto('vda_Jybeam_whitespace.fits', d, h, clobber=True)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1023,6 +1023,7 @@ def test_jybeam_lower():
         np.testing.assert_almost_equal(cube.beam.sr.value,
                                        (((1*u.arcsec/np.sqrt(8*np.log(2)))**2).to(u.sr)*2*np.pi).value)
 
+# Regression test for #257 (https://github.com/radio-astro-tools/spectral-cube/pull/257)
 def test_jybeam_whitespace():
 
     cube, data = cube_and_raw('vda_Jybeam_whitespace.fits')

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -449,7 +449,7 @@ class TestNumpyMethods(BaseTest):
         # from the cube.median method that does "the right thing"
         #
         # for regular median, we expect a failure, which is why we don't use
-        # regular median.  
+        # regular median.
 
         scmed = self.c.apply_numpy_function(np.median, axis=0)
         if StrictVersion(np.__version__) <= StrictVersion('1.9.3'):
@@ -1022,7 +1022,17 @@ def test_jybeam_lower():
         assert hasattr(cube, 'beam')
         np.testing.assert_almost_equal(cube.beam.sr.value,
                                        (((1*u.arcsec/np.sqrt(8*np.log(2)))**2).to(u.sr)*2*np.pi).value)
-        
+
+def test_jybeam_whitespace():
+
+    cube, data = cube_and_raw('vda_Jybeam_whitespace.fits')
+
+    assert cube.unit == u.Jy
+    if RADIO_BEAM_INSTALLED:
+        assert hasattr(cube, 'beam')
+        np.testing.assert_almost_equal(cube.beam.sr.value,
+                                       (((1*u.arcsec/np.sqrt(8*np.log(2)))**2).to(u.sr)*2*np.pi).value)
+
 @pytest.mark.skipif("not RADIO_BEAM_INSTALLED")
 def test_beam_proj_meta():
 


### PR DESCRIPTION
All white-space is now stripped from the BUNIT. I have a header written by CASA that has extra whitespaces in the BUNIT: ```Jy / beam ```.