### PR TITLE
Multi-threading Compatibility of Smoothing Functions

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2363,7 +2363,6 @@ class SpectralCube(BaseSpectralCube):
             self.pixels_per_beam = (self.beam.sr /
                                     (astropy.wcs.utils.proj_plane_pixel_area(self.wcs) *
                                      u.deg**2)).to(u.dimensionless_unscaled).value
-        self.external_update_function = None  # External function that updates a gui's progress bar
 
     def _new_cube_with(self, **kwargs):
         beam = kwargs.pop('beam', None)
@@ -2398,7 +2397,7 @@ class SpectralCube(BaseSpectralCube):
 
         return newcube
 
-    def spatial_smooth_median(self, ksize, **kwargs):
+    def spatial_smooth_median(self, ksize, update_function=None, **kwargs):
         """
         Smooth the image in each spatial-spatial plane of the cube using a median filter.
 
@@ -2421,11 +2420,9 @@ class SpectralCube(BaseSpectralCube):
                       self.mask.include(view=(ii, slice(None), slice(None))))
                       for ii in range(self.shape[0]))
 
-        if self.external_update_function is None:
+        if update_function is None:
             pb = ProgressBar(shape[0])
             update_function = pb.update
-        else:
-            update_function = self.external_update_function
 
         def _gsmooth_image(args):
             """
@@ -2457,7 +2454,9 @@ class SpectralCube(BaseSpectralCube):
 
     def spatial_smooth(self, kernel,
                        #numcores=None,
-                       convolve=convolution.convolve, **kwargs):
+                       convolve=convolution.convolve,
+                       update_function=None,
+                       **kwargs):
         """
         Smooth the image in each spatial-spatial plane of the cube.
 
@@ -2482,11 +2481,9 @@ class SpectralCube(BaseSpectralCube):
                      self.mask.include(view=(ii, slice(None), slice(None))))
                      for ii in range(self.shape[0]))
 
-        if self.external_update_function is None:
+        if update_function is None:
             pb = ProgressBar(shape[0])
             update_function = pb.update
-        else:
-            update_function = self.external_update_function
 
         def _gsmooth_image(args):
             """
@@ -2517,7 +2514,7 @@ class SpectralCube(BaseSpectralCube):
 
         return newcube
 
-    def spectral_smooth_median(self, ksize, **kwargs):
+    def spectral_smooth_median(self, ksize, update_function=None, **kwargs):
         """
         Smooth the cube along the spectral dimension
 
@@ -2542,11 +2539,9 @@ class SpectralCube(BaseSpectralCube):
                     for jj in range(self.shape[1])
                     for ii in range(self.shape[2]))
 
-        if self.external_update_function is None:
+        if update_function is None:
             pb = ProgressBar(shape[1] * shape[2])
             update_function = pb.update
-        else:
-            update_function = self.external_update_function
 
         def _gsmooth_spectrum(args):
             """
@@ -2585,6 +2580,7 @@ class SpectralCube(BaseSpectralCube):
     def spectral_smooth(self, kernel,
                         #numcores=None,
                         convolve=convolution.convolve,
+                        update_function=None,
                         **kwargs):
         """
         Smooth the cube along the spectral dimension
@@ -2611,11 +2607,9 @@ class SpectralCube(BaseSpectralCube):
                     for jj in range(self.shape[1])
                     for ii in range(self.shape[2]))
 
-        if self.external_update_function is None:
+        if update_function is None:
             pb = ProgressBar(shape[1] * shape[2])
             update_function = pb.update
-        else:
-            update_function = self.external_update_function
 
         def _gsmooth_spectrum(args):
             """

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2363,7 +2363,6 @@ class SpectralCube(BaseSpectralCube):
             self.pixels_per_beam = (self.beam.sr /
                                     (astropy.wcs.utils.proj_plane_pixel_area(self.wcs) *
                                      u.deg**2)).to(u.dimensionless_unscaled).value
-        self.abort = False  # Checked mid calculation
         self.external_update_function = None  # External function that updates a gui's progress bar
 
     def _new_cube_with(self, **kwargs):
@@ -2433,10 +2432,7 @@ class SpectralCube(BaseSpectralCube):
             Helper function to smooth a spectrum
             """
             (im, includemask),kwargs = args
-            if self.abort:
-                return  # dump calculation
-            else:
-                update_function()
+            update_function()
 
             if includemask.any():
                 return ndimage.filters.median_filter(im, size=ksize)
@@ -2451,8 +2447,6 @@ class SpectralCube(BaseSpectralCube):
                                                            )
                                        )
                                   ])
-        if self.abort:
-            return
 
         # TODO: do something about the mask?
         newcube = self._new_cube_with(data=smoothcube_, wcs=self.wcs,
@@ -2499,10 +2493,7 @@ class SpectralCube(BaseSpectralCube):
             Helper function to smooth an image
             """
             (im, includemask),kernel,kwargs = args
