### PR TITLE
Preserve order of spectral grid when interpolating

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2429,7 +2429,7 @@ class SpectralCube(BaseSpectralCube):
             outdiff = np.mean(np.diff(spectral_grid))
             outslice = slice(None, None, -1)
         else:
-            outslice = slice(None)
+            outslice = slice(None, None, 1)
 
         cubedata = self.filled_data
         specslice = slice(None) if indiff >= 0 else slice(None, None, -1)

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -156,7 +156,7 @@ def test_spectral_interpolate_with_fillvalue():
                                        fill_value=42)
     np.testing.assert_almost_equal(result[:,0,0].value,
                                    np.ones(4)*42)
-    
+
 
 @pytest.mark.skipif('not RADIO_BEAM_INSTALLED')
 def test_spectral_interpolate_fail():
@@ -199,6 +199,20 @@ def test_spectral_interpolate_with_mask():
                                    [0.0, 0.5, np.NaN, np.NaN])
 
     assert cube.wcs.wcs.compare(orig_wcs.wcs)
+
+
+def test_spectral_interpolate_reversed():
+
+    cube, data = cube_and_raw('522_delta.fits')
+
+    orig_wcs = cube.wcs.deepcopy()
+
+    # Reverse spectral axis
+    sg = cube.spectral_axis[::-1]
+
+    result = cube.spectral_interpolate(spectral_grid=sg)
+
+    np.testing.assert_almost_equal(sg.value, result.spectral_axis.value)
 
 
 @pytest.mark.skipif('not RADIO_BEAM_INSTALLED')


### PR DESCRIPTION
`SpectralCube.spectral_interpolate` will reverse the order of the given `spectral_grid` if it is decreasing. It's more intuitive to always output in the same order as given.