### PR TITLE
when creating composite masks, allow numpy arrays in the same way that spectral_cube.with_mask would

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -81,7 +81,10 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
         if format is None:
             format = determine_format(filename)
         if format == 'fits':
-            self.hdu.writeto(filename, clobber=overwrite)
+            try:
+                self.hdu.writeto(filename, overwrite=overwrite)
+            except TypeError:
+                self.hdu.writeto(filename, clobber=overwrite)
         else:
             raise ValueError("Unknown format '{0}' - the only available "
                              "format at this time is 'fits'")

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -339,7 +339,7 @@ class CompositeMask(MaskBase):
         mask1._validate_wcs(mask2._wcs)
         # In order to composite composites, they must have a _wcs defined.
         # (maybe this should be a property?)
-        self._wcs = self._mask1._wcs
+        self._wcs = mask1._wcs
 
         self._mask1 = mask1
         self._mask2 = mask2

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -334,6 +334,13 @@ class CompositeMask(MaskBase):
                                  "%s vs %s" % (mask2.shape, mask1.shape))
             mask2 = BooleanArrayMask(mask2, mask1._wcs, shape=mask1.shape)
 
+        # both entries must have compatible, which effectively means
+        # equal, WCSes.
+        self._mask1._validate_wcs(self._mask2._wcs)
+        # In order to composite composites, they must have a _wcs defined.
+        # (maybe this should be a property?)
+        self._wcs = self._mask1._wcs
+
         self._mask1 = mask1
         self._mask2 = mask2
         self._operation = operation

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -336,7 +336,7 @@ class CompositeMask(MaskBase):
 
         # both entries must have compatible, which effectively means
         # equal, WCSes.
-        mask1._validate_wcs(wcs=mask2._wcs)
+        mask1._validate_wcs(new_data=None, wcs=mask2._wcs)
         # In order to composite composites, they must have a _wcs defined.
         # (maybe this should be a property?)
         self._wcs = mask1._wcs

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -112,7 +112,7 @@ class MaskBase(object):
         self._validate_wcs(data, wcs, **kwargs)
         return self._include(data=data, wcs=wcs, view=view)
 
-    def _validate_wcs(self, new_data, new_wcs, **kwargs):
+    def _validate_wcs(self, new_data=None, new_wcs=None, **kwargs):
         """
         This method can be overridden in cases where the data and WCS have to
         conform to some rules. This gets called automatically when
@@ -345,9 +345,9 @@ class CompositeMask(MaskBase):
         self._mask2 = mask2
         self._operation = operation
 
-    def _validate_wcs(self, new_data, new_wcs, **kwargs):
-        self._mask1._validate_wcs(new_data, new_wcs, **kwargs)
-        self._mask2._validate_wcs(new_data, new_wcs, **kwargs)
+    def _validate_wcs(self, new_data=None, new_wcs=None, **kwargs):
+        self._mask1._validate_wcs(new_data=new_data, new_wcs=new_wcs, **kwargs)
+        self._mask2._validate_wcs(new_data=new_data, new_wcs=new_wcs, **kwargs)
 
     @property
     def shape(self):
@@ -715,7 +715,7 @@ class FunctionMask(MaskBase):
     def __init__(self, function):
         self._function = function
 
-    def _validate_wcs(self, new_data, new_wcs, **kwargs):
+    def _validate_wcs(self, new_data=None, new_wcs=None, **kwargs):
         pass
 
     def _include(self, data=None, wcs=None, view=()):

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -335,11 +335,18 @@ class CompositeMask(MaskBase):
             mask2 = BooleanArrayMask(mask2, mask1._wcs, shape=mask1.shape)
 
         # both entries must have compatible, which effectively means
-        # equal, WCSes.
-        mask1._validate_wcs(new_data=None, wcs=mask2._wcs)
-        # In order to composite composites, they must have a _wcs defined.
-        # (maybe this should be a property?)
-        self._wcs = mask1._wcs
+        # equal, WCSes.  Unless one is a function.
+        if hasattr(mask1, '_wcs') and hasattr(mask2, '_wcs'):
+            mask1._validate_wcs(new_data=None, wcs=mask2._wcs)
+            # In order to composite composites, they must have a _wcs defined.
+            # (maybe this should be a property?)
+            self._wcs = mask1._wcs
+        elif hasattr(mask1, '_wcs'):
+            # if one mask doesn't have a WCS, but the other does, the
+            # compositemask should have the same WCS as the one that does
+            self._wcs = mask1._wcs
+        elif hasattr(mask2, '_wcs'):
+            self._wcs = mask2._wcs
 
         self._mask1 = mask1
         self._mask2 = mask2

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -336,7 +336,7 @@ class CompositeMask(MaskBase):
 
         # both entries must have compatible, which effectively means
         # equal, WCSes.
-        mask1._validate_wcs(mask2._wcs)
+        mask1._validate_wcs(wcs=mask2._wcs)
         # In order to composite composites, they must have a _wcs defined.
         # (maybe this should be a property?)
         self._wcs = mask1._wcs

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -314,6 +314,17 @@ class CompositeMask(MaskBase):
     """
 
     def __init__(self, mask1, mask2, operation='and'):
