### PR TITLE
Preserve jy/beam units in cubes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
         - ASTROPY_VERSION=stable
         - CONDA_DEPENDENCIES='matplotlib aplpy pytest pytest-xdist'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
-        - PIP_DEPENDENCIES='pvextractor'
+        - PIP_DEPENDENCIES='https://github.com/radio-astro-tools/pvextractor/archive/master.zip'
         - SETUP_XVFB=True
 
     matrix:
@@ -48,7 +48,7 @@ matrix:
           env: SETUP_CMD='test --coverage'
                CONDA_DEPENDENCIES='matplotlib aplpy yt bottleneck pytest pytest-xdist'
                ASTROPY_VERSION='development'
-               PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pvextractor'
+               PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip https://github.com/radio-astro-tools/pvextractor/archive/master.zip'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
@@ -71,11 +71,16 @@ matrix:
         # Test with radio-beam
         - python: 2.7
           env:
-              PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pvextractor'
+              PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip https://github.com/radio-astro-tools/pvextractor/archive/master.zip'
               ASTROPY_VERSION='development'
         - python: 3.5
           env:
-              PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pvextractor'
+              PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip https://github.com/radio-astro-tools/pvextractor/archive/master.zip'
+              ASTROPY_VERSION='development'
+
+        - python: 3.6
+          env:
+              PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip https://github.com/radio-astro-tools/pvextractor/archive/master.zip'
               ASTROPY_VERSION='development'
 
 install:

--- a/docs/beam_handling.rst
+++ b/docs/beam_handling.rst
@@ -27,9 +27,9 @@ Multi-beam cubes
 
 Varying resolution (multi-beam) cubes are somewhat trickier to work with in
 general, though unit conversion is easy.  You can perform the same sort of unit
-conversion with `~spectral_cube.spectral_cube.VaryingResolutionSpectralCube`s
-as with regular `~spectral_cube.spectral_cube.SpectralCube`s; ``spectral-cube``
+conversion with `~spectral_cube.spectral_cube.VaryingResolutionSpectralCube` s
+as with regular `~spectral_cube.spectral_cube.SpectralCube` s; ``spectral-cube``
 will use a different beam and frequency for each plane.
 
 For other sorts of operations, discussion of how to deal with these cubes via
-smoothing to a common resolution is in the `smoothing` document.
+smoothing to a common resolution is in the :doc:`smoothing` document.

--- a/docs/beam_handling.rst
+++ b/docs/beam_handling.rst
@@ -18,8 +18,8 @@ loading the entire cube into memory!::
 
    >>> cube.unit  # doctest: +SKIP
    Unit("Jy / beam")
-   >>> kcube = cube.to(u.K)
-   >>> kcube.unit
+   >>> kcube = cube.to(u.K)  # doctest: +SKIP
+   >>> kcube.unit  # doctest: +SKIP
    Unit("K")
 
 Multi-beam cubes

--- a/docs/beam_handling.rst
+++ b/docs/beam_handling.rst
@@ -1,0 +1,28 @@
+Handling Beams
+==============
+
+If you are using radio data, your cubes should have some sort of beam
+information included.  ``spectral-cube`` handles beams using the `radio_beam
+<https://github.com/radio-astro-tools/radio_beam>`_
+package.
+
+There are two ways beams can be stored in FITS files: as FITS header
+keywords (``BMAJ``, ``BMIN``, and ``BPA``) or as a ``BinTableHDU``
+extension.  If the latter is present, ``spectral-cube`` will return
+a `~spectral_cube.spectral_cube.VaryingResolutionSpectralCube` object.
+
+For the simpler case of a single beam across all channels, the presence
+of the beam allows for direct conversion of a cube with Jy/beam units
+to surface brightness (K) units.  Note, however, that this requires
+loading the entire cube into memory!::
+
+   >>> cube.unit  # doctest: +SKIP
+   Unit("Jy / beam")
+   >>> kcube = cube.to(u.K)
+   >>> kcube.unit
+   Unit("K")
+
+Multi-beam cubes
+----------------
+
+Varying resolution (multi-beam) cubes are somewhat trickier to work with.

--- a/docs/beam_handling.rst
+++ b/docs/beam_handling.rst
@@ -25,4 +25,11 @@ loading the entire cube into memory!::
 Multi-beam cubes
 ----------------
 
