### PR TITLE
More convenient beam area determination

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -254,13 +254,11 @@ class SpectralCube(object):
         try:
             self.beam = Beam.from_fits_header(header)
             self._meta['beam'] = self.beam
-            self.beam_area_pixels = self._beam_area_pixels
+            self.beam_area_pixels = (self.beam.sr /
+                                     (wcs.utils.proj_plane_pixel_area(self.wcs) *
+                                      u.deg**2)).to(u.dimensionless_unscaled).value
         except:
             warnings.warn("Could not parse beam information from header.")
-
-    @property
-    def _beam_area_pixels(self):
-        return (self.beam.sr/(wcs.utils.proj_plane_pixel_area(self.wcs)*u.deg**2)).to(u.dimensionless_unscaled).value
 
     @property
     def unit(self):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -254,9 +254,9 @@ class SpectralCube(object):
         try:
             self.beam = Beam.from_fits_header(header)
             self._meta['beam'] = self.beam
-            self.beam_area_pixels = (self.beam.sr /
-                                     (wcs.utils.proj_plane_pixel_area(self.wcs) *
-                                      u.deg**2)).to(u.dimensionless_unscaled).value
+            self.pixels_per_beam = (self.beam.sr /
+                                    (wcs.utils.proj_plane_pixel_area(self.wcs) *
+                                     u.deg**2)).to(u.dimensionless_unscaled).value
         except:
             warnings.warn("Could not parse beam information from header.")
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -254,8 +254,13 @@ class SpectralCube(object):
         try:
             self.beam = Beam.from_fits_header(header)
             self._meta['beam'] = self.beam
+            self.beam_area_pixels = self._beam_area_pixels
         except:
             warnings.warn("Could not parse beam information from header.")
+
+    @property
+    def _beam_area_pixels(self):
+        return (self.beam.sr/(wcs.utils.proj_plane_pixel_area(self.wcs)*u.deg**2)).to(u.dimensionless_unscaled).value
 
     @property
     def unit(self):


### PR DESCRIPTION
add a cube utility attribute to get the area of the beam in pixels when a beam
is defined