### PR TITLE
Fix mask behavor to work with numpy

### DIFF
--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -273,6 +273,12 @@ class MaskableArrayMixinClass(object):
         return u.Quantity(self._get_filled_data(view, fill=self._fill_value),
                           self.unit, copy=False)
 
+    def filled(self, fill_value=None):
+        if fill_value is not None:
+            return u.Quantity(self._get_filled_data(fill=fill_value),
+                              self.unit, copy=False)
+        return self.filled_data[:]
+
     @property
     def fill_value(self):
         """ The replacement value used by :meth:`filled_data`.

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -1,11 +1,17 @@
 from __future__ import print_function, absolute_import, division
 
 import warnings
+
+import numpy as np
+from numpy.ma.core import nomask
+
+from astropy import convolution
 from astropy import units as u
 from astropy import wcs
 from astropy import convolution
 #from astropy import log
 from astropy.io.fits import Header, Card, HDUList, PrimaryHDU
+
 from .io.core import determine_format
 from . import spectral_axis
 from .utils import SliceWarning

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -8,7 +8,6 @@ from numpy.ma.core import nomask
 from astropy import convolution
 from astropy import units as u
 from astropy import wcs
-from astropy import convolution
 #from astropy import log
 from astropy.io.fits import Header, Card, HDUList, PrimaryHDU
 
@@ -18,11 +17,6 @@ from .utils import SliceWarning
 from .cube_utils import convert_bunit
 from . import wcs_utils
 from .masks import BooleanArrayMask, MaskBase
-
-from np.ma.core import nomask
-
-import numpy as np
-from astropy import convolution
 
 from .base_class import (BaseNDClass, SpectralAxisMixinClass,
                          SpatialCoordMixinClass, MaskableArrayMixinClass)

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -13,6 +13,8 @@ from .cube_utils import convert_bunit
 from . import wcs_utils
 from .masks import BooleanArrayMask, MaskBase
 
+from np.ma.core import nomask
+
 import numpy as np
 from astropy import convolution
 
@@ -145,14 +147,14 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
                              copy=False,
                              wcs=newwcs,
                              meta=self._meta,
-                             mask=(self._mask[key] if self._mask is not None
+                             mask=(self._mask[key] if self._mask is not nomask
                                    else None),
                              header=self._header,
                              **kwargs)
 
         new._wcs = newwcs
         new._meta = self._meta
-        new._mask=(self._mask[key] if self._mask is not None else None)
+        new._mask=(self._mask[key] if self._mask is not nomask else nomask)
         new._header = self._header
 
         return new
@@ -192,7 +194,7 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
         like using __ but I think it's necessary here)"""
         if self.__mask is None:
             # need this to be *exactly* the numpy boolean False
-            return np.ma.core.nomask
+            return nomask
         return self.__mask
 
     @_mask.setter
@@ -614,8 +616,9 @@ class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
                                  wcs=wcs_utils.slice_wcs(self._wcs, key,
                                                          shape=self.shape),
                                  meta=self._meta,
-                                 mask=(self._mask[key] if self._mask is not
-                                       None else None),
+                                 mask=(self._mask[key]
+                                       if self._mask is not nomask
+                                       else nomask),
                                  header=self._header,
                                  wcs_tolerance=self._wcs_tolerance,
                                  fill_value=self.fill_value,
@@ -623,7 +626,7 @@ class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
 
             return new
         else:
-            if self._mask is not None:
+            if self._mask is not nomask:
                 # Kind of a hack; this is probably inefficient
                 bad = self._mask.exclude()[key]
                 new_qty[bad] = np.nan

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -191,7 +191,8 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
         """ Annoying hack to deal with np.ma.core.is_mask failures (I don't
         like using __ but I think it's necessary here)"""
         if self.__mask is None:
-            return False
+            # need this to be *exactly* the numpy boolean False
+            return np.ma.core.nomask
         return self.__mask
 
     @_mask.setter

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -186,6 +186,16 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
         """
         return u.Quantity(self)
 
+    @property
+    def _mask(self):
+        """ Annoying hack to deal with np.ma.core.is_mask failures (I don't
+        like using __ but I think it's necessary here)"""
+        return self.__mask
+
+    @_mask.setter
+    def __mask(self, value):
+        self.__mask = value
+
 class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
 
     def __new__(cls, value, unit=None, dtype=None, copy=True, wcs=None,

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -190,10 +190,12 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
     def _mask(self):
         """ Annoying hack to deal with np.ma.core.is_mask failures (I don't
         like using __ but I think it's necessary here)"""
+        if self.__mask is None:
+            return False
         return self.__mask
 
     @_mask.setter
-    def __mask(self, value):
+    def _mask(self, value):
         self.__mask = value
 
 class Projection(LowerDimensionalObject, SpatialCoordMixinClass):

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -139,6 +139,9 @@ class MaskBase(object):
     def _exclude(self, data=None, wcs=None, view=()):
         return ~self._include(data=data, wcs=wcs, view=view)
 
+    def any(self):
+        return np.any(self.exclude())
+
     def _flattened(self, data, wcs=None, view=()):
         """
         Return a flattened array of the included elements of cube

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -525,3 +525,21 @@ def test_numpy_ma_tools_2d():
 
     assert np.ma.core.is_masked(mcube[0,:,:])
     assert np.ma.core.getmask(mcube[0,:,:]) is not None
+
+
+def test_filled():
+    """ test that 'filled' works """
+
+    cube, data = cube_and_raw('adv.fits')
+
+    med = cube.median()
+    mask = cube > med
+
+    mcube = cube.with_mask(mask)
+    assert np.isnan(mcube._fill_value)
+
+    filled = mcube.filled(np.nan)
+    filled_ = mcube.filled()
+    assert_allclose(filled, filled_)
+
+    assert (np.isnan(filled) == mcube.mask.exclude()).all()

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -493,3 +493,22 @@ def test_1dmask_indexing():
     badvals = np.array([False,True,True,False], dtype='bool')
     assert np.all(np.isnan(spec[badvals]))
     assert not np.any(np.isnan(spec[~badvals]))
+
+def test_numpy_ma_tools():
+    """
+    check that np.ma.core.is_masked works
+    """
+
+    cube, data = cube_and_raw('adv.fits')
+
+    med = cube.median()
+    mask = cube > med
+
+    mcube = cube.with_mask(mask)
+
+    assert np.ma.core.is_masked(mcube)
+    assert np.ma.core.getmask(mcube) is not None
+    assert np.ma.core.is_masked(mcube[0,:,:])
+    assert np.ma.core.getmask(mcube[0,:,:]) is not None
+    assert np.ma.core.is_masked(mcube[:,0,0])
+    assert np.ma.core.getmask(mcube[:,0,0]) is not None

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -508,7 +508,20 @@ def test_numpy_ma_tools():
 
     assert np.ma.core.is_masked(mcube)
     assert np.ma.core.getmask(mcube) is not None
-    assert np.ma.core.is_masked(mcube[0,:,:])
-    assert np.ma.core.getmask(mcube[0,:,:]) is not None
     assert np.ma.core.is_masked(mcube[:,0,0])
     assert np.ma.core.getmask(mcube[:,0,0]) is not None
+
+@pytest.mark.xfail
+def test_numpy_ma_tools_2d():
+    """ This depends on 2D objects keeping masks, which depends on #395.
+    so, TODO: un-xfail this """
+
+    cube, data = cube_and_raw('adv.fits')
+
+    med = cube.median()
+    mask = cube > med
+
+    mcube = cube.with_mask(mask)
+
+    assert np.ma.core.is_masked(mcube[0,:,:])
+    assert np.ma.core.getmask(mcube[0,:,:]) is not None


### PR DESCRIPTION
numpy doesn't behave well if mask is None; it has to be False


(this PR is also intended to provide an independent test of the pytest-xdist failures on travis)