### PR TITLE
Fill values for spectral_interpolate

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2498,9 +2498,12 @@ class SpectralCube(BaseSpectralCube):
             If disabled, a warning will be raised when interpolating onto a
             grid that does not nyquist sample the existing grid.  Disable this
             if you have already appropriately smoothed the data.
-        fill_value : float
-            Value for cube interpolates outside of the original range
-            defined in the data
+
+        fill_value : float 
+            Value for extrapolated spectral values that lie outside of
+            the spectral range defined in the original data.  The
+            default is to use the nearest spectral channel in the
+            cube.
 
         Returns
         -------

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2486,9 +2486,9 @@ class SpectralCube(BaseSpectralCube):
         return newcube
 
     def spectral_interpolate(self, spectral_grid,
-                             suppress_smooth_warning=False):
-        """
-        Resample the cube spectrally onto a specific grid
+                             suppress_smooth_warning=False,
+                             fill_value=None):
+        """Resample the cube spectrally onto a specific grid
 
         Parameters
         ----------
@@ -2498,10 +2498,14 @@ class SpectralCube(BaseSpectralCube):
             If disabled, a warning will be raised when interpolating onto a
             grid that does not nyquist sample the existing grid.  Disable this
             if you have already appropriately smoothed the data.
+        fill_value : float
+            Value for cube interpolates outside of the original range
+            defined in the data
 
         Returns
         -------
         cube : SpectralCube
+
         """
 
         inaxis = self.spectral_axis.to(spectral_grid.unit)
@@ -2545,7 +2549,8 @@ class SpectralCube(BaseSpectralCube):
             mask = self.mask.include(view=(specslice, iy, ix))
             if any(mask):
                 newcube[:,iy,ix] = np.interp(spectral_grid.value, inaxis.value,
-                                             cubedata[specslice,iy,ix].value)
+                                             cubedata[specslice,iy,ix].value,
+                                             left=fill_value, right=fill_value)
                 if all(mask):
                     newmask[:,iy,ix] = True
                 else:

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -144,17 +144,17 @@ def test_spectral_interpolate():
 
 def test_spectral_interpolate_with_fillvalue():
 
-    cube, data = cube_and_raw('522_delta.fits')
-
-    orig_wcs = cube.wcs.deepcopy()
-
+#    cube, data = cube_and_raw('522_delta.fits')
+    cube = SpectralCube.read('522_delta.fits')
     # Step one channel out of bounds.
-    sg = 2*(cube.spectral_axis[0]) - cube.spectral_axis[1]
-    result = cube.spectral_interpolate(spectral_grid=sg, fill_value=42)
-
-    np.testing.assert_almost_equal(result[0,0,0].value,
-                                   42)
-
+    sg = ((cube.spectral_axis[0]) -
+          (cube.spectral_axis[1] - cube.spectral_axis[0]) *
+          np.linspace(1,4,4))
+    result = cube.spectral_interpolate(spectral_grid=sg,
+                                       fill_value=42)
+    np.testing.assert_almost_equal(result[:,0,0].value,
+                                   np.ones(4)*42)
+    
 
 @pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
 def test_spectral_interpolate_fail():

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -124,6 +124,7 @@ def test_spectral_smooth_fail():
                                  "common resolution with `convolve_to` before "
                                  "attempting spectral smoothed.")
 
+
 def test_spectral_interpolate():
 
     cube, data = cube_and_raw('522_delta.fits')
@@ -139,6 +140,21 @@ def test_spectral_interpolate():
                                    [0.0, 0.5, 0.5, 0.0])
 
     assert cube.wcs.wcs.compare(orig_wcs.wcs)
+
+
+def test_spectral_interpolate_with_fillvalue():
+
+    cube, data = cube_and_raw('522_delta.fits')
+
+    orig_wcs = cube.wcs.deepcopy()
+
+    # Step one channel out of bounds.
+    sg = 2*(cube.spectral_axis[0]) - cube.spectral_axis[1]
+    result = cube.spectral_interpolate(spectral_grid=sg, fill_value=42)
+
+    np.testing.assert_almost_equal(result[0,0,0].value,
+                                   [42, 42, 42 42])
+
 
 @pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
 def test_spectral_interpolate_fail():

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -144,8 +144,8 @@ def test_spectral_interpolate():
 
 def test_spectral_interpolate_with_fillvalue():
 
-#    cube, data = cube_and_raw('522_delta.fits')
-    cube = SpectralCube.read('522_delta.fits')
+    cube, data = cube_and_raw('522_delta.fits')
+
     # Step one channel out of bounds.
     sg = ((cube.spectral_axis[0]) -
           (cube.spectral_axis[1] - cube.spectral_axis[0]) *

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -153,7 +153,7 @@ def test_spectral_interpolate_with_fillvalue():
     result = cube.spectral_interpolate(spectral_grid=sg, fill_value=42)
 
     np.testing.assert_almost_equal(result[0,0,0].value,
-                                   [42, 42, 42 42])
+                                   42)
 
 
 @pytest.mark.skipif('not RADIO_BEAM_INSTALLED')


### PR DESCRIPTION
`spectral_interpolate` defaults to the `np.interp` behaviour for extrapolates, which is to retain the first / last value in the domain.  Also, pardon the mess.  I'm trying out writing tests, so this might take a few tries.