### PR TITLE
Add spatial functionality to projections

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,3 +12,7 @@ API Documentation
 .. automodapi:: spectral_cube.io.casa_masks
    :no-inheritance-diagram:
    :no-inherited-members:
+
+.. automodapi:: spectral_cube.lower_dimensional_structures
+   :no-inheritance-diagram:
+   :no-inherited-members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,10 +9,6 @@ API Documentation
    :no-inheritance-diagram:
    :no-inherited-members:
 
-.. automodapi:: spectral_cube.lower_dimensional_structures
-   :no-inheritance-diagram:
-   :no-inherited-members:
-
 .. automodapi:: spectral_cube.io.casa_masks
    :no-inheritance-diagram:
    :no-inherited-members:

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -3,6 +3,7 @@ py:obj radio_beam.Beam
 py:obj astroquery.splatalogue.Splatalogue
 py:class spectral_cube.base_class.BaseNDClass
 py:class spectral_cube.base_class.SpectralAxisMixinClass
+py:class spectral_cube.base_class.SpatialCoordMixinClass
 
 # yt references
 py:obj yt.surface.export_sketchfab

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -9,3 +9,35 @@ py:class spectral_cube.base_class.SpatialCoordMixinClass
 py:obj yt.surface.export_sketchfab
 py:obj yt.show_colormaps
 
+# numpy inherited docstrings
+py:obj dtype
+py:obj a
+py:obj a.size == 1
+py:obj n
+py:obj ndarray
+py:obj args
+
+py:obj Quantity
+py:obj conjugate
+py:obj numpy.conjugate
+py:obj numpy.lib.stride_tricks.as_strided
+py:obj x
+py:obj i
+py:obj j
+py:obj axis1
+py:obj axis2
+py:obj numpy.ctypeslib
+py:obj ndarray_subclass
+py:obj ndarray.T
+py:obj order
+py:obj refcheck
+py:obj val
+py:obj offset
+py:obj lexsort
+py:obj a.transpose()
+py:obj new_order
+py:obj inplace
+py:obj subok
+py:obj ndarray.setflags
+py:obj ndarray.flat
+py:obj arr_t

--- a/spectral_cube/__init__.py
+++ b/spectral_cube/__init__.py
@@ -13,4 +13,4 @@ if not _ASTROPY_SETUP_:
     from .spectral_cube import SpectralCube, VaryingResolutionSpectralCube
     from .stokes_spectral_cube import StokesSpectralCube
     from .masks import *
-    from . import lower_dimensional_structures
+    from .lower_dimensional_structures import (OneDSpectrum, Projection, Slice)

--- a/spectral_cube/__init__.py
+++ b/spectral_cube/__init__.py
@@ -13,4 +13,5 @@ if not _ASTROPY_SETUP_:
     from .spectral_cube import SpectralCube, VaryingResolutionSpectralCube
     from .stokes_spectral_cube import StokesSpectralCube
     from .masks import *
+    from .lower_dimensional_structures import Projection
 

--- a/spectral_cube/__init__.py
+++ b/spectral_cube/__init__.py
@@ -13,5 +13,6 @@ if not _ASTROPY_SETUP_:
     from .spectral_cube import SpectralCube, VaryingResolutionSpectralCube
     from .stokes_spectral_cube import StokesSpectralCube
     from .masks import *
-    from .lower_dimensional_structures import Projection
-
+    from .lower_dimensional_structures import (LowerDimensionalObject,
+                                               Projection, Slice,
+                                               OneDSpectrum)

--- a/spectral_cube/__init__.py
+++ b/spectral_cube/__init__.py
@@ -13,6 +13,4 @@ if not _ASTROPY_SETUP_:
     from .spectral_cube import SpectralCube, VaryingResolutionSpectralCube
     from .stokes_spectral_cube import StokesSpectralCube
     from .masks import *
-    from .lower_dimensional_structures import (LowerDimensionalObject,
-                                               Projection, Slice,
-                                               OneDSpectrum)
+    from . import lower_dimensional_structures

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -56,8 +56,7 @@ class SpatialCoordMixinClass(object):
         of it.
 
         SpatialCoordMixinClass.world is called with *bracket notation*, like
