### PR TITLE
2D Lazy masks fail when indexed in 1D

### DIFF
--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -87,7 +87,10 @@ def view_of_subset(shp1, shp2, view):
         cv_view = [x for ii,x in enumerate([slice(None)]*3)
                    if ii not in dts]
 
-    return cv_view
+    # return type matters
+    # array[[0,0]] = [array[0], array[0]]
+    # array[(0,0)] = array[0,0]
+    return tuple(cv_view)
 
 class MaskBase(object):
 

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -350,9 +350,9 @@ def test_dims_to_skip(shp1, shp2, dim):
     assert dims_to_skip(shp1, shp2) == dim
 
 @pytest.mark.parametrize(('shp1','shp2', 'inview', 'outview'),
-                         (((5,5),(2,5,5),  [slice(0,1), slice(1,3), slice(2,4),], [slice(1,3), slice(2,4)]),
+                         (([5,5],[2,5,5],  (slice(0,1), slice(1,3), slice(2,4),), (slice(1,3), slice(2,4))),
                           # not a valid broadcast ([5,5],[5,5,2],  [slice(1,3), slice(2,4), slice(0,1),], [slice(1,3), slice(2,4)]),
-                          ((2,5,5),(2,5,5),[slice(0,1), slice(1,3), slice(2,4),], [slice(0,1), slice(1,3), slice(2,4),])))
+                          ([2,5,5],[2,5,5],(slice(0,1), slice(1,3), slice(2,4),), (slice(0,1), slice(1,3), slice(2,4),))))
 def test_view_of_subset(shp1, shp2, inview, outview):
     assert view_of_subset(shp1,shp2,inview) == outview
 

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -350,9 +350,9 @@ def test_dims_to_skip(shp1, shp2, dim):
     assert dims_to_skip(shp1, shp2) == dim
 
 @pytest.mark.parametrize(('shp1','shp2', 'inview', 'outview'),
-                         (([5,5],[2,5,5],  [slice(0,1), slice(1,3), slice(2,4),], [slice(1,3), slice(2,4)]),
+                         (((5,5),(2,5,5),  [slice(0,1), slice(1,3), slice(2,4),], [slice(1,3), slice(2,4)]),
                           # not a valid broadcast ([5,5],[5,5,2],  [slice(1,3), slice(2,4), slice(0,1),], [slice(1,3), slice(2,4)]),
-                          ([2,5,5],[2,5,5],[slice(0,1), slice(1,3), slice(2,4),], [slice(0,1), slice(1,3), slice(2,4),])))
+                          ((2,5,5),(2,5,5),[slice(0,1), slice(1,3), slice(2,4),], [slice(0,1), slice(1,3), slice(2,4),])))
 def test_view_of_subset(shp1, shp2, inview, outview):
     assert view_of_subset(shp1,shp2,inview) == outview
 
@@ -420,3 +420,13 @@ def test_1d_mask_amp():
     ampd = cube.mask & Mask
 
     ampd.include()
+
+def test_2dcomparison_mask_1d_index():
+    cube, data = cube_and_raw('adv.fits')
+
+    med = cube.median(axis=0)
+    mask = cube > med
+
+    mcube = cube.with_mask(mask)
+
+    spec = mcube[:,1,1]


### PR DESCRIPTION
This sort of masking + indexing:

    med = cube.median(axis=0)
    mask = cube > med

    mcube = cube.with_mask(mask)

    spec = mcube[:,1,1]

will result in a broadcast failure:

    ValueError: operands could not be broadcast together with shapes (4,) (2,2)

because the `comparison_value` is being indexed with the same view as the data.