### PR TITLE
Use deepcopy of wcs in spectral_interpolate

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2591,7 +2591,7 @@ class SpectralCube(BaseSpectralCube):
         newheader['CRVAL3'] = spectral_grid[0].value
         newheader['CDELT3'] = outdiff.value
         newheader['CUNIT3'] = spectral_grid.unit.to_string('FITS')
-        newwcs = self.wcs.copy()
+        newwcs = self.wcs.deepcopy()
         newwcs.wcs.crpix[2] = 1
         newwcs.wcs.crval[2] = spectral_grid[0].value
         newwcs.wcs.cunit[2] = spectral_grid.unit.to_string('FITS')

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2586,11 +2586,6 @@ class SpectralCube(BaseSpectralCube):
                                                  inaxis.value, mask) > 0
             pb.update()
 
-        newheader = self.header
-        newheader['CRPIX3'] = 1
-        newheader['CRVAL3'] = spectral_grid[0].value
-        newheader['CDELT3'] = outdiff.value
-        newheader['CUNIT3'] = spectral_grid.unit.to_string('FITS')
         newwcs = self.wcs.deepcopy()
         newwcs.wcs.crpix[2] = 1
         newwcs.wcs.crval[2] = spectral_grid[0].value

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2536,13 +2536,13 @@ class SpectralCube(BaseSpectralCube):
         """
 
         inaxis = self.spectral_axis.to(spectral_grid.unit)
- 
+
         indiff = np.mean(np.diff(inaxis))
         outdiff = np.mean(np.diff(spectral_grid))
 
         # account for reversed axes
         if outdiff < 0:
-            spectral_grid=spectral_grid[::-1]
+            spectral_grid = spectral_grid[::-1]
             outdiff = np.mean(np.diff(spectral_grid))
 
         if indiff < 0:
@@ -2555,24 +2555,24 @@ class SpectralCube(BaseSpectralCube):
         # insanity checks
         if indiff < 0 or outdiff < 0:
             raise ValueError("impossible.")
-    
+
         assert np.all(np.diff(spectral_grid) > 0)
         assert np.all(np.diff(inaxis) > 0)
-    
+
         np.testing.assert_allclose(np.diff(spectral_grid), outdiff,
                                    err_msg="Output grid must be linear")
-    
+
         if outdiff > 2 * indiff and not suppress_smooth_warning:
-            warnings.warn("Input grid has too small a spacing.  The data should "
+            warnings.warn("Input grid has too small a spacing. The data should "
                           "be smoothed prior to resampling.")
-    
+
         newcube = np.empty([spectral_grid.size, self.shape[1], self.shape[2]],
                            dtype=cubedata.dtype)
         newmask = np.empty([spectral_grid.size, self.shape[1], self.shape[2]],
                            dtype='bool')
-    
+
         yy,xx = np.indices(self.shape[1:])
-    
+
         pb = ProgressBar(xx.size)
         for ix, iy in (zip(xx.flat, yy.flat)):
             mask = self.mask.include(view=(slice(None), iy, ix))
@@ -2585,7 +2585,7 @@ class SpectralCube(BaseSpectralCube):
                     newmask[:,iy,ix] = np.interp(spectral_grid.value,
                                                  inaxis.value, mask) > 0
             pb.update()
-    
+
         newheader = self.header
         newheader['CRPIX3'] = 1
         newheader['CRVAL3'] = spectral_grid[0].value
@@ -2599,7 +2599,7 @@ class SpectralCube(BaseSpectralCube):
         newwcs.wcs.set()
 
         newbmask = BooleanArrayMask(newmask, wcs=newwcs)
-    
+
         newcube = self._new_cube_with(data=newcube, wcs=newwcs, mask=newbmask,
                                       meta=self.meta,
                                       fill_value=self.fill_value)
@@ -3048,13 +3048,13 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
                              "spectrally interpolated.  Convolve to a "
                              "common resolution with `convolve_to` before "
                              "attempting spectral interpolation.")
-    
+
     def spectral_smooth(self, *args, **kwargs):
         raise AttributeError("VaryingResolutionSpectralCubes can't be "
                              "spectrally smoothed.  Convolve to a "
                              "common resolution with `convolve_to` before "
                              "attempting spectral smoothed.")
-            
+
 
 
 def determine_format_from_filename(filename):

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -100,7 +100,7 @@ def test_spectral_smooth_fail():
 
     with pytest.raises(AttributeError) as exc:
         cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0))
-    
+
     assert exc.value.args[0] == ("VaryingResolutionSpectralCubes can't be "
                                  "spectrally smoothed.  Convolve to a "
                                  "common resolution with `convolve_to` before "
@@ -110,6 +110,8 @@ def test_spectral_interpolate():
 
     cube, data = cube_and_raw('522_delta.fits')
 
+    orig_wcs = cube.wcs.deepcopy()
+
     # midpoint between each position
     sg = (cube.spectral_axis[1:] + cube.spectral_axis[:-1])/2.
 
@@ -118,6 +120,8 @@ def test_spectral_interpolate():
     np.testing.assert_almost_equal(result[:,0,0].value,
                                    [0.0, 0.5, 0.5, 0.0])
 
+    assert cube.wcs.wcs.compare(orig_wcs.wcs)
+
 @pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
 def test_spectral_interpolate_fail():
 
@@ -125,7 +129,7 @@ def test_spectral_interpolate_fail():
 
     with pytest.raises(AttributeError) as exc:
         cube.spectral_interpolate(5)
-    
+
     assert exc.value.args[0] == ("VaryingResolutionSpectralCubes can't be "
                                  "spectrally interpolated.  Convolve to a "
                                  "common resolution with `convolve_to` before "


### PR DESCRIPTION
`wcs.copy` is a shallow copy: https://github.com/astropy/astropy/issues/4989. This leads to the original cube's WCS being altered:

```
In [1]: cube = SpectralCube.read("../../testingdata/Design4/Design4_21_0_0_flatrho_0021_13co.fits")

In [2]: cube.wcs.to_header()
Out[2]: 
WCSAXES =                    3 / Number of coordinate axes                      
CRPIX1  =                 64.0 / Pixel coordinate of reference point            
CRPIX2  =                  0.0 / Pixel coordinate of reference point            
CRPIX3  =                250.0 / Pixel coordinate of reference point            
CDELT1  =  -0.0052439029272473 / [deg] Coordinate increment at reference point  
CDELT2  =   0.0052439029272474 / [deg] Coordinate increment at reference point  
CDELT3  =     -40.080155424247 / [m/s] Coordinate increment at reference point  
CUNIT1  = 'deg'                / Units of coordinate increment and value        
CUNIT2  = 'deg'                / Units of coordinate increment and value        
CUNIT3  = 'm/s'                / Units of coordinate increment and value        
CTYPE1  = 'RA---CAR'           / Right ascension, plate caree projection        
CTYPE2  = 'DEC--CAR'           / Declination, plate caree projection            
CTYPE3  = 'VOPT'               / Optical velocity (linear)                      
CRVAL1  =                180.0 / [deg] Coordinate value at reference point      
CRVAL2  =                  0.0 / [deg] Coordinate value at reference point      
CRVAL3  =     -20.040086507091 / [m/s] Coordinate value at reference point      
LONPOLE =                  0.0 / [deg] Native longitude of celestial pole       
LATPOLE =                 90.0 / [deg] Native latitude of celestial pole        
RADESYS = 'FK5'                / Equatorial coordinate system                   
EQUINOX =               2000.0 / [yr] Equinox of equatorial coordinates 

In [3]: sg = (cube.spectral_axis[1:] + cube.spectral_axis[:-1])/2.
   ...: 

In [4]: result = cube.spectral_interpolate(spectral_grid=sg)

In [5]: cube.wcs.to_header()
Out[5]: 
WCSAXES =                    3 / Number of coordinate axes                      
CRPIX1  =                 64.0 / Pixel coordinate of reference point            
CRPIX2  =                  0.0 / Pixel coordinate of reference point            
CRPIX3  =                  1.0 / Pixel coordinate of reference point            
CDELT1  =  -0.0052439029272473 / [deg] Coordinate increment at reference point  
CDELT2  =   0.0052439029272474 / [deg] Coordinate increment at reference point  
CDELT3  =      40.080155424247 / [m s-1] Coordinate increment at reference point
CUNIT1  = 'deg'                / Units of coordinate increment and value        
CUNIT2  = 'deg'                / Units of coordinate increment and value        
CUNIT3  = 'm s-1'              / Units of coordinate increment and value        
CTYPE1  = 'RA---CAR'           / Right ascension, plate caree projection        
CTYPE2  = 'DEC--CAR'           / Declination, plate caree projection            
CTYPE3  = 'VOPT'               / Optical velocity (linear)                      
CRVAL1  =                180.0 / [deg] Coordinate value at reference point      
CRVAL2  =                  0.0 / [deg] Coordinate value at reference point      
CRVAL3  =     -10020.038864857 / [m s-1] Coordinate value at reference point    
LONPOLE =                  0.0 / [deg] Native longitude of celestial pole       
LATPOLE =                 90.0 / [deg] Native latitude of celestial pole        
RADESYS = 'FK5'                / Equatorial coordinate system                   
EQUINOX =               2000.0 / [yr] Equinox of equatorial coordinates 
```

Using `wcs.deepcopy` fixes things.

@keflavich - I also deleted `newheader` since it isn't actually used. Also, is your editor leaving the blank spaces?