### PR TITLE
Fix several major issues related to axis=(1,2) operations

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -480,6 +480,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         projection = self._naxes_dropped(axis) in (1,2)
 
         if how == 'slice':
+            # two-pass approach: first total the # of points,
+            # then total the value of the points, then divide
+            # (a one-pass approach is possible but requires
+            # more sophisticated bookkeeping)
             counts = self._count_nonzero_slicewise(axis=axis)
             ttl = self.apply_numpy_function(np.nansum, fill=np.nan, how=how,
                                             axis=axis, unit=None,

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -505,7 +505,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                         unit=self.unit,
                                         spectral_unit=self._spectral_unit,
                                         beams=self.beams,
-                                        meta=meta)
+                                        meta=self.meta)
                 else:
                     raise NotImplementedError("We don't yet know how to deal "
                                               "with multidimensional averages "

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -541,14 +541,8 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         """
         Return the standard deviation of the cube, optionally over an axis.
 
-        Parameters
-        ----------
-        axis : int or None
-            The axis to average over
-        how : str
-            The method to use.  This method supports slice-wise standard
-            deviation calculation ('slice') and full-cube ('cube'), but not
-            'ray'.
+        Other Parameters
+        ----------------
         ddof : int
             Means Delta Degrees of Freedom.  The divisor used in calculations
             is ``N - ddof``, where ``N`` represents the number of elements.  By

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -459,7 +459,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             return 1
 
     @aggregation_docstring
-    @warn_how
+    @warn_slow
     def sum(self, axis=None, how='auto', **kwargs):
         """
         Return the sum of the cube, optionally over an axis.
@@ -473,7 +473,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                          projection=projection, **kwargs)
 
     @aggregation_docstring
-    @warn_how
+    @warn_slow
     def mean(self, axis=None, how='cube', **kwargs):
         """
         Return the mean of the cube, optionally over an axis.
@@ -535,7 +535,9 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                            includemask=True)
         return counts
 
-    def std(self, axis=None, how='cube', ddof=0):
+    @aggregation_docstring
+    @warn_slow
+    def std(self, axis=None, how='cube', ddof=0, **kwargs):
         """
         Return the standard deviation of the cube, optionally over an axis.
 
@@ -561,10 +563,14 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                           "cannot be computed in a slicewise "
                                           "manner.  Please use a "
                                           "different strategy.")
+            if hasattr(axis, '__len__') and len(axis) == 2:
+                raise NotImplementedError("Standard deviation across two "
+                                          "dimensions slicewise is not "
+                                          "yet implemented.")
             counts = self._count_nonzero_slicewise(axis=axis)
             ttl = self.apply_numpy_function(np.nansum, fill=np.nan, how='slice',
                                             axis=axis, unit=None,
-                                            projection=False)
+                                            projection=False, **kwargs)
             # Equivalent, but with more overhead:
             # ttl = self.sum(axis=axis, how='slice').value
             mean = ttl/counts
@@ -592,10 +598,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         # implement raywise reduction
         return self.apply_numpy_function(np.nanstd, fill=np.nan, how=how,
                                          axis=axis, unit=self.unit,
-                                         projection=projection)
+                                         projection=projection, **kwargs)
 
     @aggregation_docstring
-    @warn_how
+    @warn_slow
     def mad_std(self, axis=None, **kwargs):
         """
         Use astropy's mad_std to computer the standard deviation
@@ -610,7 +616,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
 
 
     @aggregation_docstring
-    @warn_how
+    @warn_slow
     def max(self, axis=None, how='auto', **kwargs):
         """
         Return the maximum data value of the cube, optionally over an axis.
@@ -623,7 +629,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                          projection=projection, **kwargs)
 
     @aggregation_docstring
-    @warn_how
+    @warn_slow
     def min(self, axis=None, how='auto', **kwargs):
         """
         Return the minimum data value of the cube, optionally over an axis.
@@ -636,7 +642,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                          projection=projection, **kwargs)
 
     @aggregation_docstring
-    @warn_how
+    @warn_slow
     def argmax(self, axis=None, how='auto', **kwargs):
         """
         Return the index of the maximum data value.
@@ -649,7 +655,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                          how=how, axis=axis, **kwargs)
 
     @aggregation_docstring
