### PR TITLE
Allow WCS equality checks to be configured

### DIFF
--- a/docs/masking.rst
+++ b/docs/masking.rst
@@ -138,6 +138,7 @@ can also be defined directly by specifying conditions on
 
 .. TODO: add example for FunctionalMask
 
+
 Outputting masks
 ----------------
 
@@ -153,3 +154,49 @@ Optionally, a redundant Stokes axis can be added to match the original CASA imag
 
 .. note::
     Outputting to CASA masks requires that `spectral_cube` be run from a CASA python session.
+
+Masking cubes with other cubes
+------------------------------
+
+A common use case is to mask a cube based on another cube in the same
+coordinates.  For example, you want to create a mask of 13CO based on the
+brightness of 12CO.  This can be done straightforwardly if they are on an
+identical grid::
+
+    >>> mask_12co = cube12co > 0.5*u.Jy  # doctest: +SKIP
+    >>> masked_cube13co = cube13co.with_mask(mask_12co)  # doctest: +SKIP
+
+If you see errors such as ``WCS does not match mask WCS``, but you're confident
+that your two cube are on the same grid, you should have a look at the
+``cube.wcs`` attribute and see if there are subtle differences in the world
+coordinate parameters.  These frequently occur when converting from frequency
+to velocity as there is inadequate precision in the rest frequency. 
+
+For example, these two axes are *nearly* identical, but not perfectly so::
+
+    Number of WCS axes: 3
+    CTYPE : 'RA---SIN'  'DEC--SIN'  'VRAD'  
+    CRVAL : 269.08866286689999  -21.956244813729999  -3000.000559989533  
+    CRPIX : 161.0  161.0  1.0  
+    PC1_1 PC1_2 PC1_3  : 1.0  0.0  0.0  
+    PC2_1 PC2_2 PC2_3  : 0.0  1.0  0.0  
+    PC3_1 PC3_2 PC3_3  : 0.0  0.0  1.0  
+    CDELT : -1.3888888888889999e-05  1.3888888888889999e-05  299.99999994273281  
+    NAXIS    : 0 0
+
+    Number of WCS axes: 3
+    CTYPE : 'RA---SIN'  'DEC--SIN'  'VRAD'  
+    CRVAL : 269.08866286689999  -21.956244813729999  -3000.0000242346514  
+    CRPIX : 161.0  161.0  1.0  
+    PC1_1 PC1_2 PC1_3  : 1.0  0.0  0.0  
+    PC2_1 PC2_2 PC2_3  : 0.0  1.0  0.0  
+    PC3_1 PC3_2 PC3_3  : 0.0  0.0  1.0  
+    CDELT : -1.3888888888889999e-05  1.3888888888889999e-05  300.00000001056611  
+    NAXIS    : 0 0
+
+In order to compose masks from these, we need to set the ``wcs_tolerance`` parameter::
+
+    >>> masked_cube13co = cube13co.with_mask(mask_12co, wcs_tolerance=1e-3)  # doctest: +SKIP
+
+which in this case will check fro equality at the 1e-3 level, which truncates
+the 3rd CRVAL to the point of equality before comparing the values.

--- a/docs/masking.rst
+++ b/docs/masking.rst
@@ -198,5 +198,5 @@ In order to compose masks from these, we need to set the ``wcs_tolerance`` param
 
     >>> masked_cube13co = cube13co.with_mask(mask_12co, wcs_tolerance=1e-3)  # doctest: +SKIP
 
-which in this case will check fro equality at the 1e-3 level, which truncates
+which in this case will check equality at the 1e-3 level, which truncates
 the 3rd CRVAL to the point of equality before comparing the values.

--- a/spectral_cube/_moments.py
+++ b/spectral_cube/_moments.py
@@ -131,8 +131,8 @@ def moment_raywise(cube, order, axis):
 
     for x, y, slc in cube._iter_rays(axis):
         # the intensity, i.e. the weights
