### PR TITLE
Fix doc

### DIFF
--- a/docs/arithmetic.rst
+++ b/docs/arithmetic.rst
@@ -17,3 +17,6 @@ Examples::
 
 Each of these cubes is a new cube in memory.  Note that for addition and
 subtraction, the units must be equivalent to those of the cube.
+
+Please see :ref:`doc_handling_large_datasets` for details on how to perform
+arithmetic operations on a small subset of data at a time.

--- a/docs/big_data.rst
+++ b/docs/big_data.rst
@@ -35,7 +35,7 @@ memory-mapped array, because an operation like ``(x * 3)`` will require
 more RAM than exists on your system. A better way to compute y is
 by working with a single slice of ``x`` at a time::
 
-    y = x[0] * 0
+    y = np.zeros_like(x[0])
     for plane in x:
         y += np.abs(plane * 3 + 10)
 

--- a/docs/big_data.rst
+++ b/docs/big_data.rst
@@ -1,3 +1,5 @@
+.. _doc_handling_large_datasets:
+
 Handling large datasets
 =======================
 .. currentmodule:: spectral_cube

--- a/docs/masking.rst
+++ b/docs/masking.rst
@@ -114,7 +114,7 @@ from :meth:`~spectral_cube.MaskBase.exclude`
 indicate the pixel is excluded/invalid, and will be filled/filtered.
 The inclusion/exclusion behavior of any mask can be inverted via::
 
-    >>> mask_inverse = ~mask
+    >>> mask_inverse = ~mask  # doctest: +SKIP
 
 Advanced masking
 ----------------

--- a/docs/masking.rst
+++ b/docs/masking.rst
@@ -18,6 +18,11 @@ boolean mask from a boolean array ``mask_array``, you can for example use::
     >>> from spectral_cube import BooleanArrayMask
     >>> mask = BooleanArrayMask(mask=mask_array, wcs=cube.wcs)  # doctest: +SKIP
 
+.. note::
+
+   Currently, the mask convention is opposite of what is defined for
+   Numpy masked array and Astropy ``Table``.
+
 Using a pure boolean array may not always be the most efficient solution,
 because it may require a large amount of memory.
 

--- a/docs/masking.rst
+++ b/docs/masking.rst
@@ -107,8 +107,9 @@ array. `True` values in this array indicate that the pixel is included/valid,
 and not filtered/replaced in any way. Conversely, `True` values in the output
 from :meth:`~spectral_cube.MaskBase.exclude`
 indicate the pixel is excluded/invalid, and will be filled/filtered.
-The inclusion/exclusion behavior of any mask can be inverted via
-``mask_inverse = ~mask``.
+The inclusion/exclusion behavior of any mask can be inverted via::
+
+    >>> mask_inverse = ~mask
 
 Advanced masking
 ----------------
@@ -137,7 +138,7 @@ can also be defined directly by specifying conditions on
 :class:`~spectral_cube.SpectralCube` objects:
 
    >>> cube > 5*u.K  # doctest: +SKIP
-       LazyComparisonMask(...)
+   LazyComparisonMask(...)
 
 .. TODO: add example for FunctionalMask
 
@@ -151,9 +152,11 @@ be converted into a CASA image using :func:`~spectral_cube.io.casa_masks.make_ca
   >>> from spectral_cube.io.casa_masks import make_casa_mask
   >>> make_casa_mask(cube, 'casa_mask.image', add_stokes=False)  # doctest: +SKIP
 
-Optionally, a redundant Stokes axis can be added to match the original CASA image.
-.. Masks may also be appended to an existing CASA image:
-..  >>> make_casa_mask(cube, 'casa_mask.image', append_to_img=True, img='casa.image')
+Optionally, a redundant Stokes axis can be added to match the original CASA
+image. Masks may also be appended to an existing CASA image::
+
+  >>> make_casa_mask(cube, 'casa_mask.image', append_to_img=True,
+  ...                img='casa.image')
 
 .. note::
     Outputting to CASA masks requires that `spectral_cube` be run from a CASA python session.

--- a/docs/masking.rst
+++ b/docs/masking.rst
@@ -158,10 +158,11 @@ be converted into a CASA image using :func:`~spectral_cube.io.casa_masks.make_ca
   >>> make_casa_mask(cube, 'casa_mask.image', add_stokes=False)  # doctest: +SKIP
 
 Optionally, a redundant Stokes axis can be added to match the original CASA
-image. Masks may also be appended to an existing CASA image::
+image.
 
-  >>> make_casa_mask(cube, 'casa_mask.image', append_to_img=True,
-  ...                img='casa.image')
+.. Masks may also be appended to an existing CASA image::
+..   >>> make_casa_mask(cube, 'casa_mask.image', append_to_img=True,
+..                      img='casa.image')
 
 .. note::
     Outputting to CASA masks requires that `spectral_cube` be run from a CASA python session.

--- a/docs/masking.rst
+++ b/docs/masking.rst
@@ -10,7 +10,8 @@ is also possible to attach a boolean mask to the
 various forms, but one of the more common ones is a cube with the same
 dimensions as the data, and that contains e.g. the boolean value `True` where
 data should be used, and the value `False` when the data should be ignored
