### PR TITLE
Add tools to allow bad beams to be skipped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,9 @@ matrix:
         # Try older numpy versions
         - python: 2.7
           env: NUMPY_VERSION=1.9
-        - python: 2.7
-          env: NUMPY_VERSION=1.8
+        #We need nanmedian.  <=1.8 deprecated
+        # - python: 2.7
+        #   env: NUMPY_VERSION=1.8
 
         # Test with bottleneck
         - python: 2.7

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+0.4.1 (unreleased)
+------------------
+ - Deprecate numpy <=1.8 because nanmedian is needed
+   (https://github.com/radio-astro-tools/spectral-cube/pull/373)
+ - Add tools for masking bad beams in VaryingResolutionSpectralCubes
+   (https://github.com/radio-astro-tools/spectral-cube/pull/373)
+
 0.4.0 (2016-09-06)
 ------------------
  - Handle equal beams when convolving cubes spatially.

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1276,3 +1276,15 @@ def test_varyres_moment_logic_issue364():
     else:
         assert "Arithmetic beam averaging is being performed" in str(wrn[-1].message)
     assert_quantity_allclose(m0.meta['beam'].major, 0.25*u.arcsec)
+
+@pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
+def test_mask_bad_beams():
+    cube, data = cube_and_raw('vda_beams.fits')
+
+    # middle two beams have same area
+    masked_cube = cube.mask_out_bad_beams(0.01,
+                                          reference_beam=Beam(0.3*u.arcsec,
+                                                              0.2*u.arcsec,
+                                                              60*u.deg))
+
+    assert np.all(masked_cube.mask.include()[:,0,0] == [False,False,True,False])

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1288,3 +1288,6 @@ def test_mask_bad_beams():
                                                               60*u.deg))
 
     assert np.all(masked_cube.mask.include()[:,0,0] == [False,False,True,False])
+
+    mean = masked_cube.mean(axis=0)
+    assert np.all(mean == cube[2,:,:])


### PR DESCRIPTION
Includes a few new methods, including `mask_out_bad_beams`, which will mask out beams that don't match the median beam or a specified beam to within some threshold.

Beam averaging will now only check the unmasked (i.e., the included) channels when performing safety checks.