-        include = cube._mask.include(data=cube._data, wcs=cube._wcs,
-                                     view=slc)
+        include = cube._mask.include(data=cube._data, wcs=cube._wcs, view=slc,
+                                     wcs_tolerance=cube._wcs_tolerance)
         if not include.any():
             continue
 

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -103,7 +103,7 @@ class MaskBase(object):
         self._validate_wcs(data, wcs, **kwargs)
         return self._include(data=data, wcs=wcs, view=view)
 
-    def _validate_wcs(self, data, wcs):
+    def _validate_wcs(self, new_data, new_wcs, **kwargs):
         """
         This method can be overridden in cases where the data and WCS have to
         conform to some rules. This gets called automatically when
@@ -153,7 +153,7 @@ class MaskBase(object):
         """
         return data[view][self.include(data=data, wcs=wcs, view=view)]
 
-    def _filled(self, data, wcs=None, fill=np.nan, view=()):
+    def _filled(self, data, wcs=None, fill=np.nan, view=(), **kwargs):
         """
         Replace the exluded elements of *array* with *fill*.
 
@@ -180,7 +180,7 @@ class MaskBase(object):
         # type otherwise
         dt = np.find_common_type([data.dtype], [np.float])
         sliced_data = data[view].astype(dt)
-        ex = self.exclude(data=data, wcs=wcs, view=view)
+        ex = self.exclude(data=data, wcs=wcs, view=view, **kwargs)
         sliced_data[ex] = fill
         return sliced_data
 
@@ -280,9 +280,9 @@ class CompositeMask(MaskBase):
         self._mask2 = mask2
         self._operation = operation
 
-    def _validate_wcs(self, new_data, new_wcs):
-        self._mask1._validate_wcs(new_data, new_wcs)
-        self._mask2._validate_wcs(new_data, new_wcs)
+    def _validate_wcs(self, new_data, new_wcs, **kwargs):
+        self._mask1._validate_wcs(new_data, new_wcs, **kwargs)
+        self._mask2._validate_wcs(new_data, new_wcs, **kwargs)
 
     def _include(self, data=None, wcs=None, view=()):
         result_mask_1 = self._mask1._include(data=data, wcs=wcs, view=view)
@@ -592,7 +592,7 @@ class FunctionMask(MaskBase):
     def __init__(self, function):
         self._function = function
 
-    def _validate_wcs(self, data, wcs):
+    def _validate_wcs(self, new_data, new_wcs, **kwargs):
         pass
 
     def _include(self, data=None, wcs=None, view=()):

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -358,7 +358,7 @@ class BooleanArrayMask(MaskBase):
         Parameters
         ----------
         kwargs : dict
-            Passed to np.testing.assert_almost_equal
+            Passed to `wcs_utils.check_equality`
         """
         if new_data is not None and not is_broadcastable_and_smaller(self._mask.shape,
                                                                      new_data.shape):
@@ -447,7 +447,7 @@ class LazyMask(MaskBase):
         Parameters
         ----------
         kwargs : dict
-            Passed to np.testing.assert_almost_equal
+            Passed to `wcs_utils.check_equality`
         """
         if new_data is not None:
             if not is_broadcastable_and_smaller(new_data.shape, self._data.shape):

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -90,15 +90,17 @@ class MaskBase(object):
 
     __metaclass__ = abc.ABCMeta
 
-    def include(self, data=None, wcs=None, view=()):
+    def include(self, data=None, wcs=None, view=(), **kwargs):
         """
         Return a boolean array indicating which values should be included.
 
         If ``view`` is passed, only the sliced mask will be returned, which
         avoids having to load the whole mask in memory. Otherwise, the whole
         mask is returned in-memory.
+
+        kwargs are passed to _validate_wcs
         """
-        self._validate_wcs(data, wcs)
+        self._validate_wcs(data, wcs, **kwargs)
         return self._include(data=data, wcs=wcs, view=view)
 
     def _validate_wcs(self, data, wcs):
@@ -113,15 +115,17 @@ class MaskBase(object):
     def _include(self, data=None, wcs=None, view=()):
         pass
 
-    def exclude(self, data=None, wcs=None, view=()):
+    def exclude(self, data=None, wcs=None, view=(), **kwargs):
         """
         Return a boolean array indicating which values should be excluded.
 
         If ``view`` is passed, only the sliced mask will be returned, which
         avoids having to load the whole mask in memory. Otherwise, the whole
         mask is returned in-memory.
