### PR TITLE
Make lower dimensional objects preserve their parent's header

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -48,7 +48,7 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
         if self.wcs is None:
             hdu = PrimaryHDU(self.value)
         else:
-            hdu = PrimaryHDU(self.value, header=self.wcs.to_header())
+            hdu = PrimaryHDU(self.value, header=self.header)
         hdu.header['BUNIT'] = self.unit.to_string(format='fits')
 
         if 'beam' in self.meta:

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -971,7 +971,7 @@ def test_preserves_header_values():
     cube, data = cube_and_raw('advs.fits')
     cube._meta['BUNIT'] = 'K'
     cube._unit = u.K
-    cube.header['OBJECT'] = 'TestName'
+    cube._header['OBJECT'] = 'TestName'
 
     proj = cube.sum(axis=0, how='auto')
     assert isinstance(proj, Projection)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -965,6 +965,19 @@ def test_twod_numpy(func, how, axis):
     np.testing.assert_equal(proj.value, dproj)
     assert cube.unit == proj.unit
 
+def test_preserves_header_values():
+    # Check that the non-WCS header parameters are preserved during projection
+
+    cube, data = cube_and_raw('advs.fits')
+    cube._meta['BUNIT'] = 'K'
+    cube._unit = u.K
+    cube.header['OBJECT'] = 'TestName'
+
+    proj = cube.sum(axis=0, how='auto')
+    assert isinstance(proj, Projection)
+    assert proj.header['OBJECT'] == 'TestName'
+    assert proj.hdu.header['OBJECT'] == 'TestName'
+
 @pytest.mark.parametrize('func',('sum','std','max','min','mean'))
 def test_oned_numpy(func):
     # Check that a numpy function returns an appropriate spectrum


### PR DESCRIPTION
This is a bugfix and comes with a regression test