-        a NumPy array::
-            c.world[0:3, :, :]
+        a NumPy array: ``c.world[0:3, :, :]``
 
         Returns
         -------

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -56,27 +56,33 @@ class SpatialCoordMixinClass(object):
         of it.
 
         SpatialCoordMixinClass.world is called with *bracket notation*, like
-        a NumPy array: ``c.world[0:3, :, :]``
+        a NumPy array::
+
+            c.world[0:3, :, :]
 
         Returns
         -------
         [v, y, x] : list of NumPy arrays
             The 3 world coordinates at each pixel in the view. For a 2D image,
-            the output is [y, x].
+            the output is ``[y, x]``.
 
 
         Examples
         --------
         Extract the first 3 velocity channels of the cube:
+
         >>> v, y, x = c.world[0:3]
 
-        Extract all the world coordinates
+        Extract all the world coordinates:
+
         >>> v, y, x = c.world[:, :, :]
 
-        Extract every other pixel along all axes
+        Extract every other pixel along all axes:
+
         >>> v, y, x = c.world[::2, ::2, ::2]
 
         Extract all the world coordinates for a 2D image:
+
         >>> y, x = c.world[:, :]
 
         """

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -45,6 +45,10 @@ class SpatialCoordMixinClass(object):
     def _has_wcs_celestial(self):
         return self.wcs.has_celestial
 
+    def _raise_wcs_no_celestial(self):
+        if not self._has_wcs_celestial:
+            raise WCSCelestialError("WCS does not contain two spatial axes.")
+
     @cube_utils.slice_syntax
     def world(self, view):
         """
@@ -76,8 +80,7 @@ class SpatialCoordMixinClass(object):
 
         """
 
-        if not self._has_wcs_celestial:
-            raise WCSCelestialError("WCS does not contain two spatial axes.")
+        self._raise_wcs_no_celestial()
 
         # note: view is a tuple of view
 

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -1,7 +1,10 @@
 from astropy import units as u
 from astropy import log
+import numpy as np
 
 from . import wcs_utils
+from . import cube_utils
+from .utils import cached
 
 DOPPLER_CONVENTIONS = {}
 DOPPLER_CONVENTIONS['radio'] = u.doppler_radio
@@ -11,6 +14,9 @@ DOPPLER_CONVENTIONS['relativistic'] = u.doppler_relativistic
 
 
 class BaseNDClass(object):
+
+    _cache = {}
+
     @property
     def _nowcs_header(self):
         """
@@ -30,6 +36,108 @@ class BaseNDClass(object):
     @property
     def mask(self):
         return self._mask
