### PR TITLE
Major bugfix: Handle WCSes with cd matrices

### DIFF
--- a/spectral_cube/spectral_axis.py
+++ b/spectral_cube/spectral_axis.py
@@ -232,7 +232,9 @@ def convert_spectral_axis(mywcs, outunit, out_ctype, rest_value=None):
 
     # Load the input values
     crval_in = (mywcs.wcs.crval[mywcs.wcs.spec] * inunit)
-    cdelt_in = (mywcs.wcs.cdelt[mywcs.wcs.spec] * inunit)
+    # the cdelt matrix may not be correctly populated: need to account for cd,
+    # cdelt, and pc
+    cdelt_in = mywcs.pixel_scale_matrix[mywcs.wcs.spec] * inunit
 
     if in_spec_ctype == 'AWAV':
         warnings.warn("Support for air wavelengths is experimental and only "

--- a/spectral_cube/tests/test_spectral_axis.py
+++ b/spectral_cube/tests/test_spectral_axis.py
@@ -544,26 +544,16 @@ class test_nir_sinfoni_base(object):
 
         self.wavelengths = np.array([[2.12160005e-06,   2.12184505e-06,   2.12209005e-06]])
 
-    def test_nir_sinfoni_example_radio(self):
-        velocities_rad = ((self.wavelengths*u.m-self.rest_wavelength)/(self.rest_wavelength) * constants.c).to(u.km/u.s)
-
-        newwcs_rad = convert_spectral_axis(self.mywcs, u.km/u.s, 'VRAD',
-                                           rest_value=self.rest_wavelength)
-        assert newwcs_rad.wcs.cunit[0] == u.km/u.s
-        newwcs_rad.wcs.set()
-        worldpix_rad = newwcs_rad.wcs_pix2world([788,789,790], 0)
-        assert newwcs_rad.wcs.cunit[0] == u.m/u.s
-
-        np.testing.assert_almost_equal(worldpix_rad,
-                                       velocities_rad.to(newwcs_rad.wcs.cunit[0]).value)
-
-    def test_nir_sinfoni_example_optical(self):
         np.testing.assert_almost_equal(self.mywcs.wcs_pix2world([788,789,790], 0),
                                        self.wavelengths)
 
+    def test_nir_sinfoni_example_optical(self):
+
+        mywcs = self.mywcs.copy()
+
         velocities_opt = ((self.wavelengths*u.m-self.rest_wavelength)/(self.wavelengths*u.m) * constants.c).to(u.km/u.s)
 
-        newwcs_opt = convert_spectral_axis(self.mywcs, u.km/u.s, 'VOPT',
+        newwcs_opt = convert_spectral_axis(mywcs, u.km/u.s, 'VOPT',
                                            rest_value=self.rest_wavelength)
         assert newwcs_opt.wcs.cunit[0] == u.km/u.s
         newwcs_opt.wcs.set()
@@ -572,3 +562,19 @@ class test_nir_sinfoni_base(object):
 
         np.testing.assert_almost_equal(worldpix_opt,
                                        velocities_opt.to(newwcs_opt.wcs.cunit[0]).value)
+
+    def test_nir_sinfoni_example_radio(self):
+
+        mywcs = self.mywcs.copy()
+
+        velocities_rad = ((self.wavelengths*u.m-self.rest_wavelength)/(self.rest_wavelength) * constants.c).to(u.km/u.s)
+
+        newwcs_rad = convert_spectral_axis(mywcs, u.km/u.s, 'VRAD',
+                                           rest_value=self.rest_wavelength)
+        assert newwcs_rad.wcs.cunit[0] == u.km/u.s
+        newwcs_rad.wcs.set()
+        worldpix_rad = newwcs_rad.wcs_pix2world([788,789,790], 0)
+        assert newwcs_rad.wcs.cunit[0] == u.m/u.s
+
+        np.testing.assert_almost_equal(worldpix_rad,
+                                       velocities_rad.to(newwcs_rad.wcs.cunit[0]).value)

--- a/spectral_cube/tests/test_spectral_axis.py
+++ b/spectral_cube/tests/test_spectral_axis.py
@@ -550,14 +550,22 @@ def test_nir_sinfoni_example():
 
     newwcs_opt = convert_spectral_axis(mywcs, u.km/u.s, 'VOPT',
                                        rest_value=rest_wavelength)
+    assert newwcs_opt.wcs.cunit[0] == u.km/u.s
+    newwcs_opt.wcs.set()
+    worldpix_opt = newwcs_opt.wcs_pix2world([788,789,790], 0)
+    assert newwcs_opt.wcs.cunit[0] == u.m/u.s
 
-    np.testing.assert_almost_equal(newwcs_opt.wcs_pix2world([788,789,790], 0),
-                                   velocities_opt.value)
+    np.testing.assert_almost_equal(worldpix_opt,
+                                   velocities_opt.to(newwcs_opt.wcs.cunit[0]).value)
 
     velocities_rad = ((rest_wavelength-wavelengths*u.m)/(wavelengths*u.m) * constants.c).to(u.km/u.s)
 
     newwcs_rad = convert_spectral_axis(mywcs, u.km/u.s, 'VRAD',
                                        rest_value=rest_wavelength)
+    assert newwcs_rad.wcs.cunit[0] == u.km/u.s
+    newwcs_rad.wcs.set()
+    worldpix_rad = newwcs_rad.wcs_pix2world([788,789,790], 0)
+    assert newwcs_rad.wcs.cunit[0] == u.m/u.s
 
-    np.testing.assert_almost_equal(newwcs_rad.wcs_pix2world([788,789,790], 0),
-                                   velocities_rad.value)
+    np.testing.assert_almost_equal(worldpix_rad,
+                                   velocities_rad.to(newwcs_rad.wcs.cunit[0]).value)


### PR DESCRIPTION
Before this, WCSes with CD matrices would convert between spectral axis units
incorrectly, always adopting cdelt=1.0.