### PR TITLE
Reorder beam averaging

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2937,12 +2937,6 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
             """ Wrapper function around the standard operations to handle beams
             when creating projections """
 
-            result = function(*args, **kwargs)
-
-            if not isinstance(result, LowerDimensionalObject):
-                # numpy arrays are sometimes returned; these have no metadata
-                return result
-
             # check that the spectral axis is being operated over.  If it is,
             # we need to average beams
             # moments are a special case b/c they default to axis=0
@@ -2954,7 +2948,17 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
                                      function.__name__))
 
             if need_to_handle_beams:
+                # do this check *first* so we don't do an expensive operation
+                # and crash afterward
                 avg_beam = self.average_beams(beam_threshold, warn=True)
+
+            result = function(*args, **kwargs)
+
+            if not isinstance(result, LowerDimensionalObject):
+                # numpy arrays are sometimes returned; these have no metadata
+                return result
+
+            elif need_to_handle_beams:
                 result.meta['beam'] = avg_beam
                 result._beam = avg_beam
 


### PR DESCRIPTION
Error messages like this one:
```
In [3]: med = cube.median(axis=0)
Traceback (most recent call last):
  File "<ipython-input-3-245cfb0bb659>", line 1, in <module>
    med = cube.median(axis=0)
  File "/lustre/aginsbur/repos/spectral-cube/spectral_cube/spectral_cube.py", line 898, in median
    **kwargs)
  File "/lustre/aginsbur/repos/spectral-cube/spectral_cube/spectral_cube.py", line 2945, in newfunc
    avg_beam = self.average_beams(beam_threshold, warn=True)
  File "/lustre/aginsbur/repos/spectral-cube/spectral_cube/spectral_cube.py", line 2900, in average_beams
    self._check_beam_areas(threshold, mean_beam=new_beam, mask=beam_mask)
  File "/lustre/aginsbur/repos/spectral-cube/spectral_cube/spectral_cube.py", line 2785, in _check_beam_areas
    raise ValueError(errormessage)
ValueError: Beam majors differ by up to 0.011929581382873871x, which is greater than the threshold 0.01
Beam srs differ by up to 0.015317526922288244x, which is greater than the threshold 0.01
```
were possible after performing very computationally expensive operations.  This
PR will do the check before the costly operation.