### PR TITLE
Beam checking: skip PA

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2868,7 +2868,8 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
         qtys = dict(sr=u.Quantity(self.beams, u.sr),
                     major=u.Quantity([bm.major for bm in self.beams], u.deg),
                     minor=u.Quantity([bm.minor for bm in self.beams], u.deg),
-                    pa=u.Quantity([bm.pa for bm in self.beams], u.deg),
+                    # position angles are not really comparable
+                    #pa=u.Quantity([bm.pa for bm in self.beams], u.deg),
                    )
 
         errormessage = ""


### PR DESCRIPTION
As per the commmit message:
skip position angle checks: they can be horribly wrong, especially around
PA=0, and often do not affect how the beam should be averaged. Of course, in
some cases, they can have dramatic effects, but it has been causing more harm
than good so far