-(though it is also possible to flip the convention around). To create a
+(though it is also possible to flip the convention around; see
+:ref:`mask_inclusion_exclusion`). To create a
 boolean mask from a boolean array ``mask_array``, you can for example use::
 
     >>> from astropy import units as u
@@ -93,6 +94,8 @@ change the fill value on a cube, you can make use of the
 This returns a new :class:`~spectral_cube.SpectralCube` instance that
 contains a view to the same data in ``cube`` (so no data are copied).
 
+.. _mask_inclusion_exclusion:
+
 Inclusion and Exclusion
 -----------------------
 
@@ -170,28 +173,28 @@ If you see errors such as ``WCS does not match mask WCS``, but you're confident
 that your two cube are on the same grid, you should have a look at the
 ``cube.wcs`` attribute and see if there are subtle differences in the world
 coordinate parameters.  These frequently occur when converting from frequency
-to velocity as there is inadequate precision in the rest frequency. 
+to velocity as there is inadequate precision in the rest frequency.
 
 For example, these two axes are *nearly* identical, but not perfectly so::
 
     Number of WCS axes: 3
-    CTYPE : 'RA---SIN'  'DEC--SIN'  'VRAD'  
-    CRVAL : 269.08866286689999  -21.956244813729999  -3000.000559989533  
-    CRPIX : 161.0  161.0  1.0  
-    PC1_1 PC1_2 PC1_3  : 1.0  0.0  0.0  
-    PC2_1 PC2_2 PC2_3  : 0.0  1.0  0.0  
-    PC3_1 PC3_2 PC3_3  : 0.0  0.0  1.0  
-    CDELT : -1.3888888888889999e-05  1.3888888888889999e-05  299.99999994273281  
+    CTYPE : 'RA---SIN'  'DEC--SIN'  'VRAD'
+    CRVAL : 269.08866286689999  -21.956244813729999  -3000.000559989533
+    CRPIX : 161.0  161.0  1.0
+    PC1_1 PC1_2 PC1_3  : 1.0  0.0  0.0
+    PC2_1 PC2_2 PC2_3  : 0.0  1.0  0.0
+    PC3_1 PC3_2 PC3_3  : 0.0  0.0  1.0
+    CDELT : -1.3888888888889999e-05  1.3888888888889999e-05  299.99999994273281
     NAXIS    : 0 0
 
     Number of WCS axes: 3
-    CTYPE : 'RA---SIN'  'DEC--SIN'  'VRAD'  
-    CRVAL : 269.08866286689999  -21.956244813729999  -3000.0000242346514  
-    CRPIX : 161.0  161.0  1.0  
-    PC1_1 PC1_2 PC1_3  : 1.0  0.0  0.0  
-    PC2_1 PC2_2 PC2_3  : 0.0  1.0  0.0  
-    PC3_1 PC3_2 PC3_3  : 0.0  0.0  1.0  
-    CDELT : -1.3888888888889999e-05  1.3888888888889999e-05  300.00000001056611  
+    CTYPE : 'RA---SIN'  'DEC--SIN'  'VRAD'
+    CRVAL : 269.08866286689999  -21.956244813729999  -3000.0000242346514
+    CRPIX : 161.0  161.0  1.0
+    PC1_1 PC1_2 PC1_3  : 1.0  0.0  0.0
+    PC2_1 PC2_2 PC2_3  : 0.0  1.0  0.0
+    PC3_1 PC3_2 PC3_3  : 0.0  0.0  1.0
+    CDELT : -1.3888888888889999e-05  1.3888888888889999e-05  300.00000001056611
     NAXIS    : 0 0
 
 In order to compose masks from these, we need to set the ``wcs_tolerance`` parameter::

--- a/docs/moments.rst
+++ b/docs/moments.rst
@@ -44,7 +44,7 @@ plotting packages such as APLpy::
 Linewidth maps
 --------------
 
-Making linewidth maps (sometimes referered to as second moment maps in radio
+Making linewidth maps (sometimes refered to as second moment maps in radio
 astronomy), you can use:
 
     >>> sigma_map = cube.linewidth_sigma()  # doctest: +SKIP

--- a/docs/smoothing.rst
+++ b/docs/smoothing.rst
@@ -25,7 +25,7 @@ Note that the :meth:`~spectral_cube.SpectralCube.convolve_to` method will work
 for both :class:`~spectral_cube.VaryingResolutionSpectralCube` instances and
 single-resolution :class:`~spectral_cube.SpectralCube` instances, but for a
 :class:`~spectral_cube.VaryingResolutionSpectralCube`, the convolution kernel
-will be different for each slice
+will be different for each slice.
 
 Spectral Smoothing
 ==================


### PR DESCRIPTION
Changes include:

* Fix typo and syntax errors preventing proper text rendering.
* Fixes #341
* Fixes #343
* Address the doc portion of #339 and added a note to clarify mask convention.