-Varying resolution (multi-beam) cubes are somewhat trickier to work with.
+Varying resolution (multi-beam) cubes are somewhat trickier to work with in
+general, though unit conversion is easy.  You can perform the same sort of unit
+conversion with `~spectral_cube.spectral_cube.VaryingResolutionSpectralCube`s
+as with regular `~spectral_cube.spectral_cube.SpectralCube`s; ``spectral-cube``
+will use a different beam and frequency for each plane.
+
+For other sorts of operations, discussion of how to deal with these cubes via
+smoothing to a common resolution is in the `smoothing` document.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,6 +63,7 @@ Getting started
    moments.rst
    errors.rst
    quick_looks.rst
+   beam_handling.rst
    spectral_extraction.rst
 
 Advanced

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -401,7 +401,7 @@ def convert_bunit(bunit):
     # special case: CASA (sometimes) makes non-FITS-compliant jy/beam headers
     bunit_lower = re.sub("\s", "", bunit.lower())
     if bunit_lower == 'jy/beam':
-        unit = u.Jy
+        unit = u.Jy / u.beam
     else:
         try:
             unit = u.Unit(bunit)

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2142,17 +2142,17 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             # No copying
             return self
 
-        if unit.is_equivalent(u.Jy/u.beam):
+        if self.unit.is_equivalent(u.Jy/u.beam):
             # replace "beam" with the actual beam
             if not hasattr(self, 'beam'):
                 raise ValueError("To convert cubes with Jy/beam units, "
                                  "the cube needs to have a beam defined.")
-            brightness_unit = self.unit * u.beam / self.beam
+            brightness_unit = self.unit * u.beam
 
             # create a beam equivalency for brightness temperature
             bmequiv = self.beam.jtok_equiv(self.with_spectral_unit(u.Hz).spectral_axis)
             factor = brightness_unit.to(unit,
-                                        equivalencies=bmequiv)
+                                        equivalencies=bmequiv+list(equivalencies))
         else:
             # scaling factor
             factor = self.unit.to(unit, equivalencies=equivalencies)
@@ -3089,7 +3089,7 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
             # No copying
             return self
 
-        if unit.is_equivalent(u.Jy/u.beam):
+        if self.unit.is_equivalent(u.Jy/u.beam):
             # replace "beam" with the actual beam
             if not hasattr(self, 'beams'):
                 raise ValueError("To convert cubes with Jy/beam units, "
@@ -3097,12 +3097,12 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
             factors = []
             for bm,frq in zip(self.beams,
                               self.with_spectral_unit(u.Hz).spectral_axis):
-                brightness_unit = self.unit * u.beam / bm
+                brightness_unit = self.unit * u.beam
 
                 # create a beam equivalency for brightness temperature
                 bmequiv = bm.jtok_equiv(frq)
                 factor = brightness_unit.to(unit,
-                                            equivalencies=bmequiv)
+                                            equivalencies=bmequiv+list(equivalencies))
                 factors.append(factor)
             factor = np.array(factors)
         else:

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1142,6 +1142,8 @@ def test_basic_unit_conversion():
                                    (cube.filled_data[:].value *
                                     1e3))
 
+@pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
+def test_basic_unit_conversion_beams():
     cube, data = cube_and_raw('vda_beams.fits')
     cube._unit = u.K # want beams, but we want to force the unit to be something non-beamy
     cube._meta['BUNIT'] = 'K'

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1137,7 +1137,7 @@ def test_beam_jtok_array():
 
     cube, data = cube_and_raw('advs.fits')
     cube._meta['BUNIT'] = 'Jy / beam'
-    cube._unit = u.Jy
+    cube._unit = u.Jy/u.beam
 
     equiv = cube.beam.jtok_equiv(cube.with_spectral_unit(u.GHz).spectral_axis)
     jtok = cube.beam.jtok(cube.with_spectral_unit(u.GHz).spectral_axis)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1208,7 +1208,7 @@ def test_jybeam_upper():
 
     cube, data = cube_and_raw('vda_JYBEAM_upper.fits')
 