+
+        kwargs are passed to _validate_wcs
         """
-        self._validate_wcs(data, wcs)
+        self._validate_wcs(data, wcs, **kwargs)
         return self._exclude(data=data, wcs=wcs, view=view)
 
     def _exclude(self, data=None, wcs=None, view=()):
@@ -347,14 +351,23 @@ class BooleanArrayMask(MaskBase):
         else:
             self._mask = mask
 
-    def _validate_wcs(self, new_data=None, new_wcs=None):
+    def _validate_wcs(self, new_data=None, new_wcs=None, **kwargs):
+        """
+        Check that the new WCS matches the current one
+
+        Parameters
+        ----------
+        kwargs : dict
+            Passed to np.testing.assert_almost_equal
+        """
         if new_data is not None and not is_broadcastable_and_smaller(self._mask.shape,
                                                                      new_data.shape):
             raise ValueError("data shape cannot be broadcast to match mask shape")
         if new_wcs is not None:
             if new_wcs not in self._wcs_whitelist:
                 if not wcs_utils.check_equality(new_wcs, self._wcs,
-                                                warn_missing=True):
+                                                warn_missing=True,
+                                                **kwargs):
                     raise ValueError("WCS does not match mask WCS")
                 else:
                     self._wcs_whitelist.add(new_wcs)
@@ -427,14 +440,22 @@ class LazyMask(MaskBase):
 
         self._wcs_whitelist = set()
 
-    def _validate_wcs(self, new_data=None, new_wcs=None):
+    def _validate_wcs(self, new_data=None, new_wcs=None, **kwargs):
+        """
+        Check that the new WCS matches the current one
+
+        Parameters
+        ----------
+        kwargs : dict
+            Passed to np.testing.assert_almost_equal
+        """
         if new_data is not None:
             if not is_broadcastable_and_smaller(new_data.shape, self._data.shape):
                 raise ValueError("data shape cannot be broadcast to match mask shape")
         if new_wcs is not None:
             if new_wcs not in self._wcs_whitelist:
                 if not wcs_utils.check_equality(new_wcs, self._wcs,
-                                                warn_missing=True):
+                                                warn_missing=True, **kwargs):
                     raise ValueError("WCS does not match mask WCS")
                 else:
                     self._wcs_whitelist.add(new_wcs)

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -131,6 +131,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
 
         # TODO: mask should be oriented? Or should we assume correctly oriented here?
         self._data, self._wcs = cube_utils._orient(data, wcs)
+        self._wcs_tolerance = wcs_tolerance
         self._spectral_axis = None
         self._mask = mask  # specifies which elements to Nan/blank/ignore
                            # object or array-like object, given that WCS needs
@@ -205,7 +206,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
 
     def _new_cube_with(self, data=None, wcs=None, mask=None, meta=None,
                        fill_value=None, spectral_unit=None, unit=None,
-                       wcs_tolerance=0.0):
+                       wcs_tolerance=None):
 
         data = self._data if data is None else data
         if unit is None and hasattr(data, 'unit'):
@@ -243,7 +244,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         cube = SpectralCube(data=data, wcs=wcs, mask=mask, meta=meta,
                             fill_value=fill_value, header=self._header,
                             allow_huge_operations=self.allow_huge_operations,
-                            wcs_tolerance=wcs_tolerance)
+                            wcs_tolerance=wcs_tolerance or self._wcs_tolerance)
         cube._spectral_unit = spectral_unit
         cube._spectral_scale = spectral_axis.wcs_unit_scale(spectral_unit)
 

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -271,7 +271,8 @@ def test_wcs_validity_check_failure():
     assert exc.value.args[0] == "WCS does not match mask WCS"
 
     # this one should work though
-    cube = cube.with_mask(mask, decimal=4)
+    cube = cube.with_mask(mask, wcs_tolerance=1e-4)
+    assert cube._wcs_tolerance == 1e-4
 
     # then the rest of this should be OK
     s2 = cube.spectral_slab(-2 * u.km / u.s, 2 * u.km / u.s)

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -256,6 +256,28 @@ def test_wcs_validity_check():
     # just checking that this works, not that it does anything in particular
     moment_map = s3.moment(order=1)
 
+def test_wcs_validity_check_failure():
+    cube, data = cube_and_raw('adv.fits')
+    wcs2 = cube.wcs.copy()
+    wcs2.wcs.crval[2] *= 1.00001
+
+    # can make a mask
+    mask = BooleanArrayMask(data>0, cube._wcs)
+
+    # but if it's not exactly equal, an error should be raised at this step
+    with pytest.raises(ValueError) as exc:
+        cube = cube.with_mask(mask)
+    assert exc.value.args[0] == "WCS does not match mask WCS"
+
+    # this one should work though
+    cube = cube.with_mask(mask, decimal=4)
+
+    # then the rest of this should be OK
+    s2 = cube.spectral_slab(-2 * u.km / u.s, 2 * u.km / u.s)
+    s3 = s2.with_spectral_unit(u.km / u.s, velocity_convention=u.doppler_radio)
+    # just checking that this works, not that it does anything in particular
+    moment_map = s3.moment(order=1)
+
 def test_mask_spectral_unit_functions():
     cube, data = cube_and_raw('adv.fits')
 

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -259,7 +259,8 @@ def test_wcs_validity_check():
 def test_wcs_validity_check_failure():
     cube, data = cube_and_raw('adv.fits')
     wcs2 = cube.wcs.copy()
-    wcs2.wcs.crval[2] *= 1.00001
+    # add some difference in the 4th decimal place
+    wcs2.wcs.crval[2] += 0.00001
 
     # can make a mask
     mask = BooleanArrayMask(data>0, cube._wcs)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -188,7 +188,11 @@ class TestSpectralCube(object):
         cube_freq = cube.with_spectral_unit(unit)
 
         if masktype == BooleanArrayMask:
-            mask = BooleanArrayMask(data>0, wcs=cube._wcs)
+            # don't use data here:
+            # data haven't necessarily been rearranged to the correct shape by
+            # cube_utils.orient
+            mask = BooleanArrayMask(cube.filled_data[:].value>0,
+                                    wcs=cube._wcs)
         elif masktype == LazyMask:
             mask = LazyMask(lambda x: x>0, cube=cube)
         elif masktype == FunctionMask:

--- a/spectral_cube/tests/test_wcs_utils.py
+++ b/spectral_cube/tests/test_wcs_utils.py
@@ -93,6 +93,6 @@ def test_wcs_comparison():
 
     assert check_equality(wcs1,wcs2)
     assert not check_equality(wcs1,wcs3)
-    assert check_equality(wcs1, wcs3, decimal=-1)
+    assert check_equality(wcs1, wcs3, wcs_tolerance=1.0e1)
     assert not check_equality(wcs1,wcs4)
-    assert check_equality(wcs1, wcs4, decimal=3)
+    assert check_equality(wcs1, wcs4, wcs_tolerance=1e-3)

--- a/spectral_cube/tests/test_wcs_utils.py
+++ b/spectral_cube/tests/test_wcs_utils.py
@@ -88,7 +88,7 @@ def test_wcs_comparison():
     wcs3 = WCS(naxis=3)
     wcs3.wcs.crpix = np.array([50., 45., 31.], dtype='float64')
 
-    wcs4 = WCS(naxis=4)
+    wcs4 = WCS(naxis=3)
     wcs4.wcs.crpix = np.array([50., 45., 30.0001], dtype='float64')
 
     assert check_equality(wcs1,wcs2)

--- a/spectral_cube/tests/test_wcs_utils.py
+++ b/spectral_cube/tests/test_wcs_utils.py
@@ -88,5 +88,11 @@ def test_wcs_comparison():
     wcs3 = WCS(naxis=3)
     wcs3.wcs.crpix = np.array([50., 45., 31.], dtype='float64')
 
+    wcs4 = WCS(naxis=4)
+    wcs4.wcs.crpix = np.array([50., 45., 30.0001], dtype='float64')
+
     assert check_equality(wcs1,wcs2)
     assert not check_equality(wcs1,wcs3)
+    assert check_equality(wcs1, wcs3, decimal=-1)
+    assert not check_equality(wcs1,wcs4)
+    assert check_equality(wcs1, wcs4, decimal=3)

--- a/spectral_cube/wcs_utils.py
+++ b/spectral_cube/wcs_utils.py
@@ -261,7 +261,7 @@ def check_equality(wcs1, wcs2, warn_missing=False,
     #                        tolerance=tolerance)
     #Until we've switched to the wcs.compare approach, we need to have
     #np.testing.assert_almost_equal work
-    if decimal == 0:
+    if wcs_threshold == 0:
         exact = True
     else:
         exact = False

--- a/spectral_cube/wcs_utils.py
+++ b/spectral_cube/wcs_utils.py
@@ -236,8 +236,9 @@ def slice_wcs(mywcs, view, numpy_order=True):
                 wcs_new.wcs.crpix[wcs_index] -= iview.start
     return wcs_new
 
-def check_equality(wcs1, wcs2, warn_missing=False, ignore_keywords=['MJD-OBS',
-                                                                    'VELOSYS']):
+def check_equality(wcs1, wcs2, warn_missing=False,
+                   ignore_keywords=['MJD-OBS', 'VELOSYS'],
+                   **kwargs):
     """
     Check if two WCSs are equal
 