+        if isinstance(mask1, np.ndarray) and isinstance(mask2, MaskBase):
+            if not is_broadcastable_and_smaller(mask1.shape, mask2.shape):
+                raise ValueError("Mask1 shape is not broadcastable to Mask2 shape: "
+                                 "%s vs %s" % (mask1.shape, mask2.shape))
+            mask1 = BooleanArrayMask(mask1, mask2._wcs, shape=mask2.shape)
+        elif isinstance(mask2, np.ndarray) and isinstance(mask1, MaskBase):
+            if not is_broadcastable_and_smaller(mask2.shape, mask1.shape):
+                raise ValueError("Mask2 shape is not broadcastable to Mask1 shape: "
+                                 "%s vs %s" % (mask2.shape, mask1.shape))
+            mask2 = BooleanArrayMask(mask2, mask1._wcs, shape=mask1.shape)
+
         self._mask1 = mask1
         self._mask2 = mask2
         self._operation = operation

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -336,7 +336,7 @@ class CompositeMask(MaskBase):
 
         # both entries must have compatible, which effectively means
         # equal, WCSes.
-        self._mask1._validate_wcs(self._mask2._wcs)
+        mask1._validate_wcs(mask2._wcs)
         # In order to composite composites, they must have a _wcs defined.
         # (maybe this should be a property?)
         self._wcs = self._mask1._wcs

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -167,7 +167,7 @@ class MaskBase(object):
 
     def _filled(self, data, wcs=None, fill=np.nan, view=(), **kwargs):
         """
-        Replace the exluded elements of *array* with *fill*.
+        Replace the excluded elements of *array* with *fill*.
 
         Parameters
         ----------
@@ -207,6 +207,11 @@ class MaskBase(object):
 
     def __invert__(self):
         return InvertedMask(self)
+
+    @property
+    def shape(self):
+        raise NotImplementedError("{0} mask classes do not have shape attributes."
+                                  .format(self.__class__.__name__))
 
     def __getitem__(self):
         raise NotImplementedError("Slicing not supported by mask class {0}"
@@ -282,6 +287,10 @@ class InvertedMask(MaskBase):
     def __init__(self, mask):
         self._mask = mask
 
+    @property
+    def shape(self):
+        return self._mask.shape
+
     def _include(self, data=None, wcs=None, view=()):
         return ~self._mask.include(data=data, wcs=wcs, view=view)
 
@@ -314,12 +323,12 @@ class CompositeMask(MaskBase):
     """
 
     def __init__(self, mask1, mask2, operation='and'):
