### PR TITLE
Force normalization in convolution

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -300,7 +300,8 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
         convolution_kernel = \
             beam.deconvolve(self.beam).as_kernel(pixscale)
 
-        newdata = convolve(self.value, convolution_kernel)
+        newdata = convolve(self.value, convolution_kernel,
+                           normalize_kernel=True)
 
         self = Projection(newdata, unit=self.unit, wcs=self.wcs,
                           meta=self.meta, header=self.header,

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2521,7 +2521,8 @@ class SpectralCube(BaseSpectralCube):
 
         newdata = np.empty(self.shape)
         for ii,img in enumerate(self.filled_data[:]):
-            newdata[ii,:,:] = convolve(img, convolution_kernel)
+            newdata[ii,:,:] = convolve(img, convolution_kernel,
+                                       normalize_kernel=True)
             pb.update()
 
         newcube = self._new_cube_with(data=newdata, read_beam=False,
@@ -3044,7 +3045,8 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
             if kernel is None:
                 newdata[ii, :, :] = img
             else:
-                newdata[ii, :, :] = convolve(img, kernel)
+                newdata[ii, :, :] = convolve(img, kernel,
+                                             normalize_kernel=True)
             pb.update()
 
         newcube = SpectralCube(data=newdata, wcs=self.wcs, mask=self.mask,

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -41,6 +41,8 @@ def test_convolution():
                                             x_size=5, y_size=5,
                                            )
 
+    expected.normalize()
+
     np.testing.assert_almost_equal(expected.array,
                                    conv_cube.filled_data[0,:,:].value)
 
@@ -62,6 +64,7 @@ def test_beams_convolution():
     for ii,bm in enumerate(cube.beams):
         expected = target_beam.deconvolve(bm).as_kernel(pixscale, x_size=5,
                                                         y_size=5)
+        expected.normalize()
 
         np.testing.assert_almost_equal(expected.array,
                                        conv_cube.filled_data[ii,:,:].value)

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -234,6 +234,7 @@ def test_convolution_2D():
                                              (5.555555555555e-4*u.deg)).decompose().value,
                                             x_size=5, y_size=5,
                                            )
+    expected.normalize()
 
     np.testing.assert_almost_equal(expected.array,
                                    conv_proj.value)


### PR DESCRIPTION
The deconvolved beam kernels should be normalized when convolving. See #388  