### PR TITLE
Fixed to_glue with updated imports of GlueApplication and ImageWidget.

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2141,10 +2141,10 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
         if name is None:
             name = 'SpectralCube'
 
-        from glue.qt.glue_application import GlueApplication
+        from glue.app.qt.application import GlueApplication
         from glue.core import DataCollection, Data, Component
         from glue.core.coordinates import coordinates_from_header
-        from glue.qt.widgets import ImageWidget
+        from glue.viewers.image.qt.viewer_widget import ImageWidget
 
         if dataset is not None:
             if name in [d.label for d in dataset.components]:
@@ -2172,7 +2172,7 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
                                                            data=result)
 
                     if start_gui:
-                        self._glue_app.start()
+                        self._glue_app.stringart()
 
                     return self._glue_app
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2172,7 +2172,7 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
                                                            data=result)
 
                     if start_gui:
-                        self._glue_app.stringart()
+                        self._glue_app.start()
 
                     return self._glue_app
 


### PR DESCRIPTION
In the current version of glue, GlueApplication and ImageWidget classes are at different paths than the current imports in to_glue. I changed the import statements to reflect this. to_glue should now work with the latest version of glue.