@@ -250,6 +251,9 @@ def check_equality(wcs1, wcs2, warn_missing=False, ignore_keywords=['MJD-OBS',
     ignore_keywords: list of str
         Keywords that are stored as part of the WCS but do not define part of
         the coordinate system and therefore can be safely ignored.
+    kwargs : dict
+        Passed to np.testing.assert_almost_equal.  Can be used for partial or
+        near equality checks.
     """
 
     # naive version:
@@ -281,7 +285,7 @@ def check_equality(wcs1, wcs2, warn_missing=False, ignore_keywords=['MJD-OBS',
                         log.debug("Header 1, {0}: {1} != {2}".format(key,u1,u2))
             elif isinstance(c1[1], (float, np.float)):
                 try:
-                    np.testing.assert_almost_equal(c1[1], c2[1])
+                    np.testing.assert_almost_equal(c1[1], c2[1], **kwargs)
                 except AssertionError:
                     if key in ('RESTFRQ','RESTWAV'):
                         warnings.warn("{0} is not equal in WCS; ignoring ".format(key)+

--- a/spectral_cube/wcs_utils.py
+++ b/spectral_cube/wcs_utils.py
@@ -261,7 +261,7 @@ def check_equality(wcs1, wcs2, warn_missing=False,
     #                        tolerance=tolerance)
     #Until we've switched to the wcs.compare approach, we need to have
     #np.testing.assert_almost_equal work
-    if wcs_threshold == 0:
+    if wcs_tolerance == 0:
         exact = True
     else:
         exact = False

--- a/spectral_cube/wcs_utils.py
+++ b/spectral_cube/wcs_utils.py
@@ -265,7 +265,9 @@ def check_equality(wcs1, wcs2, warn_missing=False,
         exact = True
     else:
         exact = False
-        decimal = -np.log10(wcs_tolerance)
+        # np.testing.assert_almost_equal wants an integer
+        # e.g., for 0.0001, the integer is 4
+        decimal = int(np.ceil(-np.log10(wcs_tolerance)))
 
 
     # naive version:

--- a/spectral_cube/wcs_utils.py
+++ b/spectral_cube/wcs_utils.py
@@ -255,6 +255,9 @@ def check_equality(wcs1, wcs2, warn_missing=False,
         Passed to np.testing.assert_almost_equal.  Can be used for partial or
         near equality checks.
     """
+    # TODO: use this to replace the rest of the check_equality code
+    #return wcs1.wcs.compare(wcs2.wcs, cmp=wcs.WCSCOMPARE_ANCILLARY,
+    #                        tolerance=tolerance)
 
     # naive version:
     # return str(wcs1.to_header()) != str(wcs2.to_header())


### PR DESCRIPTION
This will allow small errors in WCS precision to be ignored so that cubes on
the same grid to within some tolerance can be compared.

WIP

cc @astrofrog