### PR TITLE
Fix OneDSpectrum masking through interpolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,14 @@ env:
         - ASTROPY_VERSION=stable
         - CONDA_DEPENDENCIES='matplotlib aplpy'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
-        - PIP_DEPENDENCIES='pytest-xdist pvextractor'
+        - PIP_DEPENDENCIES='pvextractor'
         - SETUP_XVFB=True
 
     matrix:
         - SETUP_CMD='egg_info'
         - # run with default settings
         - ASTROPY_VERSION='development'
-        - CONDA_DEPENDENCIES='' PIP_DEPENDENCIES='pytest-xdist'
+        - CONDA_DEPENDENCIES='' PIP_DEPENDENCIES=''
 
 matrix:
     include:
@@ -48,7 +48,7 @@ matrix:
           env: SETUP_CMD='test --coverage'
                CONDA_DEPENDENCIES='matplotlib aplpy yt bottleneck'
                ASTROPY_VERSION='development'
-               PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pytest-xdist pvextractor'
+               PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pvextractor'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
@@ -67,15 +67,15 @@ matrix:
           env: NUMPY_VERSION=1.9 CONDA_DEPENDENCIES='matplotlib aplpy bottleneck'
         - python: 3.4
           env: NUMPY_VERSION=1.9 CONDA_DEPENDENCIES='matplotlib aplpy bottleneck'
-        
+
         # Test with radio-beam
         - python: 2.7
           env:
-              PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pytest-xdist pvextractor'
+              PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pvextractor'
               ASTROPY_VERSION='development'
         - python: 3.5
           env:
-              PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pytest-xdist pvextractor'
+              PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pvextractor'
               ASTROPY_VERSION='development'
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,14 @@ env:
         - ASTROPY_VERSION=stable
         - CONDA_DEPENDENCIES='matplotlib aplpy'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
-        - PIP_DEPENDENCIES='pvextractor'
+        - PIP_DEPENDENCIES='pytest-xdist pvextractor'
         - SETUP_XVFB=True
 
     matrix:
         - SETUP_CMD='egg_info'
         - # run with default settings
         - ASTROPY_VERSION='development'
-        - CONDA_DEPENDENCIES='' PIP_DEPENDENCIES=''
+        - CONDA_DEPENDENCIES='' PIP_DEPENDENCIES='pytest-xdist'
 
 matrix:
     include:
@@ -48,7 +48,7 @@ matrix:
           env: SETUP_CMD='test --coverage'
                CONDA_DEPENDENCIES='matplotlib aplpy yt bottleneck'
                ASTROPY_VERSION='development'
-               PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pvextractor'
+               PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pytest-xdist pvextractor'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
@@ -71,11 +71,11 @@ matrix:
         # Test with radio-beam
         - python: 2.7
           env:
-              PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pvextractor'
+              PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pytest-xdist pvextractor'
               ASTROPY_VERSION='development'
         - python: 3.5
           env:
-              PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pvextractor'
+              PIP_DEPENDENCIES='https://github.com/radio-astro-tools/radio_beam/archive/master.zip pytest-xdist pvextractor'
               ASTROPY_VERSION='development'
 
 install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,8 @@
 0.4.1 (unreleased)
 ------------------
+ - Check mask inputs to OneDSpectrum and add mask handling for
+   OneDSpectrum.spectral_interpolate
+   (https://github.com/radio-astro-tools/spectral-cube/pull/400)
  - Add creating a Projection from a FITS HDU
    (https://github.com/radio-astro-tools/spectral-cube/pull/376)
  - Deprecate numpy <=1.8 because nanmedian is needed

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -10,6 +10,9 @@ py:class spectral_cube.base_class.MaskableArrayMixinClass
 py:obj yt.surface.export_sketchfab
 py:obj yt.show_colormaps
 
+# aplpy reference
+py:obj aplpy.FITSFigure
+
 # numpy inherited docstrings
 py:obj dtype
 py:obj a

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -9,6 +9,7 @@ from astropy.io import fits
 
 from .helpers import assert_allclose
 from .test_spectral_cube import cube_and_raw
+from ..spectral_cube import SpectralCube
 from ..lower_dimensional_structures import Projection, Slice, OneDSpectrum
 from ..utils import SliceWarning, WCSCelestialError
 from . import path
@@ -347,6 +348,63 @@ def test_spectral_interpolate():
     new_spec = spec.spectral_interpolate(new_xaxis)
 
     np.testing.assert_allclose(new_spec, np.linspace(0,11,23)*u.Jy)
+
+
+def test_spectral_interpolate_with_mask():
+
+    hdu = fits.open(path("522_delta.fits"))[0]
+
+    # Swap the velocity axis so indiff < 0 in spectral_interpolate
+    hdu.header["CDELT3"] = - hdu.header["CDELT3"]
+
+    cube = SpectralCube.read(hdu)
+
+    mask = np.ones(cube.shape, dtype=bool)
+    mask[:2] = False
+
+    masked_cube = cube.with_mask(mask)
+
+    spec = masked_cube[:, 0, 0]
+
+    # midpoint between each position
+    sg = (spec.spectral_axis[1:] + spec.spectral_axis[:-1])/2.
+
+    result = spec.spectral_interpolate(spectral_grid=sg[::-1])
+
+    # The output makes CDELT3 > 0 (reversed spectral axis) so the masked
+    # portion are the final 2 channels.
+    np.testing.assert_almost_equal(result.filled_data[:].value,
+                                   [0.0, 0.5, np.NaN, np.NaN])
+
+def test_spectral_interpolate_reversed():
+
+    cube, data = cube_and_raw('522_delta.fits')
+
+    # Reverse spectral axis
+    sg = cube.spectral_axis[::-1]
+
+    spec = cube[:, 0, 0]
+
+    result = spec.spectral_interpolate(spectral_grid=sg)
+
+    np.testing.assert_almost_equal(sg.value, result.spectral_axis.value)
+
+def test_spectral_interpolate_with_fillvalue():
+
+    cube, data = cube_and_raw('522_delta.fits')
+
+    # Step one channel out of bounds.
+    sg = ((cube.spectral_axis[0]) -
+          (cube.spectral_axis[1] - cube.spectral_axis[0]) *
+          np.linspace(1,4,4))
+
+    spec = cube[:, 0, 0]
+
+    result = spec.spectral_interpolate(spectral_grid=sg,
+                                       fill_value=42)
+    np.testing.assert_almost_equal(result.value,
+                                   np.ones(4)*42)
+
 
 def test_spectral_units():
     # regression test for issue 391


### PR DESCRIPTION
Added mask handling for `OneDSpectrum.spectral_interpolate`. The mask has to be handled for `spectral_interpolate` to work since we now check whether the WCS in the mask is valid with the data.

Also:
* `MaskBase.quicklook` was converting to a Projection to view, but this is won't work when we need to import mask classes into the LDOs file. The quicklook is now a near copy-paste of the quicklook in `Projection`. I could add a general function to do this, but it's not a particularly important few lines... 
* `OneDSpectrum` checks the mask type when a new spectrum is made.