### PR TITLE
Rename 'interpolate' functions to 'regrid'

### DIFF
--- a/docs/smoothing.rst
+++ b/docs/smoothing.rst
@@ -49,9 +49,9 @@ Example::
     kernel = Gaussian1DKernel(2.5)
     new_cube = cube.spectral_smooth(kernel)
 
-This can be useful if you want to interpolate onto a coarser grid but maintain
+This can be useful if you want to regrid onto a coarser grid but maintain
 Nyquist sampling.  You can then use the
-`~spectral_cube.SpectralCube.spectral_interpolate` method to regrid your
+`~spectral_cube.SpectralCube.spectral_regrid` method to regrid your
 smoothed spectrum onto a new grid.
 
 Say, for example, you have a cube with 0.5 km/s resolution, but you want to
@@ -63,7 +63,7 @@ resample it onto a 2 km/s grid.  You might then choose to smooth by a factor of
     fwhm_factor = np.sqrt(8*np.log(2))
 
     smcube = cube.spectral_smooth(Gaussian1DKernel(4/fwhm_factor))
-    interp_Cube = smcube.spectral_interpolate(new_axis,
+    interp_Cube = smcube.spectral_regrid(new_axis,
                                               suppress_smooth_warning=True)
 
 We include the ``suppress_smooth_warning`` override because there is no way for

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -392,8 +392,7 @@ class OneDSpectrum(LowerDimensionalObject,SpectralAxisMixinClass):
         return HDUList([hdu, beamhdu])
 
 
-    def spectral_interpolate(self, spectral_grid,
-                             suppress_smooth_warning=False):
+    def spectral_regrid(self, spectral_grid, suppress_smooth_warning=False):
         """
         Resample the spectrum onto a specific grid
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2485,9 +2485,8 @@ class SpectralCube(BaseSpectralCube):
 
         return newcube
 
-    def spectral_interpolate(self, spectral_grid,
-                             suppress_smooth_warning=False,
-                             fill_value=None):
+    def spectral_regrid(self, spectral_grid, suppress_smooth_warning=False,
+                        fill_value=None):
         """Resample the cube spectrally onto a specific grid
 
         Parameters
@@ -3144,9 +3143,9 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
 
         return newcube
 
-    def spectral_interpolate(self, *args, **kwargs):
+    def spectral_regrid(self, *args, **kwargs):
         raise AttributeError("VaryingResolutionSpectralCubes can't be "
-                             "spectrally interpolated.  Convolve to a "
+                             "spectrally regridded.  Convolve to a "
                              "common resolution with `convolve_to` before "
                              "attempting spectral interpolation.")
 

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -231,12 +231,12 @@ def test_convolve():
 
     np.testing.assert_allclose(spec, specsmooth)
 
-def test_spectral_interpolate():
+def test_spectral_regrid():
     test_wcs_1 = WCS(naxis=1)
     test_wcs_1.wcs.cunit[0] = 'GHz'
     spec = OneDSpectrum(np.arange(12)*u.Jy, wcs=test_wcs_1)
 
     new_xaxis = test_wcs_1.wcs_pix2world(np.linspace(0,11,23), 0)[0] * u.Unit(test_wcs_1.wcs.cunit[0])
-    new_spec = spec.spectral_interpolate(new_xaxis)
+    new_spec = spec.spectral_regrid(new_xaxis)
 
     np.testing.assert_allclose(new_spec, np.linspace(0,11,23)*u.Jy)

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -125,7 +125,7 @@ def test_spectral_smooth_fail():
                                  "attempting spectral smoothed.")
 
 
-def test_spectral_interpolate():
+def test_spectral_regrid():
 
     cube, data = cube_and_raw('522_delta.fits')
 
@@ -134,7 +134,7 @@ def test_spectral_interpolate():
     # midpoint between each position
     sg = (cube.spectral_axis[1:] + cube.spectral_axis[:-1])/2.
 
-    result = cube.spectral_interpolate(spectral_grid=sg)
+    result = cube.spectral_regrid(spectral_grid=sg)
 
     np.testing.assert_almost_equal(result[:,0,0].value,
                                    [0.0, 0.5, 0.5, 0.0])
@@ -142,7 +142,7 @@ def test_spectral_interpolate():
     assert cube.wcs.wcs.compare(orig_wcs.wcs)
 
 
-def test_spectral_interpolate_with_fillvalue():
+def test_spectral_regrid_with_fillvalue():
 
     cube, data = cube_and_raw('522_delta.fits')
 
@@ -150,31 +150,30 @@ def test_spectral_interpolate_with_fillvalue():
     sg = ((cube.spectral_axis[0]) -
           (cube.spectral_axis[1] - cube.spectral_axis[0]) *
           np.linspace(1,4,4))
-    result = cube.spectral_interpolate(spectral_grid=sg,
-                                       fill_value=42)
+    result = cube.spectral_regrid(spectral_grid=sg, fill_value=42)
     np.testing.assert_almost_equal(result[:,0,0].value,
                                    np.ones(4)*42)
     
 
 @pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
-def test_spectral_interpolate_fail():
+def test_spectral_regrid_fail():
 
     cube, data = cube_and_raw('522_delta_beams.fits')
 
     with pytest.raises(AttributeError) as exc:
-        cube.spectral_interpolate(5)
+        cube.spectral_regrid(5)
 
     assert exc.value.args[0] == ("VaryingResolutionSpectralCubes can't be "
-                                 "spectrally interpolated.  Convolve to a "
+                                 "spectrally regridded.  Convolve to a "
                                  "common resolution with `convolve_to` before "
                                  "attempting spectral interpolation.")
 
 
-def test_spectral_interpolate_with_mask():
+def test_spectral_regrid_with_mask():
 
     hdu = fits.open(path("522_delta.fits"))[0]
 
-    # Swap the velocity axis so indiff < 0 in spectral_interpolate
+    # Swap the velocity axis so indiff < 0 in spectral_regrid
     hdu.header["CDELT3"] = - hdu.header["CDELT3"]
 
     cube = SpectralCube.read(hdu)
@@ -189,7 +188,7 @@ def test_spectral_interpolate_with_mask():
     # midpoint between each position
     sg = (cube.spectral_axis[1:] + cube.spectral_axis[:-1])/2.
 
-    result = masked_cube.spectral_interpolate(spectral_grid=sg[::-1])
+    result = masked_cube.spectral_regrid(spectral_grid=sg[::-1])
 
     # The output makes CDELT3 > 0 (reversed spectral axis) so the masked
     # portion are the final 2 channels.


### PR DESCRIPTION
The 'interpolate' functions are all doing regridding, so that's a better name for them.

cc @astrofrog