### PR TITLE
Handle WCS reversal & fix 1D slice headers

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -26,6 +26,9 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
         if self.wcs is not None:
             header.update(self.wcs.to_header())
         header['BUNIT'] = self.unit.to_string(format='fits')
+        for keyword in header:
+            if 'NAXIS' in keyword:
+                del header[keyword]
         header.insert(2, Card(keyword='NAXIS', value=self.ndim))
         for ind,sh in enumerate(self.shape[::-1]):
             header.insert(3+ind, Card(keyword='NAXIS{0:1d}'.format(ind+1),

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -423,7 +423,8 @@ class BooleanArrayMask(MaskBase):
 
     def __getitem__(self, view):
         return BooleanArrayMask(self._mask[view],
-                                wcs_utils.slice_wcs(self._wcs, view),
+                                wcs_utils.slice_wcs(self._wcs, view,
+                                                    shape=self.shape),
                                 shape=self._mask[view].shape)
 
     def with_spectral_unit(self, unit, velocity_convention=None, rest_value=None):
@@ -503,7 +504,8 @@ class LazyMask(MaskBase):
 
     def __getitem__(self, view):
         return LazyMask(self._function, data=self._data[view],
-                        wcs=wcs_utils.slice_wcs(self._wcs, view))
+                        wcs=wcs_utils.slice_wcs(self._wcs, view,
+                                                shape=self._data.shape))
 
     def with_spectral_unit(self, unit, velocity_convention=None, rest_value=None):
         """

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1088,6 +1088,12 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
             # only one element, so drop an axis
             newwcs = wcs_utils.drop_axis(self._wcs, intslices[0])
             header = self._nowcs_header
+
+            if intslices[0] == 0:
+                # celestial: can report the wavelength/frequency of the axis
+                header['CRVAL3'] = self.spectral_axis[intslices[0]]
+                header['CDELT3'] = self.wcs.sub([wcs.WCSSUB_SPECTRAL]).wcs.cdelt[0]
+
             return Slice(value=self.filled_data[view],
                          wcs=newwcs,
                          copy=False,
@@ -1098,7 +1104,8 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         newmask = self._mask[view] if self._mask is not None else None
 
         return self._new_cube_with(data=self._data[view],
-                                   wcs=wcs_utils.slice_wcs(self._wcs, view),
+                                   wcs=wcs_utils.slice_wcs(self._wcs, view,
+                                                           shape=self.shape),
                                    mask=newmask,
                                    meta=meta)
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1091,8 +1091,9 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
 
             if intslices[0] == 0:
                 # celestial: can report the wavelength/frequency of the axis
-                header['CRVAL3'] = self.spectral_axis[intslices[0]]
+                header['CRVAL3'] = self.spectral_axis[intslices[0]].value
                 header['CDELT3'] = self.wcs.sub([wcs.WCSSUB_SPECTRAL]).wcs.cdelt[0]
+                header['CUNIT3'] = self._spectral_unit.to_string(format='FITS')
 
             return Slice(value=self.filled_data[view],
                          wcs=newwcs,

--- a/spectral_cube/tests/test_wcs_utils.py
+++ b/spectral_cube/tests/test_wcs_utils.py
@@ -77,6 +77,18 @@ def test_wcs_slice():
     wcs_new = slice_wcs(wcs, (slice(10,20), slice(None), slice(20,30)))
     np.testing.assert_allclose(wcs_new.wcs.crpix, [30., 45., 20.])
 
+def test_wcs_slice_reversal():
+    wcs = WCS(naxis=3)
+    wcs.wcs.crpix = [50., 45., 30.]
+    wcs.wcs.crval = [0., 0., 0.]
+    wcs.wcs.cdelt = [1., 1., 1.]
+    wcs_new = slice_wcs(wcs, (slice(None, None, -1), slice(None), slice(None)),
+                        shape=[100., 150., 200.])
+    spaxis = wcs.sub([0]).wcs_pix2world(np.arange(100), 0)
+    new_spaxis = wcs_new.sub([0]).wcs_pix2world(np.arange(100), 0)
+
+    np.testing.assert_allclose(spaxis, new_spaxis[::-1])
+
 
 def test_wcs_comparison():
     wcs1 = WCS(naxis=3)

--- a/spectral_cube/wcs_utils.py
+++ b/spectral_cube/wcs_utils.py
@@ -234,7 +234,8 @@ def slice_wcs(mywcs, view, shape=None, numpy_order=True):
                 refpix = shape[i]
             # this will raise an inconsistent axis type error if slicing over
             # celestial axes is attempted
-            crval = mywcs.sub([wcs_index]).wcs_pix2world(refpix, 0)
+            # wcs_index+1 is required because sub([0]) = sub([all])
+            crval = mywcs.sub([wcs_index+1]).wcs_pix2world([refpix], 0)[0]
             crpix = 1
             wcs_new.wcs.crpix[wcs_index] = crpix
             wcs_new.wcs.crval[wcs_index] = crval
@@ -253,6 +254,10 @@ def slice_wcs(mywcs, view, shape=None, numpy_order=True):
                 wcs_new.wcs.cdelt[wcs_index] = cdelt * iview.step
             else:
                 wcs_new.wcs.crpix[wcs_index] -= iview.start
+
+    # Without this, may cause a regression of #234
+    wcs_new.wcs.set()
+
     return wcs_new
 
 def check_equality(wcs1, wcs2, warn_missing=False,


### PR DESCRIPTION
WCS reversal, e.g. cube[::-1,:,:], is allowed now but does *not* work because
of https://github.com/astropy/astropy/pull/4962.  This PR partially implements
a reverse indexing.