+
+
+class SpatialCoordMixinClass(object):
+
+    @cube_utils.slice_syntax
+    def world(self, view):
+        """
+        Return a list of the world coordinates in a cube (or a view of it).
+
+        Cube.world is called with *bracket notation*, like a NumPy array::
+            c.world[0:3, :, :]
+
+        Returns
+        -------
+        [v, y, x] : list of NumPy arrays
+            The 3 world coordinates at each pixel in the view. For a 2D image,
+            the output is [y, x].
+
+
+        Examples
+        --------
+        Extract the first 3 velocity channels of the cube:
+        >>> v, y, x = c.world[0:3]
+
+        Extract all the world coordinates
+        >>> v, y, x = c.world[:, :, :]
+
+        Extract every other pixel along all axes
+        >>> v, y, x = c.world[::2, ::2, ::2]
+
+        Extract all the world coordinates for a 2D image:
+        >>> y, x = c.world[:, :]
+
+        """
+
+        # note: view is a tuple of view
+
+        # the next 3 lines are equivalent to (but more efficient than)
+        # inds = np.indices(self._data.shape)
+        # inds = [i[view] for i in inds]
+        inds = np.ogrid[[slice(0, s) for s in self.shape]]
+        inds = np.broadcast_arrays(*inds)
+        inds = [i[view] for i in inds[::-1]]  # numpy -> wcs order
+
+        shp = inds[0].shape
+        inds = np.column_stack([i.ravel() for i in inds])
+        world = self._wcs.all_pix2world(inds, 0).T
+
+        world = [w.reshape(shp) for w in world]  # 1D->3D
+
+        # apply units
+        world = [w * u.Unit(self._wcs.wcs.cunit[i])
+                 for i, w in enumerate(world)]
+
+        # convert spectral unit if needed
+        if len(self.shape) > 2:
+            if self._spectral_unit is not None:
+                world[2] = world[2].to(self._spectral_unit)
+
+        return world[::-1]  # reverse WCS -> numpy order
+
+    def world_spines(self):
+        """
+        Returns a list of 1D arrays, for the world coordinates
+        along each pixel axis.
+
+        Raises error if this operation is ill-posed (e.g. rotated world
+        coordinates, strong distortions)
+
+        This method is not currently implemented. Use :meth:`world` instead.
+        """
+        raise NotImplementedError()
+
+    @property
+    def spatial_coordinate_map(self):
+        if self.ndim > 2:
+            return self.world[0, :, :][1:]
+        else:
+            return self.world[1:]
+
+    @property
+    @cached
+    def world_extrema(self):
+        lat, lon = self.spatial_coordinate_map
+        _lon_min = lon.min()
+        _lon_max = lon.max()
+        _lat_min = lat.min()
+        _lat_max = lat.max()
+
+        return ((_lon_min, _lon_max),
+                (_lat_min, _lat_max))
+
+    @property
+    @cached
+    def longitude_extrema(self):
+        return self.world_extrema[0]
+
+    @property
+    @cached
+    def latitude_extrema(self):
+        return self.world_extrema[1]
+
 
 class SpectralAxisMixinClass(object):
 

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -52,9 +52,11 @@ class SpatialCoordMixinClass(object):
     @cube_utils.slice_syntax
     def world(self, view):
         """
-        Return a list of the world coordinates in a cube (or a view of it).
+        Return a list of the world coordinates in a cube, projection, or a view
+        of it.
 
-        Cube.world is called with *bracket notation*, like a NumPy array::
+        SpatialCoordMixinClass.world is called with *bracket notation*, like
+        a NumPy array::
             c.world[0:3, :, :]
 
         Returns
@@ -123,11 +125,8 @@ class SpatialCoordMixinClass(object):
 
     @property
     def spatial_coordinate_map(self):
-
-        if self.ndim > 2:
-            return self.world[0, :, :][1:]
-        else:
-            return self.world[1:]
+        view = [0 for ii in range(self.ndim - 2)] + [slice(None)] * 2
+        return self.world[view][self.ndim - 2:]
 
     @property
     @cached

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -245,6 +245,24 @@ def iterator_strategy(cube, axis=None):
     return 'slice'
 
 
+def try_load_beam(header):
+    '''
+    Try loading a beam from a FITS header.
+    '''
+    try:
+        from radio_beam import Beam
+    except ImportError:
+        warnings.warn("radio_beam is not installed. No beam "
+                      "can be created.")
+
+    try:
+        beam = Beam.from_fits_header(header)
+        return beam
+    except Exception as ex:
+        warnings.warn("Could not parse beam information from header."
+                      "  Exception was: {0}".format(ex.__repr__()))
+
+
 def beams_to_bintable(beams):
     """
     Convert a list of beams to a CASA-style BinTableHDU

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -11,7 +11,6 @@ from .cube_utils import convert_bunit
 
 import numpy as np
 from astropy import convolution
-from astropy.utils.console import ProgressBar
 
 from .base_class import BaseNDClass, SpectralAxisMixinClass, SpatialCoordMixinClass
 from . import cube_utils

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -14,7 +14,7 @@ from astropy import convolution
 from astropy.utils.console import ProgressBar
 
 from .base_class import BaseNDClass, SpectralAxisMixinClass
-from .cube_utils import beams_to_bintable
+from .cube_utils import beams_to_bintable, try_load_beam
 
 __all__ = ['LowerDimensionalObject', 'Projection', 'Slice', 'OneDSpectrum']
 
@@ -206,6 +206,10 @@ class Projection(LowerDimensionalObject):
             meta["BUNIT"] = hdu.header["BUNIT"]
         else:
             unit = None
+
+        beam = try_load_beam(hdu.header)
+        if beam is not None:
+            meta['beam'] = beam
 
         self = Projection(hdu.data, unit=unit, wcs=mywcs, meta=meta,
                           header=hdu.header)

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -12,7 +12,8 @@ from .cube_utils import convert_bunit
 import numpy as np
 from astropy import convolution
 
