### PR TITLE
broken lower-dimensional-object units

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -119,11 +119,11 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
         return new
 
     def __array_finalize__(self, obj):
-        self._unit = getattr(obj, '_unit', None)
         self._wcs = getattr(obj, '_wcs', None)
         self._meta = getattr(obj, '_meta', None)
         self._mask = getattr(obj, '_mask', None)
         self._header = getattr(obj, '_header', None)
+        super(LowerDimensionalObject, self).__array_finalize__(obj)
 
     @property
     def __array_priority__(self):


### PR DESCRIPTION
With the latest astropy, lower-dimensional-structures, which inherit from astropy Quantitys, fail.  Example:

```
In [3]: x = OneDSpectrum(np.arange(5), unit=u.km**2/u.s**2)

In [4]: x
Out[4]: <OneDSpectrum [ 0., 1., 2., 3., 4.] km2 / s2>

In [5]: x**0.5
Out[5]: <OneDSpectrum [ 0.        , 1.        , 1.41421356, 1.73205081, 2.        ] km2 / s2>
```

The units aren't being updated.

cc @mhvk: can you offer any insight on what might be happening?  This is probably related to recent changes you made to astropy.quantity, but I'm not sure what exactly.