-    @warn_how
+    @warn_slow
     def argmin(self, axis=None, how='auto', **kwargs):
         """
         Return the index of the minimum data value.

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -338,9 +338,6 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         elif how not in ['auto', 'cube']:
             warnings.warn("Cannot use how=%s. Using how=cube" % how)
 
-        if how == 'cube':
-            self
-
         if out is None:
             out = function(self._get_filled_data(fill=fill,
                                                  check_endian=check_endian),

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -484,7 +484,8 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             # then total the value of the points, then divide
             # (a one-pass approach is possible but requires
             # more sophisticated bookkeeping)
-            counts = self._count_nonzero_slicewise(axis=axis)
+            counts = self._count_nonzero_slicewise(axis=axis,
+                                                   progressbar=kwargs.get('progressbar'))
             ttl = self.apply_numpy_function(np.nansum, fill=np.nan, how=how,
                                             axis=axis, unit=None,
                                             projection=False, **kwargs)
@@ -504,7 +505,9 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                         copy=False,
                                         unit=self.unit,
                                         spectral_unit=self._spectral_unit,
-                                        beams=self.beams,
+                                        beams=(self.beams
+                                               if hasattr(self, 'beams')
+                                               else None),
                                         meta=self.meta)
                 else:
                     raise NotImplementedError("We don't yet know how to deal "

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -338,6 +338,9 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         elif how not in ['auto', 'cube']:
             warnings.warn("Cannot use how=%s. Using how=cube" % how)
 
+        if how == 'cube':
+            self
+
         if out is None:
             out = function(self._get_filled_data(fill=fill,
                                                  check_endian=check_endian),
@@ -459,6 +462,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             return 1
 
     @aggregation_docstring
+    @warn_how
     def sum(self, axis=None, how='auto', **kwargs):
         """
         Return the sum of the cube, optionally over an axis.
@@ -472,6 +476,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                          projection=projection, **kwargs)
 
     @aggregation_docstring
+    @warn_how
     def mean(self, axis=None, how='cube', **kwargs):
         """
         Return the mean of the cube, optionally over an axis.
@@ -593,6 +598,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                          projection=projection)
 
     @aggregation_docstring
+    @warn_how
     def mad_std(self, axis=None, **kwargs):
         """
         Use astropy's mad_std to computer the standard deviation
@@ -607,6 +613,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
 
 
     @aggregation_docstring
+    @warn_how
     def max(self, axis=None, how='auto', **kwargs):
         """
         Return the maximum data value of the cube, optionally over an axis.
@@ -619,6 +626,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                          projection=projection, **kwargs)
 
     @aggregation_docstring
+    @warn_how
     def min(self, axis=None, how='auto', **kwargs):
         """
         Return the minimum data value of the cube, optionally over an axis.
@@ -631,6 +639,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                          projection=projection, **kwargs)
 
     @aggregation_docstring
+    @warn_how
     def argmax(self, axis=None, how='auto', **kwargs):
         """
         Return the index of the maximum data value.
@@ -643,6 +652,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                          how=how, axis=axis, **kwargs)
 
     @aggregation_docstring
+    @warn_how
     def argmin(self, axis=None, how='auto', **kwargs):
         """
         Return the index of the minimum data value.

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -593,7 +593,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                          projection=projection)
 
     @aggregation_docstring
-    def mad_std(self, axis=None):
+    def mad_std(self, axis=None, **kwargs):
         """
         Use astropy's mad_std to computer the standard deviation
         """
@@ -603,11 +603,11 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         return self.apply_numpy_function(stats.mad_std, fill=np.nan,
                                          how='cube', axis=axis, unit=self.unit,
                                          ignore_nan=True,
-                                         projection=projection)
+                                         projection=projection, **kwargs)
 
 
     @aggregation_docstring
-    def max(self, axis=None, how='auto'):
+    def max(self, axis=None, how='auto', **kwargs):
         """
         Return the maximum data value of the cube, optionally over an axis.
         """
@@ -616,10 +616,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
 
         return self.apply_numpy_function(np.nanmax, fill=np.nan, how=how,
                                          axis=axis, unit=self.unit,
-                                         projection=projection)
+                                         projection=projection, **kwargs)
 
     @aggregation_docstring
-    def min(self, axis=None, how='auto'):
+    def min(self, axis=None, how='auto', **kwargs):
         """
         Return the minimum data value of the cube, optionally over an axis.
         """
@@ -628,10 +628,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
 
         return self.apply_numpy_function(np.nanmin, fill=np.nan, how=how,
                                          axis=axis, unit=self.unit,
-                                         projection=projection)
+                                         projection=projection, **kwargs)
 
     @aggregation_docstring
-    def argmax(self, axis=None, how='auto'):
+    def argmax(self, axis=None, how='auto', **kwargs):
         """
         Return the index of the maximum data value.
 
@@ -640,10 +640,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         """
         return self.apply_numpy_function(np.nanargmax, fill=-np.inf,
                                          reduce=False, projection=False,
-                                         how=how, axis=axis)
+                                         how=how, axis=axis, **kwargs)
 
     @aggregation_docstring
