### PR TITLE
Bugfix: spectral unit initialization in with_spectral_unit

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -239,7 +239,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
             meta['BUNIT'] = unit.to_string(format='FITS')
 
         fill_value = self._fill_value if fill_value is None else fill_value
-        spectral_unit = self._spectral_unit if spectral_unit is None else spectral_unit
+        spectral_unit = self._spectral_unit if spectral_unit is None else u.Unit(spectral_unit)
 
         cube = SpectralCube(data=data, wcs=wcs, mask=mask, meta=meta,
                             fill_value=fill_value, header=self._header,


### PR DESCRIPTION
fix a bug: if you create a new spectral cube with stringy units ('km/s'), it
will fail on writing because other functions assume _spectral_unit is a u.Unit