### PR TITLE
Silence FITSFixedWarnings

### DIFF
--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -3,6 +3,7 @@ from __future__ import print_function, absolute_import, division
 import warnings
 
 from astropy.io import fits
+from astropy import wcs
 from astropy.wcs import WCS
 from astropy.extern import six
 from collections import OrderedDict
@@ -21,6 +22,7 @@ from .. import SpectralCube, StokesSpectralCube, LazyMask, VaryingResolutionSpec
 from ..spectral_cube import BaseSpectralCube
 from .. import cube_utils
 
+warnings.filterwarnings('ignore', category=wcs.FITSFixedWarning, append=True)
 
 def first(iterable):
     return next(iter(iterable))

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -48,6 +48,7 @@ try:
 except ImportError:
     scipyOK = False
 
+warnings.filterwarnings('ignore', category=wcs.FITSFixedWarning, append=True)
 
 SIGMA2FWHM = 2. * np.sqrt(2. * np.log(2.))
 


### PR DESCRIPTION
I've received multiple complaints from users about the repeated and noisy
`FITSFixedWarning`s raised by `wcs`, like these:

```
WARNING: FITSFixedWarning: PC01_01 = 1.000000000000E+00
indices in parameterized keywords must not have leading zeroes. [astropy.wcs.wcs]
```

CASA writes these with the leading zeros, and there's nothing we can do about
that.

Any objections?  @e-koch, @low-sky?

cc @eteq, @astrofrog: this is the sort of obvious usability issue we should
probably consider with nddata, specutils, etc.  Any objection to taking this
approach?