### PR TITLE
Channel numbering in multibeam cubes should be sequential

### DIFF
--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -331,7 +331,8 @@ def beams_to_bintable(beams):
     c1 = Column(name='BMAJ', format='1E', array=[bm.major.to(u.arcsec).value for bm in beams], unit=u.arcsec.to_string('FITS'))
     c2 = Column(name='BMIN', format='1E', array=[bm.minor.to(u.arcsec).value for bm in beams], unit=u.arcsec.to_string('FITS'))
     c3 = Column(name='BPA', format='1E', array=[bm.pa.to(u.deg).value for bm in beams], unit=u.deg.to_string('FITS'))
-    c4 = Column(name='CHAN', format='1J', array=[bm.meta['CHAN'] if 'CHAN' in bm.meta else 0 for bm in beams])
+    #c4 = Column(name='CHAN', format='1J', array=[bm.meta['CHAN'] if 'CHAN' in bm.meta else 0 for bm in beams])
+    c4 = Column(name='CHAN', format='1J', array=np.arange(len(beams)))
     c5 = Column(name='POL', format='1J', array=[bm.meta['POL'] if 'POL' in bm.meta else 0 for bm in beams])
 
     bmhdu = BinTableHDU.from_columns([c1, c2, c3, c4, c5])

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1101,6 +1101,13 @@ def test_oned_slice_beams():
     assert hasattr(spec, 'beams')
     assert 'BMAJ' in spec.hdulist[1].data.names
 
+def test_subcube_slab_beams():
+    cube, data = cube_and_raw('sdav_beams.fits')
+
+    slcube = cube[1:]
+
+    assert all(slcube.hdulist[1].data['CHAN'] == np.arange(slcube.shape[0]))
+
 def test_oned_collapse():
     # Check that an operation along the spatial dims returns an appropriate
     # spectrum


### PR DESCRIPTION
The "channel" column of the beam table seems to be relatively useless, as it is just an index that is required to match `range(len(table))`.