### PR TITLE
Bugfix: ds9 region extraction

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1770,7 +1770,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         # This is a hack to use mpl to determine the outer bounds of the regions
         # (but it's a legit hack - pyregion needs a major internal refactor
         # before we can approach this any other way, I think -AG)
-        mpl_objs = pixel_regions.get_mpl_patches_texts()[0]
+        mpl_objs = pixel_regions.get_mpl_patches_texts(origin=0)[0]
 
         # Find the minimal enclosing box containing all of the regions
         # (this will speed up the mask creation below)

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1630,11 +1630,17 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
 
         return slab
 
-    def minimal_subcube(self):
+    def minimal_subcube(self, spatial_only=False):
         """
         Return the minimum enclosing subcube where the mask is valid
+
+        Parameters
+        ----------
+        spatial_only: bool
+            Only compute the minimal subcube in the spatial dimensions
         """
-        return self[self.subcube_slices_from_mask(self._mask)]
+        return self[self.subcube_slices_from_mask(self._mask,
+                                                  spatial_only=spatial_only)]
 
     def subcube_from_mask(self, region_mask):
         """
@@ -1649,7 +1655,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         return self[self.subcube_slices_from_mask(region_mask)]
 
 
-    def subcube_slices_from_mask(self, region_mask):
+    def subcube_slices_from_mask(self, region_mask, spatial_only=False):
         """
         Given a mask, return the slices corresponding to the minimum subcube
         that encloses the mask
@@ -1659,6 +1665,9 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         region_mask: `masks.MaskBase` or boolean `numpy.ndarray`
             The mask with appropraite WCS or an ndarray with matched
             coordinates
+        spatial_only: bool
+            Return only slices that affect the spatial dimensions; the spectral
+            dimension will be left unchanged
         """
         if not scipyOK:
             raise ImportError("Scipy could not be imported: this function won't work.")
@@ -1674,6 +1683,9 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
 
         slices = ndimage.find_objects(np.broadcast_arrays(include,
                                                           self._data)[0])[0]
+
+        if spatial_only:
+            slices = (slice(None), slices[1], slices[2])
 
         return slices
 
@@ -1738,7 +1750,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
 
         return self[slices]
 
-    def subcube_from_ds9region(self, ds9region):
+    def subcube_from_ds9region(self, ds9region, allow_empty=False):
         """
         Extract a masked subcube from a ds9 region or a pyregion Region object
         (only functions on celestial dimensions)
@@ -1747,6 +1759,9 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         ----------
         ds9region: str or `pyregion.Shape`
             The region to extract
