### PR TITLE
Another fix to 1D masking

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -591,6 +591,10 @@ class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
 
             return new
         else:
+            if self._mask is not None:
+                # Kind of a hack; this is probably inefficient
+                bad = self._mask.exclude()[key]
+                new_qty[bad] = np.nan
             return new_qty
 
     @property

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -476,3 +476,19 @@ def test_1dcomparison_mask_1d_index():
     assert all(spec[:-1].mask.include() == [True,False,False])
 
     assert isinstance(spec[0], u.Quantity)
+
+def test_1dmask_indexing():
+    cube, data = cube_and_raw('adv.fits')
+
+    med = cube.median()
+    mask = cube > med
+
+    mcube = cube.with_mask(mask)
+
+    assert all(mask[:,1,1].include() ==
+               mask.include()[:,1,1])
+
+    spec = mcube[:,1,1]
+
+    assert np.all(np.isnan(spec[[False,True,True,False]]))
+    assert not np.any(np.isnan(spec[[True,False,False,True]]))

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -490,5 +490,6 @@ def test_1dmask_indexing():
 
     spec = mcube[:,1,1]
 
-    assert np.all(np.isnan(spec[[False,True,True,False]]))
-    assert not np.any(np.isnan(spec[[True,False,False,True]]))
+    badvals = np.array([False,True,True,False], dtype='bool')
+    assert np.all(np.isnan(spec[badvals]))
+    assert not np.any(np.isnan(spec[~badvals]))


### PR DESCRIPTION
When you index a masked object with a boolean array (or a single value), you should get NaN if the value was masked out.