### PR TITLE
Bugfix: xhi < xlo results in bad WCS

### DIFF
--- a/docs/manipulating.rst
+++ b/docs/manipulating.rst
@@ -1,5 +1,5 @@
-Manipulating cubes
-==================
+Manipulating cubes and extracting subcubes
+==========================================
 
 Modifying the spectral axis
 ---------------------------
@@ -116,3 +116,14 @@ minimal enclosing sub-cube::
 You can also shrink any cube by this mechanism::
 
     >>> sub_cube = cube.with_mask(smaller_region).minimal_subcube()  # doctest: +SKIP
+
+
+Extract a spatial and spectral subcube
+--------------------------------------
+There is a generic subcube function that allows slices in the spatial and
+spectral axes simultaneously, as long as the spatial axes are aligned with the
+pixel axes.  An arbitrary example looks like this:
+
+    >>> sub_cube = cube.subcube(xlo=5*u.deg, xhi=6*u.deg,
+                                ylo=2*u.deg, yhi=2.1*u.deg,
+                                zlo=50*u.GHz, zhi=51*u.GHz) # doctest: +SKIP

--- a/docs/manipulating.rst
+++ b/docs/manipulating.rst
@@ -122,8 +122,8 @@ Extract a spatial and spectral subcube
 --------------------------------------
 There is a generic subcube function that allows slices in the spatial and
 spectral axes simultaneously, as long as the spatial axes are aligned with the
-pixel axes.  An arbitrary example looks like this:
+pixel axes.  An arbitrary example looks like this::
 
-    >>> sub_cube = cube.subcube(xlo=5*u.deg, xhi=6*u.deg,
-                                ylo=2*u.deg, yhi=2.1*u.deg,
+    >>> sub_cube = cube.subcube(xlo=5*u.deg, xhi=6*u.deg, # doctest: +SKIP
+                                ylo=2*u.deg, yhi=2.1*u.deg, # doctest: +SKIP
                                 zlo=50*u.GHz, zhi=51*u.GHz) # doctest: +SKIP

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -331,7 +331,8 @@ def beams_to_bintable(beams):
     c1 = Column(name='BMAJ', format='1E', array=[bm.major.to(u.arcsec).value for bm in beams], unit=u.arcsec.to_string('FITS'))
     c2 = Column(name='BMIN', format='1E', array=[bm.minor.to(u.arcsec).value for bm in beams], unit=u.arcsec.to_string('FITS'))
     c3 = Column(name='BPA', format='1E', array=[bm.pa.to(u.deg).value for bm in beams], unit=u.deg.to_string('FITS'))
-    c4 = Column(name='CHAN', format='1J', array=[bm.meta['CHAN'] if 'CHAN' in bm.meta else 0 for bm in beams])
+    #c4 = Column(name='CHAN', format='1J', array=[bm.meta['CHAN'] if 'CHAN' in bm.meta else 0 for bm in beams])
+    c4 = Column(name='CHAN', format='1J', array=np.arange(len(beams)))
     c5 = Column(name='POL', format='1J', array=[bm.meta['POL'] if 'POL' in bm.meta else 0 for bm in beams])
 
     bmhdu = BinTableHDU.from_columns([c1, c2, c3, c4, c5])

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1647,6 +1647,8 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                     limit_dict[lim] = val
 
         slices = [slice(limit_dict[xx+'lo'], limit_dict[xx+'hi'])
+                  if (limit_dict[xx+'lo'] < limit_dict[xx+'hi'])
+                  else slice(limit_dict[xx+'hi'], limit_dict[xx+'lo'])
                   for xx in 'zyx']
 
         return self[slices]

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1101,6 +1101,13 @@ def test_oned_slice_beams():
     assert hasattr(spec, 'beams')
     assert 'BMAJ' in spec.hdulist[1].data.names
 
+def test_subcube_slab_beams():
+    cube, data = cube_and_raw('sdav_beams.fits')
+
+    slcube = cube[1:]
+
+    assert all(slcube.hdulist[1].data['CHAN'] == np.arange(slcube.shape[0]))
+
 def test_oned_collapse():
     # Check that an operation along the spatial dims returns an appropriate
     # spectrum

--- a/spectral_cube/tests/test_subcubes.py
+++ b/spectral_cube/tests/test_subcubes.py
@@ -22,10 +22,13 @@ def test_subcube():
 
     sc1 = cube.subcube(xlo=1, xhi=3)
     sc2 = cube.subcube(xlo=24.06269*u.deg, xhi=24.06206*u.deg)
+    sc2b = cube.subcube(xlo=24.06206*u.deg, xhi=24.06269*u.deg)
 
     assert sc1.shape == (2,3,2)
     assert sc2.shape == (2,3,2)
+    assert sc2b.shape == (2,3,2)
     assert sc1.wcs.wcs.compare(sc2.wcs.wcs)
+    assert sc1.wcs.wcs.compare(sc2b.wcs.wcs)
 
     sc3 = cube.subcube(ylo=1, yhi=3)
     sc4 = cube.subcube(ylo=29.93464 * u.deg,


### PR DESCRIPTION
This fixes a bug in which `subcube` could create a bad WCS by slicing from high
to low instead of low to high.  This issue can arise when slicing in RA, which
usually has CDELT < 0, such that a lower pixel number maps to a higher value in
degrees.