-            if self.abort:
-                return  # dump calculation
-            else:
-                update_function()
+            update_function()
 
             if includemask.any():
                 return convolve(im, kernel, normalize_kernel=True, **kwargs)
@@ -2518,8 +2509,6 @@ class SpectralCube(BaseSpectralCube):
                                                            )
                                        )
                                   ])
-        if self.abort:
-            return
 
         # TODO: do something about the mask?
         newcube = self._new_cube_with(data=smoothcube_, wcs=self.wcs,
@@ -2564,10 +2553,7 @@ class SpectralCube(BaseSpectralCube):
             Helper function to smooth a spectrum
             """
             (spec, includemask),kwargs = args
-            if self.abort:
-                return  # dump calculation
-            else:
-                update_function()
+            update_function()
 
             if any(includemask):
                 return ndimage.filters.median_filter(spec, size=ksize)
@@ -2583,8 +2569,6 @@ class SpectralCube(BaseSpectralCube):
                                        )
                                    ]
                                   )
-        if self.abort:
-            return
 
         # empirical: need to swapaxes to get shape right
         # cube = np.arange(6*5*4).reshape([4,5,6]).swapaxes(0,2)
@@ -2638,10 +2622,7 @@ class SpectralCube(BaseSpectralCube):
             Helper function to smooth a spectrum
             """
             (spec, includemask),kernel,kwargs = args
-            if self.abort:
-                return  # dump calculation
-            else:
-                update_function()
+            update_function()
 
             if any(includemask):
                 return convolve(spec, kernel, normalize_kernel=True, **kwargs)
@@ -2658,8 +2639,6 @@ class SpectralCube(BaseSpectralCube):
                                        )
                                    ]
                                   )
-        if self.abort:
-            return
 
         # empirical: need to swapaxes to get shape right
         # cube = np.arange(6*5*4).reshape([4,5,6]).swapaxes(0,2)
@@ -2835,13 +2814,6 @@ class SpectralCube(BaseSpectralCube):
             raise ValueError("goodchannels must have a length equal to the "
                              "cube's spectral dimension.")
         return self.with_mask(goodchannels[:,None,None])
-
-    def abort_function(self):
-        """
-        Toggles abort value to true.
-        Used interrupt smoothing calculations.
-        """
-        self.abort = True
 
 
 class VaryingResolutionSpectralCube(BaseSpectralCube):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2405,6 +2405,9 @@ class SpectralCube(BaseSpectralCube):
         ----------
         ksize : int
             Size of the median filter (scipy.ndimage.filters.median_filter)
+        update_function : method
+            Method that is called to update an external progressbar.
+            If provided, it disables the default `astropy.utils.console.ProgressBar`.
         kwargs : dict
             Passed to the convolve function
         """
@@ -2468,6 +2471,9 @@ class SpectralCube(BaseSpectralCube):
             The astropy convolution function to use, either
             `astropy.convolution.convolve` or
             `astropy.convolution.convolve_fft`
+        update_function : method
+            Method that is called to update an external progressbar.
+            If provided, it disables the default `astropy.utils.console.ProgressBar`.
         kwargs : dict
             Passed to the convolve function
         """
@@ -2522,6 +2528,9 @@ class SpectralCube(BaseSpectralCube):
         ----------
         ksize : int
             Size of the median filter (scipy.ndimage.filters.median_filter)
+        update_function : method
+            Method that is called to update an external progressbar.
+            If provided, it disables the default `astropy.utils.console.ProgressBar`.
         kwargs : dict
             Passed to the convolve function
         """
@@ -2593,6 +2602,9 @@ class SpectralCube(BaseSpectralCube):
             The astropy convolution function to use, either
             `astropy.convolution.convolve` or
             `astropy.convolution.convolve_fft`
+        update_function : method
+            Method that is called to update an external progressbar.
+            If provided, it disables the default `astropy.utils.console.ProgressBar`.
         kwargs : dict
             Passed to the convolve function
         """


### PR DESCRIPTION
Please see #452 for the motivation of this work. 

The current version of SpectralCube smoothing functions use `astropy.utils.console.ProgressBar` which demanded that the smoothing function be executed on the main thread. If this requirement is not met, an exception is raised (`ValueError: signal only works in main thread` ). To resolve this issue this PR aims to provide alternatives to `astropy.utils.console.ProgressBar`. This is achieved by letting the user provide the update function which is responsible for incrementing the progress bar. To be specific, the user sets the `external_update_function` class variable before executing the smoothing functions which in turn disable `astropy.utils.console.ProgressBar` in the smoothing functions.

This PR will also adds the ability to abort smoothing mid calculation. This is achieved by adding a boolean class variable `abort` which will serve as a flag to abort the calculations.  