-from .base_class import BaseNDClass, SpectralAxisMixinClass, SpatialCoordMixinClass
+from .base_class import (BaseNDClass, SpectralAxisMixinClass,
+                         SpatialCoordMixinClass)
 from . import cube_utils
 
 __all__ = ['LowerDimensionalObject', 'Projection', 'Slice', 'OneDSpectrum']

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -82,7 +82,7 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
 
     def to(self, unit, equivalencies=[]):
         """
-        Return a new `LowerDimensionalObject` of the same class with the
+        Return a new `~spectral_cube.lower_dimensional_structures.LowerDimensionalObject` of the same class with the
         specified unit.
 
         See `astropy.units.Quantity.to` for further details.
@@ -102,7 +102,7 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
 
     def __getitem__(self, key, **kwargs):
         """
-        Return a new ``LowerDimensionalObject'' of the same class while keeping
+        Return a new `~spectral_cube.lower_dimensional_structures.LowerDimensionalObject` of the same class while keeping
         other properties fixed.
         """
         new_qty = super(LowerDimensionalObject, self).__getitem__(key)
@@ -163,7 +163,7 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
     @property
     def quantity(self):
         """
-        Get a pure `astropy.units.Quantity` representation of the LDO.
+        Get a pure `~astropy.units.Quantity` representation of the LDO.
         """
         return u.Quantity(self)
 

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -283,8 +283,8 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
 
         Returns
         -------
-        cube : `SpectralCube`
-            A SpectralCube with a single ``beam``
+        proj : `Projection`
+            A Projection convolved to the given ``beam`` object.
         """
 
         self._raise_wcs_no_celestial()
@@ -307,8 +307,7 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
 
     def reproject(self, header, order='bilinear'):
         """
-        Reproject the cube into a new header.  Fills the data with the cube's
-        ``fill_value`` to replace bad values before reprojection.
+        Reproject the image into a new header.
 
         Parameters
         ----------

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -192,12 +192,13 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
         else:
             if "beam" in self.meta:
                 self._beam = self.meta['beam']
-            else:
-                if read_beam:
-                    beam = cube_utils.try_load_beam(header)
-                    if beam is not None:
-                        self._beam = beam
-                        self.meta['beam'] = beam
+            elif read_beam:
+                beam = cube_utils.try_load_beam(header)
+                if beam is not None:
+                    self._beam = beam
+                    self.meta['beam'] = beam
+                else:
+                    warnings.warn("Cannot load beam from header.")
 
         return self
 
@@ -269,7 +270,7 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
 
     def convolve_to(self, beam, convolve=convolution.convolve_fft):
         """
-        Convolve each channel in the cube to a specified beam
+        Convolve the image to a specified beam.
 
         Parameters
         ----------

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -368,7 +368,7 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
 
         Parameters
         ----------
-        [xy]lo/[xy]hi : int or `Quantity` or `min`/`max`
+        [xy]lo/[xy]hi : int or `astropy.units.Quantity` or `min`/`max`
             The endpoints to extract.  If given as a quantity, will be
             interpreted as World coordinates.  If given as a string or
             int, will be interpreted as pixel coordinates.

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -271,6 +271,8 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
             A SpectralCube with a single ``beam``
         """
 
+        self._raise_wcs_no_celestial()
+
         if not "beam" in self.meta:
             raise ValueError("No beam is contained in Projection.meta.")
 
@@ -310,6 +312,8 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
             or an integer. A value of ``0`` indicates nearest neighbor
             interpolation.
         """
+
+        self._raise_wcs_no_celestial()
 
         try:
             from reproject.version import version
@@ -353,6 +357,8 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
             interpreted as World coordinates.  If given as a string or
             int, will be interpreted as pixel coordinates.
         """
+
+        self._raise_wcs_no_celestial()
 
         limit_dict = {'xlo': 0 if xlo == 'min' else xlo,
                       'ylo': 0 if ylo == 'min' else ylo,

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -290,7 +290,7 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
 
         self._raise_wcs_no_celestial()
 
-        if not "beam" in self.meta:
+        if not hasattr(self, 'beam'):
             raise ValueError("No beam is contained in Projection.meta.")
 
         pixscale = wcs.utils.proj_plane_pixel_area(self.wcs.celestial)**0.5 * u.deg

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1449,10 +1449,6 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass, SpatialCoordMixinCla
         """
         return spectral_axis.determine_vconv_from_ctype(self.wcs.wcs.ctype[self.wcs.wcs.spec])
 
