### PR TITLE
Fix for beam reading: do it after wcs reading

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -121,6 +121,21 @@ class SpectralCube(object):
         # Deal with metadata first because it can affect data reading
         self._meta = meta or {}
 
+        # data must not be a quantity when stored in self._data
+        if hasattr(data, 'unit'):
+            # strip the unit so that it can be treated as cube metadata
+            data = data.value
+
+        # TODO: mask should be oriented? Or should we assume correctly oriented here?
+        self._data, self._wcs = cube_utils._orient(data, wcs)
+        self._spectral_axis = None
+        self._mask = mask  # specifies which elements to Nan/blank/ignore
+                           # object or array-like object, given that WCS needs
+                           # to be consistent with data?
+        #assert mask._wcs == self._wcs
+        self._fill_value = fill_value
+
+        # Beam loading must happen *after* WCS is read
         if read_beam:
             self._try_load_beam(header)
 
@@ -160,19 +175,6 @@ class SpectralCube(object):
         else:
             self._unit = None
 
-        # data must not be a quantity when stored in self._data
-        if hasattr(data, 'unit'):
-            # strip the unit so that it can be treated as cube metadata
-            data = data.value
-
-        # TODO: mask should be oriented? Or should we assume correctly oriented here?
-        self._data, self._wcs = cube_utils._orient(data, wcs)
-        self._spectral_axis = None
-        self._mask = mask  # specifies which elements to Nan/blank/ignore
-                           # object or array-like object, given that WCS needs
-                           # to be consistent with data?
-        #assert mask._wcs == self._wcs
-        self._fill_value = fill_value
 
         self._header = Header() if header is None else header
         if not isinstance(self._header, Header):
@@ -257,8 +259,9 @@ class SpectralCube(object):
             self.pixels_per_beam = (self.beam.sr /
                                     (wcs.utils.proj_plane_pixel_area(self.wcs) *
                                      u.deg**2)).to(u.dimensionless_unscaled).value
-        except:
-            warnings.warn("Could not parse beam information from header.")
+        except Exception as ex:
+            warnings.warn("Could not parse beam information from header."
+                          "  Exception was: {0}".format(ex.__repr__()))
 
     @property
     def unit(self):


### PR DESCRIPTION
As noted in #268 after the PR was accepted, all cubes show the warning "Could
not parse beam information from header." when read.  This is because the
cube._wcs attribute has not yet been set when the beam is read.