### PR TITLE
set beam when averaging beams in a projection

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2944,6 +2944,7 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
             if need_to_handle_beams:
                 avg_beam = self.average_beams(beam_threshold, warn=True)
                 result.meta['beam'] = avg_beam
+                result._beam = avg_beam
 
             return result
 


### PR DESCRIPTION
simple fix - Projection.meta['beam'] was set, but not Projection._beam