+        allow_empty: bool
+            If this is False, an exception will be raised if the region
+            contains no overlap with the cube
         """
         import pyregion
 
@@ -1761,11 +1776,11 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
             # convert the regions to image (pixel) coordinates
             celhdr = self.wcs.sub([wcs.WCSSUB_CELESTIAL]).to_header()
             pixel_regions = shapelist.as_imagecoord(celhdr)
+            recompute_shifted_mask = False
         else:
-            # For this to work, we'd need to change the reference pixel after cropping.
-            # Alternatively, we can just make the full-sized mask... todo....
-            raise NotImplementedError("Can't use non-celestial coordinates with regions.")
             pixel_regions = shapelist
+            # we need to change the reference pixel after cropping
+            recompute_shifted_mask = True
 
         # This is a hack to use mpl to determine the outer bounds of the regions
         # (but it's a legit hack - pyregion needs a major internal refactor
@@ -1804,20 +1819,49 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         subcube = self.subcube(xlo=xlo, ylo=ylo, xhi=xhi, yhi=yhi)
 
         if any(dim == 0 for dim in subcube.shape):
-            raise ValueError("The derived subset is empty: the region does not"
-                             " overlap with the cube.")
+            if allow_empty:
+                warnings.warn("The derived subset is empty: the region does not"
+                             " overlap with the cube (but allow_empty=True).")
+            else:
+                raise ValueError("The derived subset is empty: the region does not"
+                                 " overlap with the cube.")
 
-        subhdr = subcube.wcs.sub([wcs.WCSSUB_CELESTIAL]).to_header()
+        if recompute_shifted_mask:
+            # for pixel-based regions (which we use in tests), we need to shift
+            # the coordinates for mask computation because we're cropping the
+            # cube....
+            for reg in shapelist:
+                reg.params[0].v -= xlo
+                reg.params[1].v -= ylo
+                reg.params[0].text = str(reg.params[0].v)
+                reg.params[1].text = str(reg.params[1].v)
+                reg.coord_list[0] -= xlo
+                reg.coord_list[1] -= ylo
 
+        #alternate implementation if recompute_shifted_mask:
+        #alternate implementation     # make the full mask, then crop it to appropriate size
+        #alternate implementation     mask = shapelist.get_mask(header=self.wcs.celestial.to_header(),
+        #alternate implementation                               shape=self.shape[1:])
+        #alternate implementation     mask = mask[xlo:xhi, ylo:yhi]
+
+        #alternate implementation else:
         # this is a very dangerous operation and I really want to replace it
         # with a more sane version from astropy.regions: the way pyregion defines
         # masks is not necessarily correct. -AG
-        mask = shapelist.get_mask(header=subhdr,
+        mask = shapelist.get_mask(header=subcube.wcs.celestial.to_header(),
                                   shape=subcube.shape[1:])
 
-        return subcube.with_mask(BooleanArrayMask(mask, subcube.wcs,
-                                                  shape=subcube.shape))
+        if not allow_empty and mask.sum() == 0:
+            raise ValueError("The derived subset is empty: the region does not"
+                             " overlap with the cube.  However, this is likely "
+                             "to be a bug, since at an earlier stage there was "
+                             "overlap.")
 
+        masked_subcube = subcube.with_mask(BooleanArrayMask(mask, subcube.wcs,
+                                                            shape=subcube.shape))
+        # by using ceil / floor above, we potentially introduced a NaN buffer
+        # that we can now crop out
+        return masked_subcube.minimal_subcube(spatial_only=True)
 
 
     def world_spines(self):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1779,10 +1779,10 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         xhi, yhi = extent.max
         all_extents = [obj.get_extents() for obj in mpl_objs]
         for ext in all_extents:
-            xlo = xlo if xlo < ext.min[0] else ext.min[0]
-            ylo = ylo if ylo < ext.min[1] else ext.min[1]
-            xhi = xhi if xhi > ext.max[0] else ext.max[0]
-            yhi = yhi if yhi > ext.max[1] else ext.max[1]
+            xlo = np.floor(xlo if xlo < ext.min[0] else ext.min[0])
+            ylo = np.floor(ylo if ylo < ext.min[1] else ext.min[1])
+            xhi = np.ceil(xhi if xhi > ext.max[0] else ext.max[0])
+            yhi = np.ceil(yhi if yhi > ext.max[1] else ext.max[1])
 
         # Negative indices will do bad things, like wrap around the cube
         # If xhi/yhi are negative, there is not overlap
@@ -1809,6 +1809,9 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
 
         subhdr = subcube.wcs.sub([wcs.WCSSUB_CELESTIAL]).to_header()
 
+        # this is a very dangerous operation and I really want to replace it
+        # with a more sane version from astropy.regions: the way pyregion defines
+        # masks is not necessarily correct. -AG
         mask = shapelist.get_mask(header=subhdr,
                                   shape=subcube.shape[1:])
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1821,7 +1821,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         if any(dim == 0 for dim in subcube.shape):
             if allow_empty:
                 warnings.warn("The derived subset is empty: the region does not"
-                             " overlap with the cube (but allow_empty=True).")
+                              " overlap with the cube (but allow_empty=True).")
             else:
                 raise ValueError("The derived subset is empty: the region does not"
                                  " overlap with the cube.")
@@ -1829,7 +1829,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         if recompute_shifted_mask:
             # for pixel-based regions (which we use in tests), we need to shift
             # the coordinates for mask computation because we're cropping the
-            # cube....
+            # cube
             for reg in shapelist:
                 reg.params[0].v -= xlo
                 reg.params[1].v -= ylo
@@ -1838,16 +1838,6 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
                 reg.coord_list[0] -= xlo
                 reg.coord_list[1] -= ylo
 
-        #alternate implementation if recompute_shifted_mask:
-        #alternate implementation     # make the full mask, then crop it to appropriate size
-        #alternate implementation     mask = shapelist.get_mask(header=self.wcs.celestial.to_header(),
-        #alternate implementation                               shape=self.shape[1:])
-        #alternate implementation     mask = mask[xlo:xhi, ylo:yhi]
-
-        #alternate implementation else:
-        # this is a very dangerous operation and I really want to replace it
-        # with a more sane version from astropy.regions: the way pyregion defines
-        # masks is not necessarily correct. -AG
         mask = shapelist.get_mask(header=subcube.wcs.celestial.to_header(),
                                   shape=subcube.shape[1:])
 

--- a/spectral_cube/tests/data/255-fk5.reg
+++ b/spectral_cube/tests/data/255-fk5.reg
@@ -1,0 +1,4 @@
+# Region file format: DS9 version 4.1
+global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1
+fk5
+circle(1:36:14.969,+29:56:07.68,2.6509")

--- a/spectral_cube/tests/data/255-pixel.reg
+++ b/spectral_cube/tests/data/255-pixel.reg
@@ -1,0 +1,4 @@
+# Region file format: DS9 version 4.1
+global color=green dashlist=8 3 width=1 font="helvetica 10 normal roman" select=1 highlite=1 dash=0 fixed=0 edit=1 move=1 delete=1 include=1 source=1
+image
+circle(2.5282832,3.4612342,1.3254484)

--- a/spectral_cube/tests/data/make_test_cubes.py
+++ b/spectral_cube/tests/data/make_test_cubes.py
@@ -94,3 +94,12 @@ if __name__ == "__main__":
     hdul = fits.HDUList([fits.PrimaryHDU(data=d, header=h),
                          beams])
     hdul.writeto('vda_beams.fits', clobber=True)
+
+    # make a version with spatial pixels
+    h = fits.header.Header.fromtextfile(HEADER_FILENAME)
+    for k in list(h.keys()):
+        if k.endswith('4'):
+            del h[k]
+    h['BUNIT'] = 'K' # Kelvins are a valid unit, JY/BEAM are not: they should be tested separately
+    d = np.arange(2*5*5).reshape((2,5,5))
+    fits.writeto('255.fits', d, h, clobber=True)

--- a/spectral_cube/tests/setup_package.py
+++ b/spectral_cube/tests/setup_package.py
@@ -2,5 +2,5 @@ from __future__ import print_function, absolute_import, division
 
 def get_package_data():
     return {
-        _ASTROPY_PACKAGE_NAME_ + '.tests': ['coveragerc', 'data/*.fits', 'data/*.hdr', 'data/*.lmv']
+        _ASTROPY_PACKAGE_NAME_ + '.tests': ['coveragerc', 'data/*.fits', 'data/*.hdr', 'data/*.lmv', 'data/*reg']
     }

--- a/spectral_cube/tests/test_subcubes.py
+++ b/spectral_cube/tests/test_subcubes.py
@@ -58,6 +58,7 @@ def test_ds9region(regfile, result):
         dsum = data[result].sum()
         assert_allclose(scsum, dsum)
 
+@pytest.mark.skipif('not pyregionOK', reason='Could not import pyregion')
 @pytest.mark.parametrize('regfile',
                          ('255-fk5.reg', '255-pixel.reg'),
                         )

--- a/spectral_cube/tests/test_subcubes.py
+++ b/spectral_cube/tests/test_subcubes.py
@@ -1,25 +1,14 @@
 from __future__ import print_function, absolute_import, division
 
 import pytest
-import operator
-import itertools
 
-from astropy.io import fits
 from astropy import units as u
-from astropy.wcs import WCS
+from astropy import wcs
 import numpy as np
 
-from .. import (SpectralCube, BooleanArrayMask, FunctionMask, LazyMask,
-                CompositeMask)
-from ..spectral_cube import OneDSpectrum, Projection
-from ..np_compat import allbadtonan
-from .. import spectral_axis
-
 from . import path
-from .helpers import assert_allclose, assert_array_equal
+#from .helpers import assert_allclose, assert_array_equal
 from .test_spectral_cube import cube_and_raw
-
-from distutils.version import StrictVersion
 
 try:
     import pyregion
@@ -44,28 +33,45 @@ def test_subcube():
     assert sc3.wcs.wcs.compare(cube.wcs.wcs)
     assert np.all(sc3._data == cube._data)
 
-#@pytest.mark.skipif(not pyregionOK, reason='Could not import pyregion')
-#@pytest.mark.parametrize(('regfile','result'),
-#                         (('fk5.reg', [slice(None),1,slice(None)]),
-#                          ('image.reg', NotImplementedError),
-#                          ('partial_overlap_image.reg', NotImplementedError),
-#                          ('no_overlap_image.reg', NotImplementedError),
-#                          ('partial_overlap_fk5.reg', [slice(None),1,1]),
-#                          ('no_overlap_fk5.reg', ValueError),
-#                         ))
-#def test_ds9region(regfile, result):
-#    cube, data = cube_and_raw('adv.fits')
-#
-#    regions = pyregion.open(regfile)
-#
-#    if issubclass(result, Exception):
-#        with pytest.raises(result) as exc:
-#            sc = cube.subcube_from_ds9region(regions)
-#    else:
-#        sc = cube.subcube_from_ds9region(regions)
-#        scsum = sc.sum()
-#        dsum = data[result].sum()
-#        assert scsum == dsum
+@pytest.mark.skipif('not pyregionOK', reason='Could not import pyregion')
+@pytest.mark.parametrize(('regfile','result'),
+                         (('fk5.reg', [slice(None),1,slice(None)]),
+                          ('image.reg', NotImplementedError),
+                          ('partial_overlap_image.reg', NotImplementedError),
+                          ('no_overlap_image.reg', NotImplementedError),
+                          ('partial_overlap_fk5.reg', [slice(None),1,1]),
+                          ('no_overlap_fk5.reg', ValueError),
+                         ))
+def test_ds9region(regfile, result):
+    cube, data = cube_and_raw('adv.fits')
+
+    regions = pyregion.open(path(regfile))
+
+    if issubclass(result, Exception):
+        with pytest.raises(result) as exc:
+            sc = cube.subcube_from_ds9region(regions)
+        assert isinstance(exc, result)
+    else:
+        sc = cube.subcube_from_ds9region(regions)
+        scsum = sc.sum()
+        dsum = data[result].sum()
+        assert scsum == dsum
+
+@pytest.mark.parametrize('regfile',
+                         ('255-fk5.reg', '255-pixel.reg'),
+                        )
+def test_ds9region_255(regfile):
+    # specific test for correctness
+    cube, data = cube_and_raw('255.fits')
+
+    regions = pyregion.open(path(regfile))
+
+    subhdr = cube.wcs.sub([wcs.WCSSUB_CELESTIAL]).to_header()
+
+    mask = regions.get_mask(header=subhdr,
+                            shape=cube.shape[1:])
+
+    assert all(cube[0,:,:][mask].value == [11,12,16,17])
 
 
 


### PR DESCRIPTION
For small regions, it was possible for a ds9 region to not intersect with
itself.  This probably indicates there is a much deeper, more dangerous
underlying issue and ds9 regions are simply extracting the wrong pixels in
general.  It's hard to know.  It is likely that this has to do with pyregion
defaulting to the FITS origin=1 standard instead of the correct python origin=0
when using python tools.