### PR TITLE
Handle equal beams when convolving

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,7 @@
 0.4.0 (2016-09-06)
 ------------------
+ - Handle equal beams when convolving cubes spatially.
+   (https://github.com/radio-astro-tools/spectral-cube/pull/356)
  - Whole cube convolution & reprojection has been added, including tools to
    smooth spectrally and spatially to force two cubes onto an identical grid.
    (https://github.com/radio-astro-tools/spectral-cube/pull/313)

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -262,6 +262,25 @@ def beams_to_bintable(beams):
     bmhdu.header['NPOL'] = len(set([bm.meta['POL'] for bm in beams]))
     return bmhdu
 
+
+def beam_props(beams, includemask=None):
+    '''
+    Returns separate quantities for the major, minor, and PA of a list of
+    beams.
+    '''
+    if includemask is None:
+        includemask = itertools.cycle([True])
+
+    major = u.Quantity([bm.major for bm, incl in zip(beams, includemask)
+                        if incl], u.deg)
+    minor = u.Quantity([bm.minor for bm, incl in zip(beams, includemask)
+                        if incl], u.deg)
+    pa = u.Quantity([bm.pa for bm, incl in zip(beams, includemask)
+                     if incl], u.deg)
+
+    return major, minor, pa
+
+
 def average_beams(beams, includemask=None):
     """
     Average the beam major, minor, and PA attributes.
@@ -272,14 +291,24 @@ def average_beams(beams, includemask=None):
     from radio_beam import Beam
     from astropy.stats import circmean
 
-    if includemask is None:
-        includemask = itertools.cycle([True])
-
-    major = u.Quantity([bm.major for bm,incl in zip(beams,includemask) if incl], u.deg)
-    minor = u.Quantity([bm.minor for bm,incl in zip(beams,includemask) if incl], u.deg)
-    pa = u.Quantity([bm.pa for bm,incl in zip(beams,includemask) if incl], u.deg)
+    major, minor, pa = beam_props(beams, includemask)
     new_beam = Beam(major=major.mean(), minor=minor.mean(),
                     pa=circmean(pa, weights=major/minor))
+
+    return new_beam
+
+
+def largest_beam(beams, includemask=None):
+    """
+    Returns the largest beam (by area) in a list of beams.
+    """
+
+    from radio_beam import Beam
+
+    major, minor, pa = beam_props(beams, includemask)
+    largest_idx = (major * minor).argmax()
+    new_beam = Beam(major=major[largest_idx], minor=minor[largest_idx],
+                    pa=pa[largest_idx])
 
     return new_beam
 

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -312,6 +312,21 @@ def largest_beam(beams, includemask=None):
 
     return new_beam
 
+
+def smallest_beam(beams, includemask=None):
+    """
+    Returns the smallest beam (by area) in a list of beams.
+    """
+
+    from radio_beam import Beam
+
+    major, minor, pa = beam_props(beams, includemask)
+    smallest_idx = (major * minor).argmin()
+    new_beam = Beam(major=major[smallest_idx], minor=minor[smallest_idx],
+                    pa=pa[smallest_idx])
+
+    return new_beam
+
 @contextlib.contextmanager
 def _map_context(numcores):
     """

--- a/spectral_cube/tests/test_cube_utils.py
+++ b/spectral_cube/tests/test_cube_utils.py
@@ -1,0 +1,41 @@
+import pytest
+import numpy as np
+from astropy import units as u
+from astropy import convolution
+from astropy.wcs import WCS
+from astropy import wcs
+
+from .test_spectral_cube import cube_and_raw
+from ..cube_utils import largest_beam, smallest_beam
+
+try:
+    from radio_beam import beam, Beam
+    RADIO_BEAM_INSTALLED = True
+except ImportError:
+    RADIO_BEAM_INSTALLED = False
+
+try:
+    import reproject
+    REPROJECT_INSTALLED = True
+except ImportError:
+    REPROJECT_INSTALLED = False
+
+
+@pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
+def test_largest_beam():
+
+    cube, data = cube_and_raw('522_delta_beams.fits')
+
+    large_beam = largest_beam(cube.beams)
+
+    assert large_beam == cube.beams[2]
+
+
+@pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
+def test_smallest_beam():
+
+    cube, data = cube_and_raw('522_delta_beams.fits')
+
+    small_beam = smallest_beam(cube.beams)
+
+    assert small_beam == cube.beams[0]

--- a/spectral_cube/tests/test_cube_utils.py
+++ b/spectral_cube/tests/test_cube_utils.py
@@ -1,9 +1,4 @@
 import pytest
-import numpy as np
-from astropy import units as u
-from astropy import convolution
-from astropy.wcs import WCS
-from astropy import wcs
 
 from .test_spectral_cube import cube_and_raw
 from ..cube_utils import largest_beam, smallest_beam
@@ -13,13 +8,6 @@ try:
     RADIO_BEAM_INSTALLED = True
 except ImportError:
     RADIO_BEAM_INSTALLED = False
-
-try:
-    import reproject
-    REPROJECT_INSTALLED = True
-except ImportError:
-    REPROJECT_INSTALLED = False
-
 
 @pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
 def test_largest_beam():

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -61,6 +61,21 @@ def test_beams_convolution():
         np.testing.assert_almost_equal(expected.array,
                                        conv_cube.filled_data[ii,:,:].value)
 
+@pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
+def test_beams_convolution_equal():
+    cube, data = cube_and_raw('522_delta_beams.fits')
+
+    # Only checking that the equal beam case is handled correctly.
+    # Fake the beam in the first channel. Then ensure that the first channel
+    # has NOT been convolved.
+    target_beam = Beam(1.0 * u.arcsec, 1.0 * u.arcsec, 0.0 * u.deg)
+    cube.beams[0] = target_beam
+
+    conv_cube = cube.convolve_to(target_beam)
+
+    np.testing.assert_almost_equal(cube.filled_data[0].value,
+                                   conv_cube.filled_data[0].value)
+
 @pytest.mark.skipif('not REPROJECT_INSTALLED')
 def test_reproject():
 


### PR DESCRIPTION
Added handling for when the beam in `convolveto` is equal to the channel beam.

Also added a function to return the largest beam from a list of beams.