-    assert cube.unit == u.Jy
+    assert cube.unit == u.Jy/u.beam
     if RADIO_BEAM_INSTALLED:
         assert hasattr(cube, 'beam')
         np.testing.assert_almost_equal(cube.beam.sr.value,
@@ -1218,7 +1218,7 @@ def test_jybeam_lower():
 
     cube, data = cube_and_raw('vda_Jybeam_lower.fits')
 
-    assert cube.unit == u.Jy
+    assert cube.unit == u.Jy/u.beam
     if RADIO_BEAM_INSTALLED:
         assert hasattr(cube, 'beam')
         np.testing.assert_almost_equal(cube.beam.sr.value,
@@ -1229,7 +1229,7 @@ def test_jybeam_whitespace():
 
     cube, data = cube_and_raw('vda_Jybeam_whitespace.fits')
 
-    assert cube.unit == u.Jy
+    assert cube.unit == u.Jy/u.beam
     if RADIO_BEAM_INSTALLED:
         assert hasattr(cube, 'beam')
         np.testing.assert_almost_equal(cube.beam.sr.value,

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1136,15 +1136,19 @@ def test_multibeam_slice():
 def test_beam_jtok_array():
 
     cube, data = cube_and_raw('advs.fits')
-    # technically this should be jy/beam, but astropy's equivalency doesn't
-    # handle this yet
-    cube._meta['BUNIT'] = 'Jy'
+    cube._meta['BUNIT'] = 'Jy / beam'
     cube._unit = u.Jy
 
     equiv = cube.beam.jtok_equiv(cube.with_spectral_unit(u.GHz).spectral_axis)
     jtok = cube.beam.jtok(cube.with_spectral_unit(u.GHz).spectral_axis)
 
     Kcube = cube.to(u.K, equivalencies=equiv)
+    np.testing.assert_almost_equal(Kcube.filled_data[:].value,
+                                   (cube.filled_data[:].value *
+                                    jtok[:,None,None]).value)
+
+    # test that the beam equivalencies are correctly automatically defined
+    Kcube = cube.to(u.K)
     np.testing.assert_almost_equal(Kcube.filled_data[:].value,
                                    (cube.filled_data[:].value *
                                     jtok[:,None,None]).value)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1154,6 +1154,29 @@ def test_beam_jtok_array():
                                     jtok[:,None,None]).value)
 
 @pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
+def test_multibeam_jtok_array():
+
+    cube, data = cube_and_raw('vda_beams.fits')
+    assert cube.meta['BUNIT'].strip() == 'Jy / beam'
+    assert cube.unit.is_equivalent(u.Jy/u.beam)
+
+    #equiv = [bm.jtok_equiv(frq) for bm, frq in zip(cube.beams, cube.with_spectral_unit(u.GHz).spectral_axis)]
+    jtok = u.Quantity([bm.jtok(frq) for bm, frq in zip(cube.beams, cube.with_spectral_unit(u.GHz).spectral_axis)])
+
+    # don't try this, it's nonsense for the multibeam case
+    # Kcube = cube.to(u.K, equivalencies=equiv)
+    # np.testing.assert_almost_equal(Kcube.filled_data[:].value,
+    #                                (cube.filled_data[:].value *
+    #                                 jtok[:,None,None]).value)
+
+    # test that the beam equivalencies are correctly automatically defined
+    Kcube = cube.to(u.K)
+    np.testing.assert_almost_equal(Kcube.filled_data[:].value,
+                                   (cube.filled_data[:].value *
+                                    jtok[:,None,None]).value)
+
+
+@pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
 def test_beam_jtok():
     # regression test for an error introduced when the previous test was solved
     # (the "is this an array?" test used len(x) where x could be scalar)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1131,6 +1131,29 @@ def test_multibeam_slice():
     np.testing.assert_almost_equal(flatslice.header['BMAJ'],
                                    (0.1/3600.))
 
+def test_basic_unit_conversion():
+
+    cube, data = cube_and_raw('advs.fits')
+    assert cube.unit == u.K
+
+    mKcube = cube.to(u.mK)
+
+    np.testing.assert_almost_equal(mKcube.filled_data[:].value,
+                                   (cube.filled_data[:].value *
+                                    1e3))
+
+    cube, data = cube_and_raw('vda_beams.fits')
+    cube._unit = u.K # want beams, but we want to force the unit to be something non-beamy
+    cube._meta['BUNIT'] = 'K'
+
+    assert cube.unit == u.K
+
+    mKcube = cube.to(u.mK)
+
+    np.testing.assert_almost_equal(mKcube.filled_data[:].value,
+                                   (cube.filled_data[:].value *
+                                    1e3))
+
 
 @pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
 def test_beam_jtok_array():


### PR DESCRIPTION
As an intermediate hack, we were intepreting Jy/beam BUNITs as Jy.  That is
incorrect behavior and results in BUNIT=Jy being written when that unit is
ambiguous (Jy/pixel or Jy/beam?) and not properly specified.  For the next
release, we need to handly Jy/beam properly, which also means correctly
handling Jy/beam -> K conversion, not just Jy->K.
