### PR TITLE
Attach custom beam

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.4.1 (unreleased)
 ------------------
-
+ - Add SpectralCube.with_beam and Projection.with_beam for attaching
+   beam objects. Raise error for position-spectral slices of VRSCs
+   (https://github.com/radio-astro-tools/spectral-cube/pull/433)
  - Raise a nicer error if no data is present in the default or
    selected HDU
    (https://github.com/radio-astro-tools/spectral-cube/pull/424)

--- a/docs/beam_handling.rst
+++ b/docs/beam_handling.rst
@@ -33,11 +33,14 @@ If your cube does not have a beam, a custom beam can be attached given::
     >>> new_cube.beam  # doctest: +SKIP
     Beam: BMAJ=3600.0 arcsec BMIN=3600.0 arcsec BPA=0.0 deg
 
-This is handy for synthetic observations, which initially have a point-like beam:
+This is handy for synthetic observations, which initially have a point-like beam::
 
     >>> point_beam = Beam(0 * u.deg)  # doctest: +SKIP
     >>> new_cube = synth_cube.with_beam(point_beam)  # doctest: +SKIP
     Beam: BMAJ=0.0 arcsec BMIN=0.0 arcsec BPA=0.0 deg
+
+The cube can then be convolved to a new resolution::
+
     >>> new_beam = Beam(60 * u.arcsec)  # doctest: +SKIP
     >>> conv_synth_cube = synth_cube.convolve_to(new_beam)  # doctest: +SKIP
     >>> conv_synth_cube.beam  # doctest: +SKIP

--- a/docs/beam_handling.rst
+++ b/docs/beam_handling.rst
@@ -22,6 +22,29 @@ loading the entire cube into memory!::
    >>> kcube.unit  # doctest: +SKIP
    Unit("K")
 
+
+Adding a Beam
+-------------
+
+If your cube does not have a beam, a custom beam can be attached given::
+
+    >>> new_beam = Beam(1. * u.deg)  # doctest: +SKIP
+    >>> cube.attach_beam(new_beam)  # doctest: +SKIP
+    >>> cube.beam  # doctest: +SKIP
+    Beam: BMAJ=3600.0 arcsec BMIN=3600.0 arcsec BPA=0.0 deg
+
+This is handy for synthetic observations, which initially have a point-like beam:
+
+    >>> point_beam = Beam(0 * u.deg)  # doctest: +SKIP
+    >>> synth_cube.attach_beam(point_beam)  # doctest: +SKIP
+    >>> new_beam = Beam(60 * u.arcsec)  # doctest: +SKIP
+    >>> conv_synth_cube = synth_cube.convolve_to(new_beam)  # doctest: +SKIP
+    >>> conv_synth_cube.beam  # doctest: +SKIP
+    Beam: BMAJ=60.0 arcsec BMIN=60.0 arcsec BPA=0.0 deg
+
+Beam can also be attached in the same way for `~spectral_cube.Projection` and
+`~spectral_cube.Slice` objects.
+
 Multi-beam cubes
 ----------------
 

--- a/docs/beam_handling.rst
+++ b/docs/beam_handling.rst
@@ -29,14 +29,15 @@ Adding a Beam
 If your cube does not have a beam, a custom beam can be attached given::
 
     >>> new_beam = Beam(1. * u.deg)  # doctest: +SKIP
-    >>> cube.attach_beam(new_beam)  # doctest: +SKIP
-    >>> cube.beam  # doctest: +SKIP
+    >>> new_cube = cube.with_beam(new_beam)  # doctest: +SKIP
+    >>> new_cube.beam  # doctest: +SKIP
     Beam: BMAJ=3600.0 arcsec BMIN=3600.0 arcsec BPA=0.0 deg
 
 This is handy for synthetic observations, which initially have a point-like beam:
 
     >>> point_beam = Beam(0 * u.deg)  # doctest: +SKIP
-    >>> synth_cube.attach_beam(point_beam)  # doctest: +SKIP
+    >>> new_cube = synth_cube.with_beam(point_beam)  # doctest: +SKIP
+    Beam: BMAJ=0.0 arcsec BMIN=0.0 arcsec BPA=0.0 deg
     >>> new_beam = Beam(60 * u.arcsec)  # doctest: +SKIP
     >>> conv_synth_cube = synth_cube.convolve_to(new_beam)  # doctest: +SKIP
     >>> conv_synth_cube.beam  # doctest: +SKIP

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -1,5 +1,6 @@
 py:class spectral_cube.spectral_cube.BaseSpectralCube
 py:obj radio_beam.Beam
+py:obj Beam
 py:obj astroquery.splatalogue.Splatalogue
 py:class spectral_cube.base_class.BaseNDClass
 py:class spectral_cube.base_class.SpectralAxisMixinClass

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -2,3 +2,4 @@
 numpy
 Cython
 -e git+http://github.com/astropy/astropy.git#egg=astropy
+-e git+http://github.com/radio-astro-tools/radio-beam.git#egg=radio_beam

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -17,6 +17,7 @@ from astropy.io.fits import BinTableHDU, Column
 from astropy import units as u
 import itertools
 import re
+from radio_beam import Beam
 
 
 def _fix_spectral(wcs):
@@ -267,8 +268,6 @@ def try_load_beam(header):
     Try loading a beam from a FITS header.
     '''
 
-    from radio_beam import Beam
-
     try:
         beam = Beam.from_fits_header(header)
         return beam
@@ -304,7 +303,7 @@ def try_load_beams(data):
                 if 'BPA' in hdu_item.data.names:
                     beam_table = hdu_item.data
                     return beam_table
-        
+
         try:
             # if there was a beam in a header, but not a beam table
             return beam

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -10,6 +10,7 @@ from astropy import units as u
 from astropy import wcs
 #from astropy import log
 from astropy.io.fits import Header, Card, HDUList, PrimaryHDU
+from radio_beam import Beam
 
 from .io.core import determine_format
 from . import spectral_axis
@@ -224,20 +225,35 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
             self._header = Header()
 
         if beam is not None:
-            self._beam = beam
-            self.meta['beam'] = beam
+            self.attach_beam(beam=beam)
         else:
             if "beam" in self.meta:
                 self._beam = self.meta['beam']
             elif read_beam:
                 beam = cube_utils.try_load_beam(header)
                 if beam is not None:
-                    self._beam = beam
-                    self.meta['beam'] = beam
+                    self.attach_beam(beam=beam)
                 else:
                     warnings.warn("Cannot load beam from header.")
 
         return self
+
+    def attach_beam(self, beam):
+        '''
+        Attach a new beam object to the Projection.
+
+        Parameters
+        ----------
+        beam : `~radio_beam.Beam`
+            A new beam object.
+        '''
+
+        if not isinstance(beam, Beam):
+            raise TypeError("beam must be a radio_beam.Beam object.")
+
+        self._beam = beam
+        self._meta['beam'] = beam
+        # self._header.update(beam.to_header_keywords())
 
     @property
     def beam(self):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2291,7 +2291,6 @@ class SpectralCube(BaseSpectralCube):
             self._meta['beam'] = beam
             self._header.update(beam.to_header_keywords())
 
-        if 'beam' in self._meta:
             self.pixels_per_beam = (self.beam.sr /
                                     (astropy.wcs.utils.proj_plane_pixel_area(self.wcs) *
                                      u.deg**2)).to(u.dimensionless_unscaled).value

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2679,8 +2679,7 @@ class SpectralCube(BaseSpectralCube):
                                        normalize_kernel=True)
             pb.update()
 
-        newcube = self._new_cube_with(data=newdata, read_beam=False,
-                                      beam=beam)
+        newcube = self._new_cube_with(data=newdata, beam=beam)
 
         return newcube
 
@@ -3213,7 +3212,6 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
                                meta=self.meta, fill_value=self.fill_value,
                                header=self.header,
                                allow_huge_operations=self.allow_huge_operations,
-                               read_beam=False,
                                beam=beam,
                                wcs_tolerance=self._wcs_tolerance)
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2853,6 +2853,16 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
 
             # Slice objects know how to parse Beam objects stored in the
             # metadata
+            # A 2D slice with a VRSC should not be allowed along a
+            # position-spectral axis
+            if not isinstance(self.beams[specslice], Beam):
+                raise AttributeError("2D slices along a spectral axis are not "
+                                     "allowed for "
+                                     "VaryingResolutionSpectralCubes. Convolve"
+                                     " to a common resolution with "
+                                     "`convolve_to` before attempting "
+                                     "position-spectral slicing.")
+
             meta['beam'] = self.beams[specslice]
             return Slice(value=self.filled_data[view],
                          wcs=newwcs,

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2740,7 +2740,6 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
             'pa':5.0}``
         """
         # these types of cube are undefined without the radio_beam package
-        from radio_beam import Beam
 
         beam_table = kwargs.pop('beam_table', None)
         beams = kwargs.pop('beams', None)
@@ -3005,7 +3004,6 @@ class VaryingResolutionSpectralCube(BaseSpectralCube):
         includemask : np.array
             A boolean array where ``True`` indicates the good beams
         """
-        from radio_beam import Beam
 
         includemask = np.ones(len(self.beams), dtype='bool')
 

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -282,6 +282,22 @@ def test_projection_with_beam():
     assert new_proj.meta['beam'] == exp_beam
 
 
+def test_projection_attach_beam():
+
+    exp_beam = Beam(1.0 * u.arcsec)
+    newbeam = Beam(2.0 * u.arcsec)
+
+    proj, hdu = load_projection("55.fits")
+
+    new_proj = proj.with_beam(newbeam)
+
+    assert proj.beam == exp_beam
+    assert proj.meta['beam'] == exp_beam
+
+    assert new_proj.beam == newbeam
+    assert new_proj.meta['beam'] == newbeam
+
+
 @pytest.mark.parametrize(('LDO', 'data'),
                          zip(LDOs_2d, data_two_2d))
 def test_projection_from_hdu(LDO, data):

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -271,6 +271,16 @@ def test_projection_with_beam():
     assert new_proj.beam == exp_beam
     assert new_proj.meta['beam'] == exp_beam
 
+    # load beam from beam object
+    exp_beam = Beam(3.0 * u.arcsec)
+    header = hdu.header.copy()
+    del header["BMAJ"], header["BMIN"], header["BPA"]
+    new_proj = Projection(hdu.data, wcs=proj.wcs, header=header,
+                          beam=exp_beam)
+
+    assert new_proj.beam == exp_beam
+    assert new_proj.meta['beam'] == exp_beam
+
 
 @pytest.mark.parametrize(('LDO', 'data'),
                          zip(LDOs_2d, data_two_2d))

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -127,12 +127,13 @@ translist = [('advs', [0, 1, 2, 3]),
              ('vad', [2, 0, 1]),
              ('vda', [0, 2, 1]),
              ('adv', [0, 1, 2]),
-             ('vda_beams', [0, 2, 1])
              ]
+
+translist_vrsc = [('vda_beams', [0, 2, 1])]
 
 class TestSpectralCube(object):
 
-    @pytest.mark.parametrize(('name', 'trans'), translist)
+    @pytest.mark.parametrize(('name', 'trans'), translist + translist_vrsc)
     def test_consistent_transposition(self, name, trans):
         """data() should return velocity axis first, then world 1, then world 0"""
         c, d = cube_and_raw(name + '.fits')
@@ -290,6 +291,54 @@ class TestSpectralCube(object):
         #assert_allclose(c2[1,1,:].value, expected[1,1,:])
         #assert_allclose(c2[1,:,1].value, expected[1,:,1])
         assert_allclose(c2[:,1,1].value, expected[:,1,1])
+
+    @pytest.mark.parametrize(('name', 'trans'), translist_vrsc)
+    def test_getitem_vrsc(self, name, trans):
+        c, d = cube_and_raw(name + '.fits')
+
+        expected = np.squeeze(d.transpose(trans))
+
+        # No pv slices for VRSC.
+
+        assert_allclose(c[0,:,:].value, expected[0,:,:])
+
+        # Not implemented:
+        #assert_allclose(c[0,0,:].value, expected[0,0,:])
+        #assert_allclose(c[0,:,0].value, expected[0,:,0])
+        assert_allclose(c[:,0,0].value, expected[:,0,0])
+
+        assert_allclose(c[1,:,:].value, expected[1,:,:])
+
+        # Not implemented:
+        #assert_allclose(c[1,1,:].value, expected[1,1,:])
+        #assert_allclose(c[1,:,1].value, expected[1,:,1])
+        assert_allclose(c[:,1,1].value, expected[:,1,1])
+
+        c2 = c.with_spectral_unit(u.km/u.s, velocity_convention='radio')
+
+        assert_allclose(c2[0,:,:].value, expected[0,:,:])
+
+        # Not implemented:
+        #assert_allclose(c2[0,0,:].value, expected[0,0,:])
+        #assert_allclose(c2[0,:,0].value, expected[0,:,0])
+        assert_allclose(c2[:,0,0].value, expected[:,0,0])
+
+        assert_allclose(c2[1,:,:].value, expected[1,:,:])
+
+        # Not implemented:
+        #assert_allclose(c2[1,1,:].value, expected[1,1,:])
+        #assert_allclose(c2[1,:,1].value, expected[1,:,1])
+        assert_allclose(c2[:,1,1].value, expected[:,1,1])
+
+        # @pytest.mark.xfail(raises=AttributeError)
+        @pytest.mark.parametrize(('name', 'trans'), translist_vrsc)
+        def test_getitem_vrsc(self, name, trans):
+            c, d = cube_and_raw(name + '.fits')
+
+            expected = np.squeeze(d.transpose(trans))
+
+            assert_allclose(c[:,:,0].value, expected[:,:,0])
+
 
 class TestArithmetic(object):
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1114,6 +1114,33 @@ def test_beam_attach_to_header():
     assert newcube.meta['beam'] == cube.beam
 
 
+def test_beam_custom():
+
+    cube, data = cube_and_raw('adv.fits')
+
+    header = cube._header.copy()
+    beam = Beam.from_fits_header(header)
+    del header["BMAJ"], header["BMIN"], header["BPA"]
+
+    newcube = SpectralCube(data=data, wcs=cube.wcs, header=header)
+
+    # newcube should now not have a beam
+    assert not hasattr(newcube, "beam")
+
+    # Attach the beam
+    newcube.attach_beam(beam=beam)
+
+    assert newcube.beam == cube.beam
+
+    # Header should be updated
+    assert cube.header["BMAJ"] == newcube.header["BMAJ"]
+    assert cube.header["BMIN"] == newcube.header["BMIN"]
+    assert cube.header["BPA"] == newcube.header["BPA"]
+
+    # Should be in meta too
+    assert newcube.meta['beam'] == cube.beam
+
+
 def test_multibeam_slice():
 
     cube, data = cube_and_raw('vda_beams.fits')

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1128,7 +1128,7 @@ def test_beam_custom():
     assert not hasattr(newcube, "beam")
 
     # Attach the beam
-    newcube.attach_beam(beam=beam)
+    newcube = newcube.with_beam(beam=beam)
 
     assert newcube.beam == cube.beam
 
@@ -1139,6 +1139,21 @@ def test_beam_custom():
 
     # Should be in meta too
     assert newcube.meta['beam'] == cube.beam
+
+    # Try changing the beam properties
+    newbeam = Beam(beam.major * 2)
+
+    newcube2 = newcube.with_beam(beam=newbeam)
+
+    assert newcube2.beam == newbeam
+
+    # Header should be updated
+    assert newcube2.header["BMAJ"] == newbeam.major.value
+    assert newcube2.header["BMIN"] == newbeam.minor.value
+    assert newcube2.header["BPA"] == newbeam.pa.value
+
+    # Should be in meta too
+    assert newcube2.meta['beam'] == newbeam
 
 
 def test_multibeam_slice():


### PR DESCRIPTION
From #432. A beam object can now be attached with:
```
newcube = cube.with_beam(beam)
newproj = projection.with_beam(beam)
```

Since radio-beam is now a dependency, I've removed the `read_beam` option from `SpectralCube`. We need to keep it for `Projection` though since there remains the issue with non-matching celestial axes for some slices.