### PR TITLE
glue import fails

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2141,7 +2141,7 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
         if name is None:
             name = 'SpectralCube'
 
-        from glue.app.qt.application import GlueApplication
+        from glue.app.qt import GlueApplication
         from glue.core import DataCollection, Data
         from glue.core.coordinates import coordinates_from_header
         from glue.viewers.image.qt.viewer_widget import ImageWidget

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2142,7 +2142,7 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass):
             name = 'SpectralCube'
 
         from glue.app.qt.application import GlueApplication
-        from glue.core import DataCollection, Data, Component
+        from glue.core import DataCollection, Data
         from glue.core.coordinates import coordinates_from_header
         from glue.viewers.image.qt.viewer_widget import ImageWidget
 


### PR DESCRIPTION
@astrofrog - the `to_glue` tool no longer works:
```
In [2]: cube2.to_glue()
/Users/adam/repos/glue/glue/qt/__init__.py:6: GlueDeprecationWarning: The glue.qt subpackage is deprecated - see the v0.7 release announcement for more details
  "announcement for more details", GlueDeprecationWarning)
Traceback (most recent call last):
  File "<ipython-input-2-38873324d2be>", line 1, in <module>
    cube2.to_glue()
  File "/Users/adam/repos/spectral-cube/spectral_cube/spectral_cube.py", line 2144, in to_glue
    from glue.qt.glue_application import GlueApplication
ImportError: No module named 'glue.qt.glue_application'
```