### PR TITLE
Fixed Sphinx warnings and enabled nitpicky mode

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,3 +3,16 @@ API Documentation
 
 .. automodapi:: spectral_cube
    :no-inheritance-diagram:
+   :inherited-members:
+
+.. automodapi:: spectral_cube.ytcube
+   :no-inheritance-diagram:
+   :no-inherited-members:
+
+.. automodapi:: spectral_cube.lower_dimensional_structures
+   :no-inheritance-diagram:
+   :no-inherited-members:
+
+.. automodapi:: spectral_cube.io.casa_masks
+   :no-inheritance-diagram:
+   :no-inherited-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ except ImportError:
 
 # Load all of the global Astropy configuration
 from astropy_helpers.sphinx.conf import *
+from astropy.extern import six
 
 # Get configuration information from setup.cfg
 try:
@@ -67,6 +68,8 @@ exclude_patterns.append('_templates')
 # be used globally.
 rst_epilog += """
 """
+
+intersphinx_mapping['astroquery'] = ('http://astroquery.readthedocs.org/en/latest/', None)
 
 # -- Project information ------------------------------------------------------
 
@@ -163,3 +166,13 @@ if eval(setup_cfg.get('edit_on_github')):
 
     edit_on_github_source_root = ""
     edit_on_github_doc_root = "docs"
+
+nitpicky = True
+nitpick_ignore = []
+
+for line in open('nitpick-exceptions'):
+    if line.strip() == "" or line.startswith("#"):
+        continue
+    dtype, target = line.split(None, 1)
+    target = target.strip()
+    nitpick_ignore.append((dtype, six.u(target)))

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,12 +1,9 @@
 Spectral Cube documentation
 ===========================
 
-The ``spectral-cube`` package provides an easy way to read, manipulate,
-analyze, and write data cubes with two positional dimensions and one
-spectral dimension, optionally with Stokes parameters.
-
-``spectral-cube`` aims to be a versatile data container for building
-custom analysis routines. It provides the following main features:
+The spectral-cube package provides an easy way to read, manipulate, analyze,
+and write data cubes with two positional dimensions and one spectral dimension,
+optionally with Stokes parameters. It provides the following main features:
 
 - A uniform interface to spectral cubes, robust to the
   wide range of conventions of axis order, spatial projections,
@@ -19,7 +16,7 @@ custom analysis routines. It provides the following main features:
 Quick start
 -----------
 
-Here's a simple script demonstrating ``spectral-cube``::
+Here's a simple script demonstrating the spectral-cube package::
 
     >>> import astropy.units as u
     >>> from spectral_cube import SpectralCube
@@ -40,8 +37,8 @@ Here's a simple script demonstrating ``spectral-cube``::
     >>> m1 = masked_slab.moment(order=1)  # doctest: +SKIP
     >>> m1.write('moment_1.fits')  # doctest: +SKIP
 
-Using ``spectral-cube``
------------------------
+Using spectral-cube
+-------------------
 
 The package centers around the
 :class:`~spectral_cube.SpectralCube` class. In the following

--- a/docs/masking.rst
+++ b/docs/masking.rst
@@ -8,8 +8,8 @@ In addition to supporting the representation of data and associated WCS, it
 is also possible to attach a boolean mask to the
 :class:`~spectral_cube.SpectralCube` class. Masks can take
 various forms, but one of the more common ones is a cube with the same
-dimensions as the data, and that contains e.g. the boolean value ``True`` where
-data should be used, and the value ``False`` when the data should be ignored
+dimensions as the data, and that contains e.g. the boolean value `True` where
+data should be used, and the value `False` when the data should be ignored
 (though it is also possible to flip the convention around). To create a
 boolean mask from a boolean array ``mask_array``, you can for example use::
 
@@ -99,10 +99,10 @@ Inclusion and Exclusion
 The term "mask" is often used to refer both to the act of exluding
 and including pixels from analysis. To be explicit about how they behave,
 all mask objects have an
-:meth:`~spectral_cube.masks.MaskBase.include` method that returns a boolean
-array. True values in this array indicate that the pixel is included/valid,
-and not filtered/replaced in any way. Conversely, True values in the output
-from :meth:`~spectral_cube.masks.MaskBase.exclude`
+:meth:`~spectral_cube.MaskBase.include` method that returns a boolean
+array. `True` values in this array indicate that the pixel is included/valid,
+and not filtered/replaced in any way. Conversely, `True` values in the output
+from :meth:`~spectral_cube.MaskBase.exclude`
 indicate the pixel is excluded/invalid, and will be filled/filtered.
 The inclusion/exclusion behavior of any mask can be inverted via
 ``mask_inverse = ~mask``.
