### PR TITLE
allow an equivalency to be specified for Jy<->K in LDOs, don't force them to have frequency defined

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -197,13 +197,17 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
 
             # create a beam equivalency for brightness temperature
             if freq is None:
-                try:
-                    freq = self.with_spectral_unit(u.Hz).spectral_axis
-                except AttributeError:
-                    raise TypeError("Object of type {0} has no spectral "
-                                    "information. `freq` must be provided for"
-                                    " unit conversion from Jy/beam"
-                                    .format(type(self)))
+                if any({u.Jy, u.K}.issubset(set(eq)) for eq in equivalencies):
+                    # Do nothing: we already have a valid equivalency
+                    pass
+                else:
+                    try:
+                        freq = self.with_spectral_unit(u.Hz).spectral_axis
+                    except AttributeError:
+                        raise TypeError("Object of type {0} has no spectral "
+                                        "information. `freq` must be provided for"
+                                        " unit conversion from Jy/beam"
+                                        .format(type(self)))
             else:
                 if not freq.unit.is_equivalent(u.Hz):
                     raise u.UnitsError("freq must be given in equivalent "

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -189,7 +189,7 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
             return self
 
         if ((self.unit.is_equivalent(u.Jy / u.beam) and
-             not any({u.Jy, u.K}.issubset(set(eq)) for eq in equivalencies))):
+             not any({u.Jy/u.beam, u.K}.issubset(set(eq)) for eq in equivalencies))):
             # the 'not any' above checks that there is not already a defined
             # Jy<->K equivalency.  If there is, the code below is redundant
             # and will cause problems.
@@ -215,6 +215,12 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
                                        "frequency units.")
 
             bmequiv = self.beam.jtok_equiv(freq)
+
+            # backport to handle astropy < 3: the beam equivalency was only
+            # modified to handle jy/beam in astropy 3
+            if bmequiv[0] == u.Jy:
+                bmequiv.append([u.Jy/u.beam, u.K, bmequiv[2], bmequiv[3]])
+
             factor = brightness_unit.to(unit,
                                         equivalencies=bmequiv + list(equivalencies))
 


### PR DESCRIPTION
currently, trying to do `projection.to(u.K, equivalency)` will fail if no frequency is associated with the ldo