### PR TITLE
LowerDimensionalObjects lose important properties when doing X

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -118,15 +118,22 @@ class LowerDimensionalObject(u.Quantity):
 
         return new
 
-    def __array_wrap__(self, obj, context=None):
-        new = self.__class__(value=obj.value,
-                             unit=obj.unit,
-                             copy=False,
-                             wcs=self._wcs,
-                             meta=self._meta,
-                             mask=self._mask,
-                             header=self._header)
-        return new
+    def __array_finalize__(self, obj):
+        self._unit = getattr(obj, '_unit', None)
+        self._wcs = getattr(obj, '_wcs', None)
+        self._meta = getattr(obj, '_meta', None)
+        self._mask = getattr(obj, '_mask', None)
+        self._header = getattr(obj, '_header', None)
+
+    #def __array_wrap__(self, obj, context=None):
+    #    new = self.__class__(value=obj.value,
+    #                         unit=obj.unit,
+    #                         copy=False,
+    #                         wcs=self._wcs,
+    #                         meta=self._meta,
+    #                         mask=self._mask,
+    #                         header=self._header)
+    #    return new
 
     @property
     def __array_priority__(self):

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -119,19 +119,6 @@ class LowerDimensionalObject(u.Quantity):
         return new
 
     def __array_wrap__(self, obj, context=None):
-        print("Context = {0}".format(context))
-        print("Array wrap for {0}->{1} called".format(self, obj))
-        print("Array wrap for {0}->{1} called".format(type(self), type(obj)))
-        print("self has wcs: {0} meta: {1} mask: {2} header: {3}"
-              .format(hasattr(self,'_wcs'),
-                      hasattr(self,'_meta'),
-                      hasattr(self,'_mask'),
-                      hasattr(self,'_header')))
-        print("obj has wcs: {0} meta: {1} mask: {2} header: {3}"
-              .format(hasattr(obj,'_wcs'),
-                      hasattr(obj,'_meta'),
-                      hasattr(obj,'_mask'),
-                      hasattr(obj,'_header')))
         new = self.__class__(value=obj.value,
                              unit=obj.unit,
                              copy=False,
@@ -140,6 +127,10 @@ class LowerDimensionalObject(u.Quantity):
                              mask=self._mask,
                              header=self._header)
         return new
+
+    @property
+    def __array_priority__(self):
+        return super(LowerDimensionalObject, self).__array_priority__*2
 
 
 class Projection(LowerDimensionalObject):

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -125,16 +125,6 @@ class LowerDimensionalObject(u.Quantity):
         self._mask = getattr(obj, '_mask', None)
         self._header = getattr(obj, '_header', None)
 
-    #def __array_wrap__(self, obj, context=None):
-    #    new = self.__class__(value=obj.value,
-    #                         unit=obj.unit,
-    #                         copy=False,
-    #                         wcs=self._wcs,
-    #                         meta=self._meta,
-    #                         mask=self._mask,
-    #                         header=self._header)
-    #    return new
-
     @property
     def __array_priority__(self):
         return super(LowerDimensionalObject, self).__array_priority__*2

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -119,8 +119,21 @@ class LowerDimensionalObject(u.Quantity):
         return new
 
     def __array_wrap__(self, obj, context=None):