-    def argmin(self, axis=None, how='auto'):
+    def argmin(self, axis=None, how='auto', **kwargs):
         """
         Return the index of the minimum data value.
 
@@ -652,7 +652,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         """
         return self.apply_numpy_function(np.nanargmin, fill=np.inf,
                                          reduce=False, projection=False,
-                                         how=how, axis=axis)
+                                         how=how, axis=axis, **kwargs)
 
     def chunked(self, chunksize=1000):
         """

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -490,12 +490,26 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                             projection=False, **kwargs)
             out = ttl / counts
             if projection:
-                new_wcs = wcs_utils.drop_axis(self._wcs, np2wcs[axis])
-                meta = {'collapse_axis': axis}
-                meta.update(self._meta)
-                return Projection(out, copy=False, wcs=new_wcs,
-                                  meta=meta,
-                                  unit=self.unit, header=self._nowcs_header)
+                if self._naxes_dropped(axis) == 1:
+                    new_wcs = wcs_utils.drop_axis(self._wcs, np2wcs[axis])
+                    meta = {'collapse_axis': axis}
+                    meta.update(self._meta)
+                    return Projection(out, copy=False, wcs=new_wcs,
+                                      meta=meta,
+                                      unit=self.unit, header=self._nowcs_header)
+                elif axis == (1,2):
+                    newwcs = self._wcs.sub([wcs.WCSSUB_SPECTRAL])
+                    return OneDSpectrum(value=out,
+                                        wcs=newwcs,
+                                        copy=False,
+                                        unit=self.unit,
+                                        spectral_unit=self._spectral_unit,
+                                        beams=self.beams,
+                                        meta=meta)
+                else:
+                    raise NotImplementedError("We don't yet know how to deal "
+                                              "with multidimensional averages "
+                                              "that are non-spectral")
             else:
                 return out
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -100,6 +100,11 @@ def test_huge_disallowed():
             cube + 5*cube.unit
         assert 'entire cube into memory' in exc.value.args[0]
 
+        with pytest.raises(ValueError) as exc:
+            cube.max(how='cube')
+        assert 'entire cube into memory' in exc.value.args[0]
+
+
         cube.allow_huge_operations = True
 
         # just make sure it doesn't fail

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -578,6 +578,9 @@ class TestNumpyMethods(BaseTest):
         for axis in [None, 0, 1, 2]:
             assert_allclose(getattr(c1, method)(axis=axis),
                             getattr(c2, method)(axis=axis))
+            # check that all these accept progressbar kwargs
+            assert_allclose(getattr(c1, method)(axis=axis, progressbar=True),
+                            getattr(c2, method)(axis=axis, progressbar=True))
 
 
 class TestSlab(BaseTest):

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -570,8 +570,8 @@ class TestNumpyMethods(BaseTest):
         assert not np.any(np.isnan(scpct.value))
         assert scpct.unit == self.c.unit
 
-    @pytest.mark.parametrize('method', ('sum', 'min', 'max',
-                             'median', 'argmin', 'argmax'))
+    @pytest.mark.parametrize('method', ('sum', 'min', 'max', 'std', 'mad_std',
+                                        'median', 'argmin', 'argmax'))
     def test_transpose(self, method):
         c1, d1 = cube_and_raw('adv.fits')
         c2, d2 = cube_and_raw('vad.fits')

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1108,7 +1108,8 @@ def test_subcube_slab_beams():
 
     assert all(slcube.hdulist[1].data['CHAN'] == np.arange(slcube.shape[0]))
 
-def test_oned_collapse():
+@pytest.mark.parametrize('how', ('auto', 'cube', 'slice', 'ray'))
+def test_oned_collapse(how):
     # Check that an operation along the spatial dims returns an appropriate
     # spectrum
 
@@ -1116,7 +1117,7 @@ def test_oned_collapse():
     cube._meta['BUNIT'] = 'K'
     cube._unit = u.K
 
-    spec = cube.mean(axis=(1,2))
+    spec = cube.mean(axis=(1,2), how=how)
     assert isinstance(spec, OneDSpectrum)
     # data has a redundant 1st axis
     np.testing.assert_equal(spec.value, data.mean(axis=(0,2,3)))

--- a/spectral_cube/utils.py
+++ b/spectral_cube/utils.py
@@ -24,14 +24,15 @@ def warn_slow(function):
 
     @wraps(function)
     def wrapper(self, *args, **kwargs):
-        if self._is_huge and not self.allow_huge_operations:
+        warn_how = ('how' in kwargs and kwargs['how'] == 'cube') or 'how' not in kwargs
+        if self._is_huge and not self.allow_huge_operations and warn_how:
             raise ValueError("This function ({0}) requires loading the entire "
                              "cube into memory, and the cube is large ({1} "
                              "pixels), so by default we disable this operation. "
                              "To enable the operation, set "
                              "`cube.allow_huge_operations=True` and try again."
                              .format(str(function), self.size))
-        elif not self._is_huge:
+        elif warn_how and not self._is_huge:
             # TODO: add check for whether cube has been loaded into memory
             warnings.warn("This function ({0}) requires loading the entire cube into "
                           "memory and may therefore be slow.".format(str(function)))

--- a/spectral_cube/utils.py
+++ b/spectral_cube/utils.py
@@ -24,6 +24,7 @@ def warn_slow(function):
 
     @wraps(function)
     def wrapper(self, *args, **kwargs):
+        # if the function accepts a 'how', the 'cube' approach requires the whole cube in memory
         warn_how = ('how' in kwargs and kwargs['how'] == 'cube') or 'how' not in kwargs
         if self._is_huge and not self.allow_huge_operations and warn_how:
             raise ValueError("This function ({0}) requires loading the entire "


### PR DESCRIPTION
First, and most important, it was possible to unintentionally and unacceptably have full-memory runs initiated when explicitly setting `how='slice'` because of a try/except clause I had added (that was very wrong).

To solve this, I just implemented multidimensional averaging in `mean` and `_reduce_slicewise`.    I added some more tests, too, and the ability to require progressbars