### PR TITLE
Fixes to make imshow(slice) work

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -76,3 +76,27 @@ or the FWHM.
 The solution is either to make a tighter mask, excluding the pixels far from
 the centroid position, or to ensure that the baseline does not have any
 negative systematic offset.
+
+
+Looking at images with matplotlib
+---------------------------------
+Matplotlib accesses a lot of hidden properties of arrays when plotting.  If you
+try to show a slice with ``imshow``, you may encounter the WCS-related error::
+
+    NotImplementedError: Reversing an axis is not implemented.
+
+If you see this error, the only solution at present is to specify
+``origin='lower'``, which is the standard for images anyway.  For example::
+
+    import pylab as pl
+    pl.imshow(cube[5,:,:], origin='lower')
+
+should work, where ``origin='upper'`` will not.  This is due to a limitation in
+``astropy.wcs`` slicing.
+
+An alternative option, if it is absolutely necessary to use ``origin='upper'``
+or if you encounter other matplotlib-related issues, is to use the ``.value``
+attribute of the slice to get a bald numpy array to plot::
+
+    import pylab as pl
+    pl.imshow(cube[5,:,:].value)

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -202,6 +202,16 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
     def _mask(self, value):
         self.__mask = value
 
+    def shrink_mask(self):
+        """
+        Copy of the numpy masked_array shrink_mask method.  This is essentially
+        a hack needed for matplotlib to show images.
+        """
+        m = self._mask
+        if m.ndim and not m.any():
+            self._mask = nomask
+        return self
+
 class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
 
     def __new__(cls, value, unit=None, dtype=None, copy=True, wcs=None,

--- a/spectral_cube/tests/test_visualization.py
+++ b/spectral_cube/tests/test_visualization.py
@@ -45,8 +45,19 @@ def test_projvis():
     mom0 = cube.moment0()
     mom0.quicklook(use_aplpy=False)
 
+@pytest.mark.skipif("not MATPLOTLIB_INSTALLED")
+def test_proj_imshow():
+
+    cube, data = cube_and_raw('vda_Jybeam_lower.fits')
+
+    mom0 = cube.moment0()
+
+    import pylab as pl
+    pl.imshow(mom0)
+
+
 @pytest.mark.skipif("not APLPY_INSTALLED")
-def test_projvis():
+def test_projvis_aplpy():
 
     cube, data = cube_and_raw('vda_Jybeam_lower.fits')
 


### PR DESCRIPTION
imshow(slice) was failing with these errors:

```
In [6]: pl.imshow(cube[5,:,:])
Traceback (most recent call last):
  File "<ipython-input-6-6baa54d900b2>", line 1, in <module>
    pl.imshow(cube[5,:,:])
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/matplotlib/pyplot.py", line 3029, in imshow
    **kwargs)
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/matplotlib/__init__.py", line 1819, in inner
    return func(ax, *args, **kwargs)
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/matplotlib/axes/_axes.py", line 4922, in imshow
    im.set_data(X)
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/matplotlib/image.py", line 445, in set_data
    self._A = cbook.safe_masked_invalid(A, copy=True)
  File "/Users/adam/anaconda/envs/astropy35/lib/python3.5/site-packages/matplotlib/cbook.py", line 1523, in safe_masked_invalid
    xm.shrink_mask()
  File "/Users/adam/repos/astropy/astropy/units/quantity.py", line 966, in __getattr__
    attr))
AttributeError: 'Slice' object has no 'shrink_mask' member
```

this PR adds a `shrink_mask` method copied verbatim from `numpy` and adds a
section to the docs describing workarounds for related issues.