### PR TITLE
Don't warn if no beam was found

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
    (https://github.com/radio-astro-tools/spectral-cube/pull/373)
  - Add tools for masking bad beams in VaryingResolutionSpectralCubes
    (https://github.com/radio-astro-tools/spectral-cube/pull/373)
+ - Don't warn if no beam was found in a cube
+   (https://github.com/radio-astro-tools/spectral-cube/pull/422)
 
 0.4.0 (2016-09-06)
 ------------------

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -256,8 +256,11 @@ def try_load_beam(header):
         beam = Beam.from_fits_header(header)
         return beam
     except Exception as ex:
-        warnings.warn("Could not parse beam information from header."
-                      "  Exception was: {0}".format(ex.__repr__()))
+        # We don't emit a warning if no beam was found since it's ok for
+        # cubes to not have beams
+        if 'No BMAJ' not in str(ex):
+            warnings.warn("Could not parse beam information from header."
+                          "  Exception was: {0}".format(ex.__repr__()))
 
 
 def beams_to_bintable(beams):


### PR DESCRIPTION
Fixes https://github.com/radio-astro-tools/spectral-cube/issues/422

In future if we merge https://github.com/radio-astro-tools/radio_beam/pull/57 then we can do this more cleanly without looking at the exception message.
