### PR TITLE
have average_beams raise an error if it encounters NaNs by default

### DIFF
--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -281,7 +281,7 @@ def beam_props(beams, includemask=None):
     return major, minor, pa
 
 
-def average_beams(beams, includemask=None):
+def average_beams(beams, includemask=None, raise_for_nan=True):
     """
     Average the beam major, minor, and PA attributes.
 
@@ -292,8 +292,16 @@ def average_beams(beams, includemask=None):
     from astropy.stats import circmean
 
     major, minor, pa = beam_props(beams, includemask)
+
+    if raise_for_nan and (np.any(np.isnan(major)) or np.any(np.isnan(minor)) or
+                          np.any(np.isnan(pa))):
+        raise ValueError("Some beam parameters are NaN.  Try masking out the bad beams.")
+
     new_beam = Beam(major=major.mean(), minor=minor.mean(),
                     pa=circmean(pa, weights=major/minor))
+
+    if raise_for_nan and np.any(np.isnan(new_beam)):
+        raise ValueError("NaNs after averaging.  This is a bug.")
 
     return new_beam
 


### PR DESCRIPTION
this will most likely happen if the includemask is empty