### PR TITLE
Broadcast np.ndarray masks in with_mask

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1032,7 +1032,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
             if not is_broadcastable_and_smaller(mask.shape, self._data.shape):
                 raise ValueError("Mask shape is not broadcastable to data shape: "
                                  "%s vs %s" % (mask.shape, self._data.shape))
-            mask = BooleanArrayMask(mask, self._wcs)
+            mask = BooleanArrayMask(mask, self._wcs, shape=self._data.shape)
 
         if self._mask is not None:
             new_mask = self._mask & mask if inherit_mask else mask

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -728,6 +728,14 @@ def test_with_mask_with_boolean_array():
     assert cube2._mask._mask is mask
 
 
+def test_with_mask_with_good_array_shape():
+    cube = _dummy_cube()
+    mask = np.zeros((1, 5), dtype=np.bool)
+    cube2 = cube.with_mask(mask, inherit_mask=False)
+    assert isinstance(cube2._mask, BooleanArrayMask)
+    np.testing.assert_equal(cube2._mask._mask, mask.reshape((1, 1, 5)))
+
+
 def test_with_mask_with_bad_array_shape():
     cube = _dummy_cube()
     mask = np.zeros((5, 5), dtype=np.bool)


### PR DESCRIPTION
Set the shape of the `BooleanArrayMask` to the shape of the data so the `np.ndarray` mask is broadcasted. Without setting `shape`, the mask keeps its original shape, which may not be the shape of the data.

@keflavich is the `is_broadcastable_and_smaller` check still needed here? I think a check is already done within `BooleanArrayMask`.