### PR TITLE
Raise exception when attempting to subcube an empty set

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1690,6 +1690,10 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         include = region_mask.include(self._data, self._wcs,
                                       wcs_tolerance=self._wcs_tolerance)
 
+        if not any(include):
+            # should this return an empty slice instead?
+            raise ValueError("There are no valid pixels included.")
+
         slices = ndimage.find_objects(np.broadcast_arrays(include,
                                                           self._data)[0])[0]
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1691,8 +1691,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
                                       wcs_tolerance=self._wcs_tolerance)
 
         if not include.any():
-            # should this return an empty slice instead?
-            raise ValueError("There are no valid pixels included.")
+            return (slice(0),)*3
 
         slices = ndimage.find_objects(np.broadcast_arrays(include,
                                                           self._data)[0])[0]

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1690,7 +1690,7 @@ class SpectralCube(BaseNDClass, SpectralAxisMixinClass):
         include = region_mask.include(self._data, self._wcs,
                                       wcs_tolerance=self._wcs_tolerance)
 
-        if not any(include):
+        if not include.any():
             # should this return an empty slice instead?
             raise ValueError("There are no valid pixels included.")
 


### PR DESCRIPTION
Would it be better to return empty?  Please chime in if you have an opinion.