### PR TITLE
Memory Error in SpectralCube._pix_size

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1366,15 +1366,15 @@ class SpectralCube(object):
 
         _, _, spectral = self._wcs.all_pix2world(xpix, ypix, zpix, 0)
 
-        dspectral = np.diff(spectral)
+        # Take spectral units into account
+        # order of operations here is crucial!  If this is done after
+        # broadcasting, the full array size is allocated, which is bad!
+        dspectral = np.diff(spectral) * self._spectral_scale
 
         dx = np.abs(np.degrees(dx.reshape(1, dx.shape[0], dx.shape[1])))
         dy = np.abs(np.degrees(dy.reshape(1, dy.shape[0], dy.shape[1])))
         dspectral = np.abs(dspectral.reshape(-1, 1, 1))
         dx, dy, dspectral = np.broadcast_arrays(dx, dy, dspectral)
-
-        # Take spectral units into account
-        dspectral = dspectral * self._spectral_scale
 
         return dspectral, dy, dx
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1265,7 +1265,7 @@ class SpectralCube(object):
         x[:, 1:] = np.cumsum(np.degrees(dx), axis=1)
         y[1:, :] = np.cumsum(np.degrees(dy), axis=0)
 
-        a, b, c = np.broadcast_arrays(x[None,:,:], y[None,:,:], spectral[:,None,None])
+        x, y, spectral = np.broadcast_arrays(x[None,:,:], y[None,:,:], spectral[:,None,None])
 
         return spectral, y, x
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1271,6 +1271,16 @@ class SpectralCube(object):
 
         return spectral, y, x
 
