### PR TITLE
cube.to can handle array equivalencies

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2256,6 +2256,7 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
     def hdulist(self):
         return HDUList(self.hdu)
 
+    @warn_slow
     def to(self, unit, equivalencies=()):
         """
         Return the cube converted to the given unit (assuming it is equivalent).
@@ -2272,8 +2273,15 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
         # scaling factor
         factor = self.unit.to(unit, equivalencies=equivalencies)
 
-        return self._new_cube_with(data=self._data*factor,
-                                   unit=unit)
+        # special case: array in equivalencies
+        # (I don't think this should have to be special cased, but I don't know
+        # how to manipulate broadcasting rules any other way)
+        if len(factor) == len(self):
+            return self._new_cube_with(data=self._data*factor[:,None,None],
+                                       unit=unit)
+        else:
+            return self._new_cube_with(data=self._data*factor,
+                                       unit=unit)
 
 
     def find_lines(self, velocity_offset=None, velocity_convention=None,

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1099,8 +1099,9 @@ def test_beam_jtok_array():
     jtok = cube.beam.jtok(cube.with_spectral_unit(u.GHz).spectral_axis)
 
     Kcube = cube.to(u.K, equivalencies=equiv)
-    np.testing.assert_almost_equal(Kcube.filled_data[:],
-                                   cube.filled_data[:] * jtok)
+    np.testing.assert_almost_equal(Kcube.filled_data[:].value,
+                                   (cube.filled_data[:].value *
+                                    jtok[:,None,None]).value)
 
 @pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
 def test_varyres_moment():

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1085,6 +1085,23 @@ def test_multibeam_slice():
     np.testing.assert_almost_equal(flatslice.header['BMAJ'],
                                    (0.1/3600.))
 
+
+@pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
+def test_beam_jtok_array():
+
+    cube, data = cube_and_raw('advs.fits')
+    # technically this should be jy/beam, but astropy's equivalency doesn't
+    # handle this yet
+    cube._meta['BUNIT'] = 'Jy'
+    cube._unit = u.Jy
+
+    equiv = cube.beam.jtok_equiv(cube.with_spectral_unit(u.GHz).spectral_axis)
+    jtok = cube.beam.jtok(cube.with_spectral_unit(u.GHz).spectral_axis)
+
+    Kcube = cube.to(u.K, equivalencies=equiv)
+    np.testing.assert_almost_equal(Kcube.filled_data[:],
+                                   cube.filled_data[:] * jtok)
+
 @pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
 def test_varyres_moment():
     cube, data = cube_and_raw('vda_beams.fits')


### PR DESCRIPTION
(1) the cube.to function may be expensive, added warn_slow 

(2) have to special-case for the array-equivalency case