-    # @property
-    # def spatial_coordinate_map(self):
-    #     return self.world[0, :, :][1:]
-
     def closest_spectral_channel(self, value):
         """
         Find the index of the closest spectral channel to the specified

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -40,8 +40,7 @@ from distutils.version import LooseVersion
 __all__ = ['SpectralCube', 'VaryingResolutionSpectralCube']
 
 # apply_everywhere, world: do not have a valid cube to test on
-__doctest_skip__ = ['BaseSpectralCube.world',
-                    'BaseSpectralCube._apply_everywhere']
+__doctest_skip__ = ['BaseSpectralCube._apply_everywhere']
 
 try:
     from scipy import ndimage
@@ -821,6 +820,10 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass, SpatialCoordMixinCla
         Retrieve the world coordinates corresponding to the extracted flattened
         version of the cube
         """
+
+        # NOTE: this should be moved to SpatialCoordMixinClass once masks
+        # are implemented for lower dim objects - EK
+
         lon,lat,spec = self.world[view]
         spec = self._mask._flattened(data=spec, wcs=self._wcs, view=slice)
         lon = self._mask._flattened(data=lon, wcs=self._wcs, view=slice)

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -184,11 +184,11 @@ class BaseSpectralCube(BaseNDClass, SpectralAxisMixinClass, SpatialCoordMixinCla
 
     def _attach_beam(self):
 
-            beam = cube_utils.try_load_beam(self.header)
+        beam = cube_utils.try_load_beam(self.header)
 
-            if beam is not None:
-                self.beam = beam
-                self._meta['beam'] = beam
+        if beam is not None:
+            self.beam = beam
+            self._meta['beam'] = beam
 
     @property
     def unit(self):

--- a/spectral_cube/tests/data/make_test_cubes.py
+++ b/spectral_cube/tests/data/make_test_cubes.py
@@ -141,3 +141,8 @@ if __name__ == "__main__":
     h['BUNIT'] = 'K'
     d = np.arange(5 * 5).reshape((5, 5))
     fits.writeto('55.fits', d, h, clobber=True)
+
+    # test cube for convolution, regridding
+    d = np.zeros([5, 5], dtype='float')
+    d[2, 2] = 1.0
+    fits.writeto('55_delta.fits', d, h, clobber=True)

--- a/spectral_cube/tests/data/make_test_cubes.py
+++ b/spectral_cube/tests/data/make_test_cubes.py
@@ -132,3 +132,12 @@ if __name__ == "__main__":
     hdul = fits.HDUList([fits.PrimaryHDU(data=d, header=h),
                          beams])
     hdul.writeto('522_delta_beams.fits', clobber=True)
+
+    # Make a 2D spatial version
+    h = fits.header.Header.fromtextfile(HEADER_FILENAME)
+    for k in list(h.keys()):
+        if k.endswith('4') or k.endswith('3'):
+            del h[k]
+    h['BUNIT'] = 'K'
+    d = np.arange(5 * 5).reshape((5, 5))
+    fits.writeto('55.fits', d, h, clobber=True)

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -5,10 +5,12 @@ import pytest
 import numpy as np
 from astropy import units as u
 from astropy.wcs import WCS
+from astropy.io import fits
 
 from .helpers import assert_allclose
 from ..lower_dimensional_structures import Projection, Slice, OneDSpectrum
 from ..utils import SliceWarning
+from . import path
 
 try:
     from radio_beam import Beam
@@ -29,6 +31,15 @@ data_two = (two_qty_2d, two_qty_2d, two_qty_1d)
 data_twelve = (twelve_qty_2d, twelve_qty_2d, twelve_qty_1d)
 data_two_2d = (two_qty_2d, two_qty_2d,)
 data_twelve_2d = (twelve_qty_2d, twelve_qty_2d,)
+
+
+def load_projection(filename):
+
+    hdu = fits.open(path(filename))[0]
+    proj = Projection.from_hdu(hdu)
+
+    return proj, hdu
+
 
 @pytest.mark.parametrize(('LDO', 'data'),
                          zip(LDOs_2d, data_two_2d))

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -288,9 +288,6 @@ def test_projection_subimage():
     assert proj2.shape == (5, 2)
     assert proj1.wcs.wcs.compare(proj2.wcs.wcs)
 
-    # Make sure the beam is kept
-    assert proj.beam == proj1.beam
-
     proj3 = proj.subimage(ylo=1, yhi=3)
     proj4 = proj.subimage(ylo=29.93464 * u.deg,
                           yhi=29.93522 * u.deg)
@@ -316,4 +313,3 @@ def test_projection_subimage_nocelestial_fail():
         proj.subimage(xlo=1, xhi=3)
 
     assert exc.value.args[0] == ("WCS does not contain two spatial axes.")
-

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -241,3 +241,22 @@ def test_projection_from_hdu_with_beam(LDO, data):
 
     assert (p == p_new).all()
     assert beam == p_new.meta['beam']
+
+
+def test_projection_subimage():
+
+    proj, hdu = load_projection("55.fits")
+
+    proj1 = proj.subimage(xlo=1, xhi=3)
+    proj2 = proj.subimage(xlo=24.06269 * u.deg,
+                          xhi=24.06206 * u.deg)
+
+    assert proj1.shape == (5, 2)
+    assert proj2.shape == (5, 2)
+    assert proj1.wcs.wcs.compare(proj2.wcs.wcs)
+
+    proj3 = proj.subimage()
+
+    assert proj3.shape == proj.shape
+    assert proj3.wcs.wcs.compare(proj.wcs.wcs)
+    assert np.all(proj3.value == proj.value)

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -288,6 +288,9 @@ def test_projection_subimage():
     assert proj2.shape == (5, 2)
     assert proj1.wcs.wcs.compare(proj2.wcs.wcs)
 
+    # Make sure the beam is kept
+    assert proj.beam == proj1.beam
+
     proj3 = proj.subimage(ylo=1, yhi=3)
     proj4 = proj.subimage(ylo=29.93464 * u.deg,
                           yhi=29.93522 * u.deg)

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -257,12 +257,12 @@ def test_projection_subimage():
     assert proj1.wcs.wcs.compare(proj2.wcs.wcs)
 
     proj3 = proj.subimage(ylo=1, yhi=3)
-    proj3 = proj.subimage(ylo=29.93464 * u.deg,
+    proj4 = proj.subimage(ylo=29.93464 * u.deg,
                           yhi=29.93522 * u.deg)
 
     assert proj3.shape == (2, 5)
-    assert proj3.shape == (2, 5)
-    assert proj3.wcs.wcs.compare(proj3.wcs.wcs)
+    assert proj4.shape == (2, 5)
+    assert proj3.wcs.wcs.compare(proj4.wcs.wcs)
 
     proj5 = proj.subimage()
 

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -185,6 +185,7 @@ def test_spectral_interpolate_with_mask():
     assert cube.wcs.wcs.compare(orig_wcs.wcs)
 
 
+@pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
 def test_convolution_2D():
 
     proj, hdu = load_projection("55_delta.fits")
@@ -206,6 +207,7 @@ def test_convolution_2D():
     assert conv_proj.beam == target_beam
 
 
+@pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
 def test_nocelestial_convolution_2D_fail():
 
     cube, data = cube_and_raw('255_delta.fits')
@@ -242,6 +244,7 @@ def test_reproject_2D():
     assert result.beam == proj.beam
 
 
+@pytest.mark.skipif('not REPROJECT_INSTALLED')
 def test_nocelestial_reproject_2D_fail():
 
     cube, data = cube_and_raw('255_delta.fits')

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -7,6 +7,7 @@ from astropy import wcs
 from astropy.io import fits
 
 from .. import SpectralCube
+from ..utils import WCSCelestialError
 from .test_spectral_cube import cube_and_raw
 from .test_projection import load_projection
 from . import path
@@ -204,6 +205,20 @@ def test_convolution_2D():
                                    conv_proj.value)
 
 
+def test_nocelestial_convolution_2D_fail():
+
+    cube, data = cube_and_raw('255_delta.fits')
+
+    proj = cube.moment0(axis=1)
+
+    test_beam = Beam(1.0 * u.arcsec)
+
+    with pytest.raises(WCSCelestialError) as exc:
+        proj.convolve_to(test_beam)
+
+    assert exc.value.args[0] == ("WCS does not contain two spatial axes.")
+
+
 @pytest.mark.skipif('not REPROJECT_INSTALLED')
 def test_reproject_2D():
 
@@ -223,3 +238,15 @@ def test_reproject_2D():
     result = proj.reproject(header_out)
 
     assert result.shape == (5, 4)
+
+
+def test_nocelestial_reproject_2D_fail():
+
+    cube, data = cube_and_raw('255_delta.fits')
+
+    proj = cube.moment0(axis=1)
+
+    with pytest.raises(WCSCelestialError) as exc:
+        proj.reproject(cube.header)
+
+    assert exc.value.args[0] == ("WCS does not contain two spatial axes.")

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -203,6 +203,7 @@ def test_convolution_2D():
 
     np.testing.assert_almost_equal(expected.array,
                                    conv_proj.value)
+    assert conv_proj.beam == target_beam
 
 
 def test_nocelestial_convolution_2D_fail():
@@ -238,6 +239,7 @@ def test_reproject_2D():
     result = proj.reproject(header_out)
 
     assert result.shape == (5, 4)
+    assert result.beam == proj.beam
 
 
 def test_nocelestial_reproject_2D_fail():

--- a/spectral_cube/tests/test_subcubes.py
+++ b/spectral_cube/tests/test_subcubes.py
@@ -27,11 +27,19 @@ def test_subcube():
     assert sc2.shape == (2,3,2)
     assert sc1.wcs.wcs.compare(sc2.wcs.wcs)
 
-    sc3 = cube.subcube()
+    sc3 = cube.subcube(ylo=1, yhi=3)
+    sc4 = cube.subcube(ylo=29.93464 * u.deg,
+                       yhi=29.93522 * u.deg)
 
-    assert sc3.shape == cube.shape
-    assert sc3.wcs.wcs.compare(cube.wcs.wcs)
-    assert np.all(sc3._data == cube._data)
+    assert sc3.shape == (2, 2, 4)
+    assert sc4.shape == (2, 2, 4)
+    assert sc3.wcs.wcs.compare(sc4.wcs.wcs)
+
+    sc5 = cube.subcube()
+
+    assert sc5.shape == cube.shape
+    assert sc5.wcs.wcs.compare(cube.wcs.wcs)
+    assert np.all(sc5._data == cube._data)
 
 @pytest.mark.skipif('not pyregionOK', reason='Could not import pyregion')
 @pytest.mark.parametrize(('regfile','result'),
@@ -86,7 +94,7 @@ def test_ds9region_255(regfile):
     # THIS TEST FAILS!
     # I think the coordinate transformation in ds9 is wrong;
     # it uses kapteyn?
-    
+
     #region = 'circle(2,2,2)'
     #subcube = cube.subcube_from_ds9region(region)
 

--- a/spectral_cube/utils.py
+++ b/spectral_cube/utils.py
@@ -44,3 +44,6 @@ class SliceWarning(AstropyUserWarning):
 
 class BeamAverageWarning(AstropyUserWarning):
     pass
+
+class WCSCelestialError(Exception):
+    pass


### PR DESCRIPTION
Adds much of the spatial functionality from `SpectralCube` for a 2D spatial `Projection`.

* Added `SpatialCoordMixinClass` for world coordinates handling.
* Beam handling/loading for `Projection`
* `Projection.convolve_to` and `Projection.reproject`
* `Projection.subimage` for slicing with quantities (as in `SpectralCube.subcube`)
* `WCSCelestialError` is raised if the `Projection` does not have 2 spatial axes
*  Added 2D test images

Not all of the spatial functionality has been abstracted out of `SpectralCube`. Things like `SpectralCube.flattened_world` require mask handling to be implemented for lower dimensional objects. Same goes for `SpectralCube.subcube_from_ds9_region`, in its current implementation.