+    def _pix_size_slice(self, axis):
+        """
+        Return the size of each pixel along any given direction.  Assumes
+        pixels have equal size.
+        """
+        if axis == 0:
+            return self.wcs.wcs.cdelt[0] * self._spectral_scale
+        else:
+            return self.wcs.wcs.cdelt[axis]
+
     @cached
     def _pix_size(self):
         """

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1264,10 +1264,13 @@ class SpectralCube(object):
         x[:, 1:] = np.cumsum(np.degrees(dx), axis=1)
         y[1:, :] = np.cumsum(np.degrees(dy), axis=0)
 
-        x = x.reshape(1, x.shape[0], x.shape[1])
-        y = y.reshape(1, y.shape[0], y.shape[1])
-        spectral = spectral.reshape(-1, 1, 1) - spectral.ravel()[0]
-        x, y, spectral = np.broadcast_arrays(x, y, spectral)
+        x = np.lib.stride_tricks.as_strided(x, shape=self.shape, strides=(0,) +
+                                            x.strides)
+        y = np.lib.stride_tricks.as_strided(y, shape=self.shape,
+                                            strides=(y.strides[0], 0,
+                                                     y.strides[1]))
+        spectral = np.lib.stride_tricks.as_strided(spectral, shape=self.shape,
+                                                   strides=spectral.strides + (0,))
 
         return spectral, y, x
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1265,25 +1265,7 @@ class SpectralCube(object):
         x[:, 1:] = np.cumsum(np.degrees(dx), axis=1)
         y[1:, :] = np.cumsum(np.degrees(dy), axis=0)
 
-        # "manual" approach to striding; there is a mistake somewhere in here.
-        #x = np.lib.stride_tricks.as_strided(x, shape=self.shape, strides=(0,) +
-        #                                    x.strides)
-        #y = np.lib.stride_tricks.as_strided(y, shape=self.shape,
-        #                                    strides=(y.strides[0], 0,
-        #                                             y.strides[1]))
-        #spectral = np.lib.stride_tricks.as_strided(spectral, shape=self.shape,
-        #                                           strides=spectral.strides + (0,0,))
-
         a, b, c = np.broadcast_arrays(x[None,:,:], y[None,:,:], spectral[:,None,None])
-
-        x = x.reshape(1, x.shape[0], x.shape[1])
-        y = y.reshape(1, y.shape[0], y.shape[1])
-        spectral = spectral.reshape(-1, 1, 1)
-        x, y, spectral = np.broadcast_arrays(x, y, spectral)
-
-        assert np.all(a==x)
-        assert np.all(b==y)
-        assert np.all(c==spectral)
 
         return spectral, y, x
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1288,7 +1288,7 @@ class SpectralCube(object):
         if axis == 0:
             # note that self._spectral_scale is required here because wcs
             # forces into units of m, m/s, or Hz
-            return self.wcs.pixel_scale_matrix[2,2] * self._spectral_scale
+            return np.abs(self.wcs.pixel_scale_matrix[2,2]) * self._spectral_scale
         elif axis in (1,2):
             # the pixel size is a projection.  I think the pixel_scale_matrix
             # must be symmetric, such that psm[axis,:]**2 == psm[:,axis]**2

--- a/spectral_cube/tests/test_moments.py
+++ b/spectral_cube/tests/test_moments.py
@@ -79,7 +79,7 @@ if StrictVersion(astropy.__version__[:3]) > StrictVersion('1.0'):
     # The relative error is slightly larger on astropy-dev
     # There is no obvious reason for this.
     rtol = 2e-7
-    atol = 1e-40
+    atol = 1e-30
 else:
     rtol = 1e-7
     atol = 0.0

--- a/spectral_cube/tests/test_performance.py
+++ b/spectral_cube/tests/test_performance.py
@@ -1,7 +1,8 @@
 """
 Performance-related tests to make sure we don't use more memory than we should
 """
-from . test_moments import moment_cube
+from .test_moments import moment_cube
+from .helpers import assert_allclose
 from ..spectral_cube import SpectralCube
 
 def find_base_nbytes(obj):
@@ -14,7 +15,31 @@ def test_pix_size():
     mc_hdu = moment_cube()
     sc = SpectralCube.read(mc_hdu)
 
-    s,y,x = sc._pixel_size()
+    s,y,x = sc._pix_size()
+
+    # float64 by default
+    bytes_per_pix = 8
+
+    assert find_base_nbytes(s) == sc.shape[0]*bytes_per_pix
+    assert find_base_nbytes(y) == sc.shape[1]*sc.shape[2]*bytes_per_pix
+    assert find_base_nbytes(x) == sc.shape[1]*sc.shape[2]*bytes_per_pix
+
+def test_compare_pix_size_approaches():
+    mc_hdu = moment_cube()
+    sc = SpectralCube.read(mc_hdu)
+
+    sa,ya,xa = sc._pix_size()
+    s,y,x = (sc._pix_size_slice(ii) for ii in range(3))
+
+    assert_allclose(sa, s)
+    assert_allclose(ya, y)
+    assert_allclose(xa, x)
+
+def test_pix_cen():
+    mc_hdu = moment_cube()
+    sc = SpectralCube.read(mc_hdu)
+
+    s,y,x = sc._pix_cen()
 
     # float64 by default
     bytes_per_pix = 8

--- a/spectral_cube/tests/test_performance.py
+++ b/spectral_cube/tests/test_performance.py
@@ -1,0 +1,24 @@
+"""
+Performance-related tests to make sure we don't use more memory than we should
+"""
+from . test_moments import moment_cube
+from ..spectral_cube import SpectralCube
+
+def find_base_nbytes(obj):
+    # from http://stackoverflow.com/questions/34637875/size-of-numpy-strided-array-broadcast-array-in-memory
+    if obj.base is not None:
+        return find_base_nbytes(obj.base)
+    return obj.nbytes
+
+def test_pix_size():
+    mc_hdu = moment_cube()
+    sc = SpectralCube.read(mc_hdu)
+
+    s,y,x = sc._pixel_size()
+
+    # float64 by default
+    bytes_per_pix = 8
+
+    assert find_base_nbytes(s) == sc.shape[0]*bytes_per_pix
+    assert find_base_nbytes(y) == sc.shape[1]*sc.shape[2]*bytes_per_pix
+    assert find_base_nbytes(x) == sc.shape[1]*sc.shape[2]*bytes_per_pix

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1071,3 +1071,27 @@ def test_proj_meta():
 
     assert 'BUNIT' in proj.meta
     assert proj.meta['BUNIT'] == 'K'
+
+def test_pix_sign():
+    
+    cube, data = cube_and_raw('advs.fits')
+
+    s,y,x = (cube._pix_size_slice(ii) for ii in range(3))
+
+    assert s>0
+    assert y>0
+    assert x>0
+
+    cube.wcs.cdelt *= -1
+    s,y,x = (cube._pix_size_slice(ii) for ii in range(3))
+
+    assert s>0
+    assert y>0
+    assert x>0
+
+    cube.wcs.pc *= -1
+    s,y,x = (cube._pix_size_slice(ii) for ii in range(3))
+
+    assert s>0
+    assert y>0
+    assert x>0

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1082,14 +1082,14 @@ def test_pix_sign():
     assert y>0
     assert x>0
 
-    cube.wcs.cdelt *= -1
+    cube.wcs.wcs.cdelt *= -1
     s,y,x = (cube._pix_size_slice(ii) for ii in range(3))
 
     assert s>0
     assert y>0
     assert x>0
 
-    cube.wcs.pc *= -1
+    cube.wcs.wcs.pc *= -1
     s,y,x = (cube._pix_size_slice(ii) for ii in range(3))
 
     assert s>0


### PR DESCRIPTION
This arose when computing the 0th moment of a cube.
Running `cube._pix_cen()` gives the following:
```
---------------------------------------------------------------------------
MemoryError                               Traceback (most recent call last)
<ipython-input-2-a118f0eff323> in <module>()
----> 1 cube._pix_size()

/home/eric/Dropbox/code_development/radio_astro_tools/spectral-cube/spectral_cube/spectral_cube.py in wrapper(self, *args)
     61         # The cache lives in the instance so that it gets garbage collected
     62         if func not in self._cache:
---> 63             self._cache[func] = func(self, *args)
     64         return self._cache[func]
     65 

/home/eric/Dropbox/code_development/radio_astro_tools/spectral-cube/spectral_cube/spectral_cube.py in _pix_size(self)
   1345 
   1346         # Take spectral units into account
-> 1347         dspectral = dspectral * self._spectral_scale
   1348 
   1349         return dspectral, dy, dx

MemoryError: 
```

It's a fairly large cube (~30 Gb). I read it in with:
```
cube = SpectralCube.read("M33_14B-088_HI.clean.image.fits", mode='denywrite', memmap=True)
```

Commenting out line 1347 does seems to fix the issue, and the units of the moment map remain correct. The `cube._spectral_scale` is a float, not a quantity. Setting it to a quantity (e.g., km/s) still gives the memory error.