### PR TITLE
Add Jy/beam -> K for 2D objects

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -86,60 +86,6 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
             raise ValueError("Unknown format '{0}' - the only available "
                              "format at this time is 'fits'")
 
-    def to(self, unit, equivalencies=[], freq=None):
-        """
-        Return a new `~spectral_cube.lower_dimensional_structures.LowerDimensionalObject`
-        of the same class with the specified unit.
-
-        See `astropy.units.Quantity.to` for further details.
-        """
-
-        if not isinstance(unit, u.Unit):
-            unit = u.Unit(unit)
-
-        if unit == self.unit:
-            # No copying
-            return self
-
-        if self.unit.is_equivalent(u.Jy / u.beam):
-            # replace "beam" with the actual beam
-            if not hasattr(self, 'beam'):
-                raise ValueError("To convert objects with Jy/beam units, "
-                                 "the object needs to have a beam defined.")
-            brightness_unit = self.unit * u.beam
-
-            # create a beam equivalency for brightness temperature
-            if freq is None:
-                try:
-                    freq = self.with_spectral_unit(u.Hz).spectral_axis
-                except AttributeError:
-                    raise TypeError("Object of type {0} has no spectral "
-                                    "information. `freq` must be provided for"
-                                    " unit conversion from Jy/beam"
-                                    .format(type(self)))
-            else:
-                if not freq.unit.is_equivalent(u.Hz):
-                    raise u.UnitsError("freq must be given in equivalent "
-                                       "frequency units.")
-
-            bmequiv = self.beam.jtok_equiv(freq)
-            factor = brightness_unit.to(unit,
-                                        equivalencies=bmequiv + list(equivalencies))
-        else:
-            # scaling factor
-            factor = self.unit.to(unit, equivalencies=equivalencies)
-
-        converted_array = (self.quantity * factor).value
-
-        # use private versions of variables, not the generated property
-        # versions
-        # Not entirely sure the use of __class__ here is kosher, but we do want
-        # self.__class__, not super()
-        new = self.__class__(value=converted_array, unit=unit, copy=True,
-                             wcs=self._wcs, meta=self._meta, mask=self._mask,
-                             header=self._header)
-
-        return new
 
     def __getslice__(self, start, end, increment=None):
         # I don't know why this is needed, but apparently one of the inherited
@@ -526,6 +472,61 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass):
 
         return self[slices]
 
+    def to(self, unit, equivalencies=[], freq=None):
+        """
+        Return a new `~spectral_cube.lower_dimensional_structures.Projection`
+        of the same class with the specified unit.
+
+        See `astropy.units.Quantity.to` for further details.
+        """
+
+        if not isinstance(unit, u.Unit):
+            unit = u.Unit(unit)
+
+        if unit == self.unit:
+            # No copying
+            return self
+
+        if self.unit.is_equivalent(u.Jy / u.beam):
+            # replace "beam" with the actual beam
+            if not hasattr(self, 'beam'):
+                raise ValueError("To convert objects with Jy/beam units, "
+                                 "the object needs to have a beam defined.")
+            brightness_unit = self.unit * u.beam
+
+            # create a beam equivalency for brightness temperature
+            if freq is None:
+                try:
+                    freq = self.with_spectral_unit(u.Hz).spectral_axis
+                except AttributeError:
+                    raise TypeError("Object of type {0} has no spectral "
+                                    "information. `freq` must be provided for"
+                                    " unit conversion from Jy/beam"
+                                    .format(type(self)))
+            else:
+                if not freq.unit.is_equivalent(u.Hz):
+                    raise u.UnitsError("freq must be given in equivalent "
+                                       "frequency units.")
+
+            bmequiv = self.beam.jtok_equiv(freq)
+            factor = brightness_unit.to(unit,
+                                        equivalencies=bmequiv + list(equivalencies))
+        else:
+            # scaling factor
+            factor = self.unit.to(unit, equivalencies=equivalencies)
+
+        converted_array = (self.quantity * factor).value
+
+        # use private versions of variables, not the generated property
+        # versions
+        # Not entirely sure the use of __class__ here is kosher, but we do want
+        # self.__class__, not super()
+        new = self.__class__(value=converted_array, unit=unit, copy=True,
+                             wcs=self._wcs, meta=self._meta, mask=self._mask,
+                             header=self._header)
+
+        return new
+
 # A slice is just like a projection in every way
 class Slice(Projection):
     pass
@@ -875,6 +876,28 @@ class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
         newspec = convolve(self.value, kernel, normalize_kernel=True, **kwargs)
 
         return self._new_spectrum_with(data=newspec)
+
+    def to(self, unit, equivalencies=[]):
+        """
+        Return a new `~spectral_cube.lower_dimensional_structures.OneDSpectrum` of the same class with the
+        specified unit.
+        See `astropy.units.Quantity.to` for further details.
+        """
+
+        # NOTE: This won't work for conversions from Jy/beam
+
+        converted_array = u.Quantity.to(self, unit,
+                                        equivalencies=equivalencies).value
+
+        # use private versions of variables, not the generated property
+        # versions
+        # Not entirely sure the use of __class__ here is kosher, but we do want
+        # self.__class__, not super()
+        new = self.__class__(value=converted_array, unit=unit, copy=True,
+                             wcs=self._wcs, meta=self._meta, mask=self._mask,
+                             header=self._header)
+
+        return new
 
     def with_fill_value(self, fill_value):
         """

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -541,3 +541,26 @@ def test_LDO_arithmetic():
     spx2 = sp * 2
     assert np.all(spx2.value == sp.value*2)
     assert np.all(spx2.filled_data[:].value == sp.value*2)
+
+
+def test_beam_jtok_2D():
+
+    cube, data = cube_and_raw('advs.fits')
+    cube._meta['BUNIT'] = 'Jy / beam'
+    cube._unit = u.Jy / u.beam
+
+    plane = cube[0]
+
+    freq = cube.with_spectral_unit(u.GHz).spectral_axis[0]
+
+    equiv = plane.beam.jtok_equiv(freq)
+    jtok = plane.beam.jtok(freq)
+
+    Kplane = plane.to(u.K, equivalencies=equiv, freq=freq)
+    np.testing.assert_almost_equal(Kplane.value,
+                                   (plane.value * jtok).value)
+
+    # test that the beam equivalencies are correctly automatically defined
+    Kplane = plane.to(u.K, freq=freq)
+    np.testing.assert_almost_equal(Kplane.value,
+                                   (plane.value * jtok).value)


### PR DESCRIPTION
Jy/beam unit conversion for 2D objects. The previous unit conversion is still being used for `OneDSpectrum`, but I don't have time to fix that one right now. I've added an issue for it in #461.