-        new = self.__class__(value=self.value,
-                             unit=self.unit,
+        print("Context = {0}".format(context))
+        print("Array wrap for {0}->{1} called".format(self, obj))
+        print("Array wrap for {0}->{1} called".format(type(self), type(obj)))
+        print("self has wcs: {0} meta: {1} mask: {2} header: {3}"
+              .format(hasattr(self,'_wcs'),
+                      hasattr(self,'_meta'),
+                      hasattr(self,'_mask'),
+                      hasattr(self,'_header')))
+        print("obj has wcs: {0} meta: {1} mask: {2} header: {3}"
+              .format(hasattr(obj,'_wcs'),
+                      hasattr(obj,'_meta'),
+                      hasattr(obj,'_mask'),
+                      hasattr(obj,'_header')))
+        new = self.__class__(value=obj.value,
+                             unit=obj.unit,
                              copy=False,
                              wcs=self._wcs,
                              meta=self._meta,

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -118,6 +118,15 @@ class LowerDimensionalObject(u.Quantity):
 
         return new
 
+    def __array_wrap__(self, obj, context=None):
+        new = self.__class__(value=self.value,
+                             unit=self.unit,
+                             copy=False,
+                             wcs=self._wcs,
+                             meta=self._meta,
+                             mask=self._mask,
+                             header=self._header)
+        return new
 
 
 class Projection(LowerDimensionalObject):

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -1,35 +1,57 @@
 from __future__ import print_function, absolute_import, division
 
+import pytest
 import numpy as np
 from astropy import units as u
 
 from .helpers import assert_allclose
-from ..lower_dimensional_structures import Projection
+from ..lower_dimensional_structures import Projection, Slice, OneDSpectrum
 
-def test_slices_of_projections_not_projections():
+# set up for parametrization
+LDOs = (Projection, Slice, OneDSpectrum)
+LDOs_2d = (Projection, Slice,)
+
+two_qty_2d = np.ones((2,2)) * u.Jy
+twelve_qty_2d = np.ones((12,12)) * u.Jy
+two_qty_1d = np.ones((2,)) * u.Jy
+twelve_qty_1d = np.ones((12,)) * u.Jy
+
+data_two = (two_qty_2d, two_qty_2d, two_qty_1d)
+data_twelve = (twelve_qty_2d, twelve_qty_2d, twelve_qty_1d)
+data_two_2d = (two_qty_2d, two_qty_2d,)
+data_twelve_2d = (twelve_qty_2d, twelve_qty_2d,)
+
+@pytest.mark.parametrize(('LDO', 'data'),
+                         zip(LDOs_2d, data_two_2d))
+def test_slices_of_projections_not_projections(LDO, data):
     # slices of projections that have <2 dimensions should not be projections
-    image = np.ones((2, 2)) * u.Jy
-    p = Projection(image, copy=False)
+    p = LDO(data, copy=False)
 
-    assert not isinstance(p[0,0], Projection)
-    assert not isinstance(p[0], Projection)
+    assert not isinstance(p[0,0], LDO)
+    assert not isinstance(p[0], LDO)
 
+@pytest.mark.parametrize(('LDO', 'data'),
+                         zip(LDOs_2d, data_twelve_2d))
+def test_copy_false(LDO, data):
+    # copy the data so we can manipulate inplace without affecting other tests
+    image = data.copy()
 
-def test_copy_false():
-    image = np.ones((12, 12)) * u.Jy
-    p = Projection(image, copy=False)
+    p = LDO(image, copy=False)
     image[3,4] = 2 * u.Jy
     assert_allclose(p[3,4], 2 * u.Jy)
 
-def test_write(tmpdir):
-    image = np.ones((12, 12)) * u.Jy
-    p = Projection(image)
+@pytest.mark.parametrize(('LDO', 'data'),
+                         zip(LDOs, data_twelve))
+def test_write(LDO, data, tmpdir):
+    p = LDO(data)
     p.write(tmpdir.join('test.fits').strpath)
 
-def test_preserve_wcs_to():
+@pytest.mark.parametrize(('LDO', 'data'),
+                         zip(LDOs_2d, data_twelve_2d))
+def test_preserve_wcs_to(LDO, data):
     # regression for #256
-    image = np.ones((12, 12)) * u.Jy
-    p = Projection(image, copy=False)
+    image = data.copy()
+    p = LDO(image, copy=False)
     image[3,4] = 2 * u.Jy
 
     p2 = p.to(u.mJy)
@@ -38,11 +60,12 @@ def test_preserve_wcs_to():
 
     assert p2.wcs == p.wcs
 
-def test_multiplication():
+@pytest.mark.parametrize(('LDO', 'data'),
+                         zip(LDOs, data_twelve))
+def test_multiplication(LDO, data):
     # regression: 265
 
-    image = np.ones((12, 12)) * u.Jy
-    p = Projection(image, copy=False)
+    p = LDO(data, copy=False)
 
     p2 = p * 5
 
@@ -51,11 +74,13 @@ def test_multiplication():
     assert p2.wcs == p.wcs
     assert np.all(p2.value == 5)
 
-def test_unit_division():
+@pytest.mark.parametrize(('LDO', 'data'),
+                         zip(LDOs, data_twelve))
+def test_unit_division(LDO, data):
     # regression: 265
 
-    image = np.ones((12, 12)) * u.Jy
-    p = Projection(image, copy=False)
+    image = data
+    p = LDO(image, copy=False)
 
     p2 = p / u.beam
 
@@ -63,14 +88,35 @@ def test_unit_division():
     assert hasattr(p2, '_wcs')
     assert p2.wcs == p.wcs
 
-def test_isnan():
+@pytest.mark.parametrize(('LDO', 'data'),
+                         zip(LDOs_2d, data_twelve_2d))
+def test_isnan(LDO, data):
     # Check that np.isnan strips units
 
-    image = np.ones((12, 12)) * u.Jy
+    image = data.copy()
     image[5,6] = np.nan
-    p = Projection(image, copy=False)
+    p = LDO(image, copy=False)
 
     mask = np.isnan(p)
 
     assert mask.sum() == 1
     assert not hasattr(mask, 'unit')
+
+@pytest.mark.parametrize(('LDO', 'data'),
+                         zip(LDOs, data_twelve))
+def test_self_arith(LDO, data):
+
+    image = data
+    p = LDO(image, copy=False)
+
+    p2 = p + p
+
+    assert hasattr(p2, '_wcs')
+    assert p2.wcs == p.wcs
+    assert np.all(p2.value==2)
+
+    p2 = p - p
+
+    assert hasattr(p2, '_wcs')
+    assert p2.wcs == p.wcs
+    assert np.all(p2.value==0)

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -46,8 +46,10 @@ def test_multiplication():
 
     p2 = p * 5
 
+    assert p2.unit == u.Jy
     assert hasattr(p2, '_wcs')
     assert p2.wcs == p.wcs
+    assert np.all(p2.value == 5)
 
 def test_unit_division():
     # regression: 265
@@ -57,5 +59,6 @@ def test_unit_division():
 
     p2 = p / u.beam
 
+    assert p2.unit == u.Jy/u.beam
     assert hasattr(p2, '_wcs')
     assert p2.wcs == p.wcs

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -38,7 +38,7 @@ def test_preserve_wcs_to():
 
     assert p2.wcs == p.wcs
 
-def test_division():
+def test_multiplication():
     # regression: 265
 
     image = np.ones((12, 12)) * u.Jy
@@ -46,4 +46,16 @@ def test_division():
 
     p2 = p * 5
 
+    assert hasattr(p2, '_wcs')
+    assert p2.wcs == p.wcs
+
+def test_unit_division():
+    # regression: 265
+
+    image = np.ones((12, 12)) * u.Jy
+    p = Projection(image, copy=False)
+
+    p2 = p / u.beam
+
+    assert hasattr(p2, '_wcs')
     assert p2.wcs == p.wcs

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -62,3 +62,15 @@ def test_unit_division():
     assert p2.unit == u.Jy/u.beam
     assert hasattr(p2, '_wcs')
     assert p2.wcs == p.wcs
+
+def test_isnan():
+    # Check that np.isnan strips units
+
+    image = np.ones((12, 12)) * u.Jy
+    image[5,6] = np.nan
+    p = Projection(image, copy=False)
+
+    mask = np.isnan(p)
+
+    assert mask.sum() == 1
+    assert not hasattr(mask, 'unit')

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -37,3 +37,13 @@ def test_preserve_wcs_to():
     assert_allclose(p[3,4], 2000 * u.mJy)
 
     assert p2.wcs == p.wcs
+
+def test_division():
+    # regression: 265
+
+    image = np.ones((12, 12)) * u.Jy
+    p = Projection(image, copy=False)
+
+    p2 = p * 5
+
+    assert p2.wcs == p.wcs


### PR DESCRIPTION
Division, multiplication, etc. result in non-LDOs, e.g.:

```
x=Projection(...)
y=x/(u.km/u.s)
```
`y` will lack a `_wcs`.  See #206, #256 