### PR TITLE
Update astropy-helpers to v2.0.2

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -491,7 +491,6 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                            includemask=True)
         return counts
 
-    @aggregation_docstring
     def std(self, axis=None, how='cube', ddof=0):
         """
         Return the standard deviation of the cube, optionally over an axis.
@@ -507,7 +506,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         ddof : int
             Means Delta Degrees of Freedom.  The divisor used in calculations
             is ``N - ddof``, where ``N`` represents the number of elements.  By
-            default `ddof` is zero.
+            default ``ddof`` is zero.
         """
 
         projection = self._naxes_dropped(axis) in (1,2)


### PR DESCRIPTION
This is an automated update of the astropy-helpers submodule to v2.0.2. This includes both the update of the astropy-helpers sub-module, and the ``ah_bootstrap.py`` file, if needed.

*This is intended to be helpful, but if you would prefer to manage these updates yourself, or if you notice any issues with this automated update, please let @bsipocz or @astrofrog know!*