### PR TITLE
Bugfix with ints and views

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1050,7 +1050,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
     def __getitem__(self, view):
 
         # Need to allow self[:], self[:,:]
-        if isinstance(view, (slice,int)):
+        if isinstance(view, (slice,int,np.int64)):
             view = (view, slice(None), slice(None))
         elif len(view) == 2:
             view = view + (slice(None),)


### PR DESCRIPTION
Don't know why, but I just hit an instance of an int64 being used as an index.  Raised exception.  Hrm.