@@ -143,7 +143,7 @@ Outputting masks
 ----------------
 
 The attached mask to the given :class:`~spectral_cube.SpectralCube` class can
-be converted into a CASA image using :func:`~spectral_cube.io.make_casa_mask`:
+be converted into a CASA image using :func:`~spectral_cube.io.casa_masks.make_casa_mask`:
 
   >>> from spectral_cube.io.casa_masks import make_casa_mask
   >>> make_casa_mask(cube, 'casa_mask.image', add_stokes=False)  # doctest: +SKIP

--- a/docs/moments.rst
+++ b/docs/moments.rst
@@ -22,7 +22,7 @@ axis::
           moment is computed as the variance. For linewidth maps, see the
           `Linewidth maps`_ section.
 
-The moment maps returned are :class:`~spectral_cube.Projection` instances,
+The moment maps returned are :class:`~spectral_cube.lower_dimensional_structures.Projection` instances,
 which act like :class:`~astropy.units.Quantity` objects, and also have
 convenience methods for writing to a file::
 
@@ -50,5 +50,5 @@ astronomy), you can use:
     >>> sigma_map = cube.linewidth_sigma()  # doctest: +SKIP
     >>> fwhm_map = cube.linewidth_fwhm()  # doctest: +SKIP
 
-These also return :class:`~spectral_cube.Projection` instances as for the
+These also return :class:`~spectral_cube.lower_dimensional_structures.Projection` instances as for the
 `Moment maps`_.

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -1,0 +1,10 @@
+py:class spectral_cube.spectral_cube.BaseSpectralCube
+py:obj radio_beam.Beam
+py:obj astroquery.splatalogue.Splatalogue
+py:class spectral_cube.base_class.BaseNDClass
+py:class spectral_cube.base_class.SpectralAxisMixinClass
+
+# yt references
+py:obj yt.surface.export_sketchfab
+py:obj yt.show_colormaps
+

--- a/docs/quick_looks.rst
+++ b/docs/quick_looks.rst
@@ -2,7 +2,7 @@ Quick Looks
 ===========
 
 Once you've loaded a cube, you inevitably will want to look at it in various
-ways.  Slices in any direction have `quicklook` methods:
+ways.  Slices in any direction have ``quicklook`` methods:
 
     >>> cube[50,:,:].quicklook() # show an image  # doctest: +SKIP
     >>> cube[:, 50, 50].quicklook() # plot a spectrum  # doctest: +SKIP

--- a/docs/smoothing.rst
+++ b/docs/smoothing.rst
@@ -1,8 +1,6 @@
 Smoothing
 ---------
 
-
-
 There are two types of smoothing routine available in ``spectral_cube``:
 spectral and spatial.
 
@@ -23,21 +21,22 @@ A simple example::
     beam = radio_beam.Beam(major=1*u.arcsec, minor=1*u.arcsec, pa=0*u.deg)
     new_cube = cube.convolve_to(beam)
 
-Note that the `~spectral_cube.SpectralCube.convolve_to` method will work for
-both `~spectral_cube.VaryingResolutionSpectralCube`s and single-resolution
-`~spectral_cube.SpectralCube`s, but for a
-`~spectral_cube.VaryingResolutionSpectralCube`, the convolution kernel will be
-different for each slice
+Note that the :meth:`~spectral_cube.SpectralCube.convolve_to` method will work
+for both :class:`~spectral_cube.VaryingResolutionSpectralCube` instances and
+single-resolution :class:`~spectral_cube.SpectralCube` instances, but for a
+:class:`~spectral_cube.VaryingResolutionSpectralCube`, the convolution kernel
+will be different for each slice
 
 Spectral Smoothing
 ==================
 
-Only `~spectral_cube.SpectralCube`s with a consistent beam can be spectrally
-smoothed, so if you have a `~spectral_cube.VaryingResolutionSpectralCube`,
-you must convolve each slice in it to a common resolution before spectrally
-smoothing.  `~spectral_cube.SpectralCube.spectral_smooth` will apply a convolution
-kernel to each spectrum in turn.  As of July 2016, a parallelized version
-is partly written but incomplete.
+Only :class:`~spectral_cube.SpectralCube` instances with a consistent beam can
+be spectrally smoothed, so if you have a
+:class:`~spectral_cube.VaryingResolutionSpectralCube`, you must convolve each
+slice in it to a common resolution before spectrally smoothing.
+:meth:`~spectral_cube.SpectralCube.spectral_smooth` will apply a convolution
+kernel to each spectrum in turn. As of July 2016, a parallelized version is
+partly written but incomplete.
 
 Example::
 

