### PR TITLE
Add a cube reprojection method

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2320,7 +2320,8 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         newcube, newcube_valid = reproject_interp((self.filled_data[:],
                                                    self.header),
                                                   (newwcs, shape_out),
-                                                  order=order)
+                                                  order=order,
+                                                  independent_celestial_slices=True)
 
         return self._new_cube_with(data=newcube,
                                    wcs=newwcs,


### PR DESCRIPTION
cc @cdeil, @adonath, @astrofrog

This is a long-awaited feature, and all the pieces seem to finally be in place
to have it.  It won't work for cubes with different spectral axes until
https://github.com/astrofrog/reproject/pull/96 is merged.

TODO:

 * [ ] add ``reproject`` as a soft dependency
 * [ ] Increase efficiency of reprojection by pre-slicing the cube to contain
   the minimal subcube represented by the reprojection target header