### PR TITLE
CASA-related bintable writing fixes

### DIFF
--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -1,4 +1,5 @@
 from astropy import units as u
+from astropy import log
 
 from . import wcs_utils
 
@@ -15,6 +16,7 @@ class BaseNDClass(object):
         """
         Return a copy of the header with no WCS information attached
         """
+        log.debug("Stripping WCS from header")
         return wcs_utils.strip_wcs_from_header(self._header)
 
     @property

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -250,6 +250,8 @@ def beams_to_bintable(beams):
     bmhdu.header['EXTNAME'] = 'BEAMS'
     bmhdu.header['EXTVER'] = 1
     bmhdu.header['XTENSION'] = 'BINTABLE'
+    bmhdu.header['NCHAN'] = len(beams)
+    bmhdu.header['NPOL'] = len(set([bm.meta['POL'] for bm in beams]))
     return bmhdu
 
 def average_beams(beams, includemask=None):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2244,6 +2244,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
 
     @property
     def header(self):
+        log.debug("Creating header")
         # Preserve non-WCS information from previous header iteration
         header = self._nowcs_header
         header.update(self.wcs.to_header())
@@ -2275,6 +2276,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         """
         HDU version of self
         """
+        log.debug("Creating HDU")
         hdu = PrimaryHDU(self.filled_data[:].value, header=self.header)
         return hdu
 


### PR DESCRIPTION
CASA would crash trying to import cubes generated with the previous
BinTableHDU writer.  This version does a better job of preserving units,
metadata, and the original shape of the CASA beam tables