### PR TITLE
Please don't use distutils.version.StrictVersion

### DIFF
--- a/spectral_cube/np_compat.py
+++ b/spectral_cube/np_compat.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import, division
 
 import numpy as np
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 def allbadtonan(function):
     """
@@ -11,7 +11,7 @@ def allbadtonan(function):
     """
     def f(data, axis=None):
         result = function(data, axis=axis)
-        if StrictVersion(np.__version__) >= StrictVersion('1.9.0'):
+        if LooseVersion(np.__version__) >= LooseVersion('1.9.0'):
             if axis is None:
                 if np.all(np.isnan(data)):
                     return np.nan

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -34,7 +34,7 @@ from .lower_dimensional_structures import (Projection, Slice, OneDSpectrum,
                                            LowerDimensionalObject)
 from .base_class import BaseNDClass, SpectralAxisMixinClass, DOPPLER_CONVENTIONS
 
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 __all__ = ['SpectralCube', 'VaryingResolutionSpectralCube']
 
@@ -2071,8 +2071,8 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
 
         import yt
 
-        if ('dev' in yt.__version__ or
-            StrictVersion(yt.__version__) >= StrictVersion('3.0')):
+        if (('dev' in yt.__version__) or
+            (LooseVersion(yt.__version__) >= LooseVersion('3.0'))):
 
             from yt.frontends.fits.api import FITSDataset
             from yt.units.unit_object import UnitParseError

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -14,7 +14,7 @@ from .. import (BooleanArrayMask, SpectralCube, LazyMask, LazyComparisonMask,
                 FunctionMask, CompositeMask)
 from ..masks import is_broadcastable_and_smaller, dims_to_skip, view_of_subset
 
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 
 def test_spectral_cube_mask():
@@ -370,7 +370,7 @@ def test_flat_mask():
     assert np.all(cube.sum(axis=0)[mask_array] == mcube.sum(axis=0)[mask_array])
     assert np.all(np.isnan(mcube.sum(axis=0)[~mask_array]))
 
-@pytest.mark.skipif(StrictVersion(np.__version__) < StrictVersion('1.7'),
+@pytest.mark.skipif(LooseVersion(np.__version__) < LooseVersion('1.7'),
                     reason='Numpy <1.7 does not support multi-slice indexing.')
 def test_flat_mask_spectral():
     cube, data = cube_and_raw('adv.fits')

--- a/spectral_cube/tests/test_moments.py
+++ b/spectral_cube/tests/test_moments.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import, division
 
 import warnings
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 import pytest
 import numpy as np
@@ -78,7 +78,7 @@ axis_order = pytest.mark.parametrize(('axis', 'order'),
                                      (1, 0), (1, 1), (1, 2),
                                      (2, 0), (2, 1), (2, 2)))
 
-if StrictVersion(astropy.__version__[:3]) >= StrictVersion('1.0'):
+if LooseVersion(astropy.__version__[:3]) >= LooseVersion('1.0'):
     # The relative error is slightly larger on astropy-dev
     # There is no obvious reason for this.
     rtol = 2e-7

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -4,7 +4,7 @@ import operator
 import itertools
 import warnings
 import mmap
-from distutils.version import StrictVersion, LooseVersion
+from distutils.version import LooseVersion
 
 # needed to test for warnings later
 warnings.simplefilter('always', UserWarning)
@@ -468,12 +468,12 @@ class TestNumpyMethods(BaseTest):
         scmed = self.c.apply_numpy_function(np.median, axis=0)
         # this checks whether numpy <=1.9.3 has a bug?
         # as far as I can tell, np==1.9.3 no longer has this bug/feature
-        #if StrictVersion(np.__version__) <= StrictVersion('1.9.3'):
+        #if LooseVersion(np.__version__) <= LooseVersion('1.9.3'):
         #    # print statements added so we get more info in the travis builds
-        #    print("Numpy version is: {0}".format(StrictVersion(np.__version__)))
+        #    print("Numpy version is: {0}".format(LooseVersion(np.__version__)))
         #    assert np.count_nonzero(np.isnan(scmed)) == 5
         #else:
-        #    print("Numpy version is: {0}".format(StrictVersion(np.__version__)))
+        #    print("Numpy version is: {0}".format(LooseVersion(np.__version__)))
         assert np.count_nonzero(np.isnan(scmed)) == 6
 
         scmed = self.c.apply_numpy_function(np.nanmedian, axis=0)
@@ -667,7 +667,7 @@ def test_read_write_rountrip(tmpdir):
     assert cube.shape == cube.shape
     assert_allclose(cube._data, cube2._data)
     if (((hasattr(_wcs, '__version__')
-          and StrictVersion(_wcs.__version__) < StrictVersion('5.9'))
+          and LooseVersion(_wcs.__version__) < LooseVersion('5.9'))
          or not hasattr(_wcs, '__version__'))):
         # see https://github.com/astropy/astropy/pull/3992 for reasons:
         # we should upgrade this for 5.10 when the absolute accuracy is


### PR DESCRIPTION
The current release of spectral-cube [does not work well](https://ci.debian.net/data/packages/unstable/amd64/s/spectral-cube/latest-autopkgtest/log.gz) with the version 1.11RC1 of numpy, because `distutils.version.StrictVersion` fails with this version number. I originally thought this is an issue of numpy, and filed numpy/numpy#7697. However it appears that the problem is `StrictVersion` which should not be used.
The problem is that otherwise, it is difficult to test spectral-cube against the RCs of numpy.