--- a/docs/yt_example.rst
+++ b/docs/yt_example.rst
@@ -33,7 +33,7 @@ When working with datasets in yt, it may be useful to convert world coordinates
 to pixel coordinates, so that whenever you may have to input a position in yt
 (e.g., for slicing or volume rendering) you can get the pixel coordinate that
 corresponds to the desired world coordinate. For this purpose, the method
-:meth:`~spectral_cube.ytCube.world2yt` is provided::
+:meth:`~spectral_cube.ytcube.ytCube.world2yt` is provided::
 
     >>> import astropy.units as u
     >>> pix_coord = ytcube.world2yt([51.424522,
@@ -41,7 +41,7 @@ corresponds to the desired world coordinate. For this purpose, the method
     ...                              5205.18071],  # units of deg, deg, m/s
     ...                             )  # doctest: +SKIP
 
-There is also a reverse method provided, :meth:`~spectral_cube.ytCube.yt2world`::
+There is also a reverse method provided, :meth:`~spectral_cube.ytcube.ytCube.yt2world`::
 
     >>> world_coord = ytcube.yt2world([ds.domain_center])  # doctest: +SKIP
 

--- a/spectral_cube/__init__.py
+++ b/spectral_cube/__init__.py
@@ -13,3 +13,4 @@ if not _ASTROPY_SETUP_:
     from .spectral_cube import SpectralCube, VaryingResolutionSpectralCube
     from .stokes_spectral_cube import StokesSpectralCube
     from .masks import *
+