-        if isinstance(mask1, np.ndarray) and isinstance(mask2, MaskBase):
+        if isinstance(mask1, np.ndarray) and isinstance(mask2, MaskBase) and hasattr(mask2, 'shape'):
             if not is_broadcastable_and_smaller(mask1.shape, mask2.shape):
                 raise ValueError("Mask1 shape is not broadcastable to Mask2 shape: "
                                  "%s vs %s" % (mask1.shape, mask2.shape))
             mask1 = BooleanArrayMask(mask1, mask2._wcs, shape=mask2.shape)
-        elif isinstance(mask2, np.ndarray) and isinstance(mask1, MaskBase):
+        elif isinstance(mask2, np.ndarray) and isinstance(mask1, MaskBase) and hasattr(mask1, 'shape'):
             if not is_broadcastable_and_smaller(mask2.shape, mask1.shape):
                 raise ValueError("Mask2 shape is not broadcastable to Mask1 shape: "
                                  "%s vs %s" % (mask2.shape, mask1.shape))
@@ -332,6 +341,20 @@ class CompositeMask(MaskBase):
     def _validate_wcs(self, new_data, new_wcs, **kwargs):
         self._mask1._validate_wcs(new_data, new_wcs, **kwargs)
         self._mask2._validate_wcs(new_data, new_wcs, **kwargs)
+
+    @property
+    def shape(self):
+        try:
+            assert self._mask1.shape == self._mask2.shape
+            return self._mask1.shape
+        except AssertionError:
+            raise ValueError("The composite mask does not have a well-defined "
+                             "shape; its two components have shapes {0} and "
+                             "{1}.".format(self._mask1.shape,
+                                           self._mask2.shape))
+        except NotImplementedError:
+            raise ValueError("The composite mask contains at least one "
+                             "component with no defined shape.")
 
     def _include(self, data=None, wcs=None, view=()):
         result_mask_1 = self._mask1._include(data=data, wcs=wcs, view=view)
@@ -524,6 +547,10 @@ class LazyMask(MaskBase):
             raise ValueError("Either a cube or (data & wcs) is required.")
 
         self._wcs_whitelist = set()
+
+    @property
+    def shape(self):
+        return self._data.shape
 
     def _validate_wcs(self, new_data=None, new_wcs=None, **kwargs):
         """

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -37,7 +37,6 @@ def test_spectral_cube_mask():
     assert_allclose(m._filled(data, wcs, view=(0, 0, slice(1, 4))), [1, 2, np.nan])
     assert_allclose(m._flattened(data, wcs, view=(0, 0, slice(1, 4))), [1, 2])
 
-
 def test_lazy_mask():
 
     data = np.arange(5).reshape((1, 1, 5))
@@ -543,3 +542,16 @@ def test_filled():
     assert_allclose(filled, filled_)
 
     assert (np.isnan(filled) == mcube.mask.exclude()).all()
+
+def test_boolean_array_composite_mask():
+
+    cube, data = cube_and_raw('adv.fits')
+
+    med = cube.median()
+    mask = cube > med
+    arrmask = cube.max(axis=0) > med
+
+    # we're just testing that this doesn't fail
+    combined_mask = mask & arrmask
+
+    mcube = cube.with_mask(combined_mask)

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -555,3 +555,6 @@ def test_boolean_array_composite_mask():
     combined_mask = mask & arrmask
 
     mcube = cube.with_mask(combined_mask)
+
+    # not doing assert_almost_equal because I don't want to worry about precision
+    assert (mcube.sum() > 9.5 * u.K) & (mcube.sum() < 9.6*u.K)


### PR DESCRIPTION
Currently, if you try something like:

```
cube.with_mask((cube > 5*cube.unit) & (cube.max(axis=0) > 10*cube.unit))
```

you'll get an uninformative `AttributeError: 'numpy.ndarray' object has no attribute '_validate_wcs'` because `with_mask` isn't handling the input mask, CompositeMask is.  This fixes that.

TODO:

 * [x] write a test