--- a/spectral_cube/_astropy_init.py
+++ b/spectral_cube/_astropy_init.py
@@ -59,7 +59,7 @@ def test(package=None, test_path=None, args=None, plugins=None,
 
     verbose : bool, optional
         Convenience option to turn on verbose output from py.test_. Passing
-        True is the same as specifying ``'-v'`` in ``args``.
+        `True` is the same as specifying ``'-v'`` in ``args``.
 
     pastebin : {'failed','all',None}, optional
         Convenience option for turning on py.test_ pastebin output. Set to
@@ -68,7 +68,7 @@ def test(package=None, test_path=None, args=None, plugins=None,
 
     remote_data : bool, optional
         Controls whether to run tests marked with @remote_data. These
-        tests use online data and are not run by default. Set to True to
+        tests use online data and are not run by default. Set to `True` to
         run these tests.
 
     pep8 : bool, optional

--- a/spectral_cube/io/casa_masks.py
+++ b/spectral_cube/io/casa_masks.py
@@ -7,6 +7,8 @@ import warnings
 
 from ..wcs_utils import add_stokes_axis_to_wcs
 
+__all__ = ['make_casa_mask']
+
 
 def make_casa_mask(SpecCube, outname, append_to_image=True,
                    img=None, add_stokes=True, stokes_posn=None):

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -12,10 +12,12 @@ import numpy as np
 from .base_class import BaseNDClass, SpectralAxisMixinClass
 from .cube_utils import beams_to_bintable
 
+__all__ = ['LowerDimensionalObject', 'Projection', 'Slice', 'OneDSpectrum']
+
 
 class LowerDimensionalObject(u.Quantity, BaseNDClass):
     """
-    Generic class for 1D and 2D objects
+    Generic class for 1D and 2D objects.
     """
 
     @property
@@ -63,7 +65,7 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
         format : str
             The kind of file to write. (Currently limited to 'fits')
         overwrite : bool
-            If True, overwrite `filename` if it exists
+            If True, overwrite ``filename`` if it exists
         """
         if format is None:
             format = determine_format(filename)
@@ -75,8 +77,10 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
 
     def to(self, unit, equivalencies=[]):
         """
-        Return a new ``LowerDimensionalObject'' of the same class with the
-        specified unit.  See `astropy.units.Quantity.to` for further details.
+        Return a new `LowerDimensionalObject` of the same class with the
+        specified unit.
+
+        See `astropy.units.Quantity.to` for further details.
         """
         converted_array = u.Quantity.to(self, unit,
                                         equivalencies=equivalencies).value
@@ -156,8 +160,9 @@ class Projection(LowerDimensionalObject):
 
     def quicklook(self, filename=None, use_aplpy=True):
         """
-        Use aplpy to make a quick-look image of the projection.  This will make
-        the `FITSFigure` attribute available.
+        Use `APLpy <https://pypi.python.org/pypi/APLpy>`_ to make a quick-look
+        image of the projection. This will make the ``FITSFigure`` attribute
+        available.
 
         If there are unmatched celestial axes, this will instead show an image
         without axis labels.

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -9,7 +9,7 @@ from . import wcs_utils
 from .lower_dimensional_structures import Projection
 
 
-__all__ = ['InvertedMask', 'CompositeMask', 'BooleanArrayMask',
+__all__ = ['MaskBase', 'InvertedMask', 'CompositeMask', 'BooleanArrayMask',
            'LazyMask', 'LazyComparisonMask', 'FunctionMask']
 
 # Global version of the with_spectral_unit docs to avoid duplicating them
@@ -453,7 +453,7 @@ class LazyMask(MaskBase):
     function : callable
         The function to apply to ``data``. This method should accept
         a numpy array, which will be a subset of the data array passed
-        to __init__. It should return a boolean array, where True values
+        to __init__. It should return a boolean array, where `True` values
         indicate that which pixels are valid/unaffected by masking.
     data : array-like
         The array to evaluate ``function`` on. This should support Numpy-like
@@ -533,7 +533,7 @@ class LazyComparisonMask(LazyMask):
         The function to apply to ``data``. This method should accept
         a numpy array, which will be the data array passed to __init__,  and a
         second argument also passed to __init__. It should return a boolean
-        array, where True values indicate that which pixels are
+        array, where `True` values indicate that which pixels are
         valid/unaffected by masking.
     comparison_value : float or array
         The comparison value for the array

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -346,7 +346,7 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
 
         Parameters
         ----------
-        function : `numpy.ufunc`
+        function : Numpy ufunc
             A numpy ufunc to apply to the cube
         fill : float
             The fill value to use on the data
@@ -361,19 +361,18 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
            decreasing subsets of the data, to conserve memory.
            Default='auto'
         projection : bool
-            Return a `Projection` if the resulting array is 2D or a
+            Return a :class:`~spectral_cube.lower_dimensional_structures.Projection` if the resulting array is 2D or a
             OneDProjection if the resulting array is 1D and the sum is over both
             spatial axes?
         unit : None or `astropy.units.Unit`
             The unit to include for the output array.  For example,
-            `SpectralCube.max` calls `SpectralCube.apply_numpy_function(np.max,
-            unit=self.unit)`, inheriting the unit from the original cube.
+            `SpectralCube.max` calls ``SpectralCube.apply_numpy_function(np.max, unit=self.unit)``, inheriting the unit from the original cube.
             However, for other numpy functions, e.g. `numpy.argmax`, the return
             is an index and therefore unitless.
         check_endian : bool
             A flag to check the endianness of the data before applying the
             function.  This is only needed for optimized functions, e.g. those
-            in the `bottleneck` package.
+            in the `bottleneck <https://pypi.python.org/pypi/Bottleneck>`_ package.
         progressbar : bool
             Show a progressbar while iterating over the slices through the
             cube?
@@ -382,11 +381,11 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
 
         Returns
         -------
-        result : `Projection` or `~astropy.units.Quantity` or float
+        result : :class:`~spectral_cube.lower_dimensional_structures.Projection` or `~astropy.units.Quantity` or float
             The result depends on the value of ``axis``, ``projection``, and
             ``unit``.  If ``axis`` is None, the return will be a scalar with or
             without units.  If axis is an integer, the return will be a
-            `Projection` if ``projection`` is set
+            :class:`~spectral_cube.lower_dimensional_structures.Projection` if ``projection`` is set
         """
 
 
@@ -783,11 +782,11 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
 
         Returns
         -------
-        result : `Projection` or `~astropy.units.Quantity` or float
+        result : :class:`~spectral_cube.lower_dimensional_structures.Projection` or `~astropy.units.Quantity` or float
             The result depends on the value of ``axis``, ``projection``, and
             ``unit``.  If ``axis`` is None, the return will be a scalar with or
             without units.  If axis is an integer, the return will be a
-            `Projection` if ``projection`` is set
+            :class:`~spectral_cube.lower_dimensional_structures.Projection` if ``projection`` is set
         """
         if axis is None:
             out = function(self.flattened(), **kwargs)
@@ -984,7 +983,7 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
         mask : :class:`MaskBase` instance, or boolean numpy array
             The mask to apply. If a boolean array is supplied,
             it will be converted into a mask, assuming that
-            True values indicate included elements.
+            `True` values indicate included elements.
 
         inherit_mask : bool (optional, default=True)
             If True, combines the provided mask with the
@@ -1681,7 +1680,7 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
 
         Parameters
         ----------
-        [xyz]lo/[xyz]hi : int or `Quantity` or `min`/`max`
+        [xyz]lo/[xyz]hi : int or :class:`~astropy.units.Quantity` or ``min``/``max``
             The endpoints to extract.  If given as a quantity, will be
             interpreted as World coordinates.  If given as a string or
             int, will be interpreted as pixel coordinates.
@@ -2047,7 +2046,7 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
         format : str
             The format of the file to write. (Currently limited to 'fits')
         overwrite : bool
-            If True, overwrite `filename` if it exists
+            If True, overwrite ``filename`` if it exists
         """
         from .io.core import write
         write(filename, self, overwrite=overwrite, format=format)
@@ -2137,7 +2136,7 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
             An existing Data object to add the cube to.  This is a good way
             to compare cubes with the same dimensions.  Supercedes ``glue_app``
         start_gui : bool
-            Start the GUI when this is run.  Set to False for testing.
+            Start the GUI when this is run.  Set to `False` for testing.
         """
         if name is None:
             name = 'SpectralCube'
@@ -2662,7 +2661,7 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
 
         Other Parameters
         ----------------
-        beam_table : `numpy.recordarray`
+        beam_table : `numpy.recarray`
             A table of beam major and minor axes in arcseconds and position
             angles, with labels BMAJ, BMIN, BPA
         beams : list

--- a/spectral_cube/stokes_spectral_cube.py
+++ b/spectral_cube/stokes_spectral_cube.py
@@ -103,7 +103,7 @@ class StokesSpectralCube(object):
         mask : :class:`MaskBase` instance, or boolean numpy array
             The mask to apply. If a boolean array is supplied,
             it will be converted into a mask, assuming that
-            True values indicate included elements.
+            `True` values indicate included elements.
 
         inherit_mask : bool (optional, default=True)
             If True, combines the provided mask with the
@@ -192,6 +192,6 @@ class StokesSpectralCube(object):
         format : str
             The format of the file to write. (Currently limited to 'fits')
         overwrite : bool
-            If True, overwrite `filename` if it exists
+            If True, overwrite ``filename`` if it exists
         """
         raise NotImplementedError("")

--- a/spectral_cube/ytcube.py
+++ b/spectral_cube/ytcube.py
@@ -16,6 +16,8 @@ try:
 except ImportError:
     ytOK = False
 
+__all__ = ['ytCube']
+
 class ytCube(object):
     """ Light wrapper of a yt object with ability to translate yt<->wcs
     coordinates """
@@ -163,7 +165,7 @@ class ytCube(object):
 
         pipe = _make_movie(outdir, prefix=image_prefix,
                            filename=output_filename)
-        
+
         return images
 
     def auto_transfer_function(self, cmap_range, log=False, colormap='doom',
@@ -206,8 +208,8 @@ class ytCube(object):
             file), or a .ply file.  The latter two require ``filename``
             specification
         filename: None or str
-            Optional - prefix for output filenames if `export_to` is 'obj', 
-            or the full filename when `export_to` is 'ply'.  Ignored for
+            Optional - prefix for output filenames if ``export_to`` is 'obj',
+            or the full filename when ``export_to`` is 'ply'.  Ignored for
             'sketchfab'
         kwargs: dict
             Keyword arguments are passed to the appropriate yt function
@@ -256,10 +258,10 @@ def _rescale_images(images, prefix):
     Save a sequence of images, at a common scaling
     Reduces flickering
     """
- 
+
     cmax = max(np.percentile(i[:, :, :3].sum(axis=2), 99.5) for i in images)
     amax = max(np.percentile(i[:, :, 3], 95) for i in images)
- 
+
     for i, image in enumerate(images):
         image = image.rescale(cmax=cmax, amax=amax).swapaxes(0,1)
         image.write_png("%s%04i.png" % (prefix, i), rescale=False)


### PR DESCRIPTION
@bsipocz - this might bring back memories ;) I was thinking we should probably add the nitpicky option by default to the package-template to encourage good practices? (also with the chunk of code to read in a potential nitpick-exceptions file if present?)

This fixes https://github.com/radio-astro-tools/spectral-cube/issues/338

Note that rather than add ``BaseSpectralCube`` to the API, which I think would be confusing for users, I added the option to add inherited methods to the SpectralCube class (and other top-level objects). This means we can't import Projection and Slice into the top-level at the moment since they inherit Quantity, and that causes a number of issues, so best leave it as-is for now.