### PR TITLE
Memory mapping in smoothing operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         - SETUP_CMD='test -a "--boxed"'
         - NUMPY_VERSION=1.13
         - ASTROPY_VERSION=stable
-        - CONDA_DEPENDENCIES='matplotlib aplpy pytest pytest-xdist astropy-helpers'
+        - CONDA_DEPENDENCIES='matplotlib aplpy pytest pytest-xdist astropy-helpers joblib'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
         - PIP_DEPENDENCIES='https://github.com/radio-astro-tools/pvextractor/archive/master.zip radio_beam'
         - SETUP_XVFB=True
@@ -45,7 +45,7 @@ matrix:
         # make sure *everything* is run for coverage tests
         - python: 3.6
           env: SETUP_CMD='test --coverage'
-               CONDA_DEPENDENCIES='matplotlib aplpy yt bottleneck pytest pytest-xdist astropy-helpers'
+               CONDA_DEPENDENCIES='matplotlib aplpy yt bottleneck pytest pytest-xdist astropy-helpers joblib'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,8 @@
 ------------------
  - Refactor spectral smoothing tools to allow parallelized application *and*
    memory mapped output (to avoid loading cube into memory).  Created
-   ``apply_function_parallel_spectral`` to make this general.
+   ``apply_function_parallel_spectral`` to make this general.  Added
+   ``joblib`` as a dependency.
    (https://github.com/radio-astro-tools/spectral-cube/pull/474)
 
 0.4.2 (2018-02-21)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 0.4.3 (unreleased)
 ------------------
- - none yet
+ - Refactor spectral smoothing tools to allow parallelized application *and*
+   memory mapped output (to avoid loading cube into memory).  Created
+   ``apply_function_parallel_spectral`` to make this general.
+   (https://github.com/radio-astro-tools/spectral-cube/pull/474)
 
 0.4.2 (2018-02-21)
 ------------------

--- a/pip-requirements
+++ b/pip-requirements
@@ -1,0 +1,3 @@
+numpy>=1.9
+astropy>=1.0
+joblib

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -397,6 +397,9 @@ def _map_context(numcores):
     """
     Mapping context manager to allow parallel mapping or regular mapping
     depending on the number of cores specified.
+
+    The builtin map is overloaded to handle python3 problems: python3 returns a
+    generator, while ``multiprocessing.Pool.map`` actually runs the whole thing
     """
     if numcores is not None and numcores > 1:
         try:
@@ -405,13 +408,13 @@ def _map_context(numcores):
             map = p.map
             parallel = True
         except ImportError:
-            map = builtins.map
+            map = lambda x,y: list(builtins.map(x,y))
             warnings.warn("Could not import multiprocessing.  "
                           "map will be non-parallel.")
             parallel = False
     else:
         parallel = False
-        map = builtins.map
+        map = lambda x,y: list(builtins.map(x,y))
 
     try:
         yield map

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -403,24 +403,20 @@ def _map_context(numcores):
     """
     if numcores is not None and numcores > 1:
         try:
-            import multiprocessing
-            p = multiprocessing.Pool(processes=numcores)
-            map = p.map
+            from joblib import Parallel, delayed
+            from joblib.pool import has_shareable_memory
+            map = lambda x,y: Parallel(n_jobs=numcores)(delayed(has_shareable_memory)(x))(y)
             parallel = True
         except ImportError:
             map = lambda x,y: list(builtins.map(x,y))
-            warnings.warn("Could not import multiprocessing.  "
+            warnings.warn("Could not import joblib.  "
                           "map will be non-parallel.")
             parallel = False
     else:
         parallel = False
         map = lambda x,y: list(builtins.map(x,y))
 
-    try:
-        yield map
-    finally:
-        if parallel:
-            p.close()
+    yield map
 
 
 def convert_bunit(bunit):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2608,12 +2608,12 @@ class SpectralCube(BaseSpectralCube):
         if not scipyOK:
             raise ImportError("Scipy could not be imported: this function won't work.")
 
-        return self.apply_function_parallel_spectral(ndimage.filters.median_filter,
-                                                     data=self.filled_data,
-                                                     size=ksize,
-                                                     num_cores=num_cores,
-                                                     use_memmap=use_memmap,
-                                                     **kwargs)
+        return self._apply_function_parallel_spectral(ndimage.filters.median_filter,
+                                                      data=self.filled_data,
+                                                      size=ksize,
+                                                      num_cores=num_cores,
+                                                      use_memmap=use_memmap,
+                                                      **kwargs)
 
     def _apply_function_parallel_spectral(self,
                                           function,

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2690,7 +2690,7 @@ class SpectralCube(BaseSpectralCube):
                                                                    **kwargs)
                                           for arg in spectra)
             except ImportError:
-                if num_cores > 1:
+                if num_cores is not None and num_cores > 1:
                     warnings.warn("Could not import joblib.  Will run in serial.",
                                   ImportError)
                 parallel = False

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -779,7 +779,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         return self._new_cube_with(data=data, unit=unit)
 
     def apply_function(self, function, axis=None, weights=None, unit=None,
-                       projection=False, progressbar=False, 
+                       projection=False, progressbar=False,
                        update_function=None, keep_shape=False, **kwargs):
         """
         Apply a function to valid data along the specified axis or to the whole

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2651,9 +2651,10 @@ class SpectralCube(BaseSpectralCube):
         Parameters
         ----------
         function : function
-            The function to apply in the spectral dimension.  It must take a
-            single argument, which is an array representing a spectrum.
-            It may also accept **kwargs.
+            The function to apply in the spectral dimension.  It must take
+            two arguments: an array representing a spectrum and a boolean array
+            representing the mask.  It may also accept **kwargs.  The function
+            must return an object with the same shape as the input spectrum.
         update_function : method
             Method that is called to update an external progressbar
             If provided, it disables the default `astropy.utils.console.ProgressBar`
@@ -2703,7 +2704,7 @@ class SpectralCube(BaseSpectralCube):
             update_function()
 
             if any(includemask):
-                outcube[:,jj,ii] = function(spec, **kwargs)
+                outcube[:,jj,ii] = function(spec, mask, **kwargs)
             else:
                 outcube[:,jj,ii] = spec
 
@@ -2752,7 +2753,7 @@ class SpectralCube(BaseSpectralCube):
             Passed to the convolve function
         """
 
-        def func(spec):
+        def func(spec, mask):
             return convolve(spec, kernel, normalize_kernel=True, **kwargs)
 
         return self.apply_function_parallel_spectral(func, num_cores=num_cores,
@@ -2821,6 +2822,7 @@ class SpectralCube(BaseSpectralCube):
         if outdiff > 2 * indiff and not suppress_smooth_warning:
             warnings.warn("Input grid has too small a spacing. The data should "
                           "be smoothed prior to resampling.")
+
 
         newcube = np.empty([spectral_grid.size, self.shape[1], self.shape[2]],
                            dtype=cubedata[:1, 0, 0].dtype)

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2669,14 +2669,15 @@ class SpectralCube(BaseSpectralCube):
 
         shape = self.shape
 
+        # 'spectra' is a generator
         # the boolean check will skip smoothing for bad spectra
         # TODO: should spatial good/bad be cached?
-        spectra = [(self.filled_data[:,jj,ii],
+        spectra = ((self.filled_data[:,jj,ii],
                     self.mask.include(view=(slice(None), jj, ii)),
                     ii, jj,
                    )
                    for jj in range(shape[1])
-                   for ii in range(shape[2])]
+                   for ii in range(shape[2]))
 
         if update_function is None:
             pb = ProgressBar(shape[1] * shape[2])

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2633,7 +2633,7 @@ class SpectralCube(BaseSpectralCube):
         num_cores : int or None
             The number of cores to use if running in parallel
         kwargs : dict
-            Passed to the convolve function
+            Passed to ``function``
         """
         shape = self.shape
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -90,7 +90,9 @@ def aggregation_docstring(func):
 
 def _apply_function(arguments, outcube, function, **kwargs):
     """
-    Helper function to smooth a spectrum
+    Helper function to apply a function to a spectrum.
+    Needs to be declared toward the top of the code to allow pickling by
+    joblib.
     """
     (spec, includemask, ii, jj) = arguments
 
@@ -2675,7 +2677,8 @@ class SpectralCube(BaseSpectralCube):
                                  "override this restriction.")
             outcube = np.empty(shape=shape, dtype=np.float)
 
-        if parallel:
+        if parallel and use_memmap:
+            # it is not possible to run joblib parallelization without memmap
             try:
                 from joblib import Parallel, delayed
 
@@ -2694,7 +2697,7 @@ class SpectralCube(BaseSpectralCube):
 
         # this isn't an else statement because we want to catch the case where
         # the above clause fails on ImportError
-        if not parallel:
+        if not parallel or not use_memmap:
             if verbose > 0:
                 progressbar = ProgressBar(self.shape[1]*self.shape[2])
                 pbu = progressbar.update

--- a/spectral_cube/tests/test_performance.py
+++ b/spectral_cube/tests/test_performance.py
@@ -62,11 +62,11 @@ def test_parallel_performance_smoothing():
     import timeit
 
     setup = 'cube,_ = utilities.generate_gaussian_cube(shape=(300,100,100))'
-    stmt = 'result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores={0}, use_memmap=False)'
+    stmt = 'result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(20.0), num_cores={0}, use_memmap=False)'
 
     rslt = {}
     for ncores in (1,2,3,4):
-        time = timeit.timeit(stmt=stmt.format(ncores), setup=setup, number=5, globals=globals())
+        time = timeit.timeit(stmt=stmt.format(ncores), setup=setup, number=3, globals=globals())
         rslt[ncores] = time
 
     print()
@@ -74,14 +74,13 @@ def test_parallel_performance_smoothing():
     print(rslt)
 
     setup = 'cube,_ = utilities.generate_gaussian_cube(shape=(300,100,100))'
-    stmt = 'result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores={0}, use_memmap=True)'
+    stmt = 'result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(20.0), num_cores={0}, use_memmap=True)'
 
     rslt = {}
     for ncores in (1,2,3,4):
-        time = timeit.timeit(stmt=stmt.format(ncores), setup=setup, number=5, globals=globals())
+        time = timeit.timeit(stmt=stmt.format(ncores), setup=setup, number=3, globals=globals())
         rslt[ncores] = time
 
     print()
     print("memmap=True")
     print(rslt)
-

--- a/spectral_cube/tests/test_performance.py
+++ b/spectral_cube/tests/test_performance.py
@@ -61,7 +61,7 @@ def test_parallel_performance_smoothing():
 
     import timeit
 
-    setup = 'cube,_ = utilities.generate_gaussian_cube(shape=(300,100,100))'
+    setup = 'cube,_ = utilities.generate_gaussian_cube(shape=(300,32,32))'
     stmt = 'result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(20.0), num_cores={0}, use_memmap=False)'
 
     rslt = {}
@@ -73,7 +73,7 @@ def test_parallel_performance_smoothing():
     print("memmap=False")
     print(rslt)
 
-    setup = 'cube,_ = utilities.generate_gaussian_cube(shape=(300,100,100))'
+    setup = 'cube,_ = utilities.generate_gaussian_cube(shape=(300,32,32))'
     stmt = 'result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(20.0), num_cores={0}, use_memmap=True)'
 
     rslt = {}

--- a/spectral_cube/tests/test_performance.py
+++ b/spectral_cube/tests/test_performance.py
@@ -61,24 +61,24 @@ def test_parallel_performance_smoothing():
 
     import timeit
 
-    setup = 'cube,_ = utilities.generate_gaussian_cube(shape=(300,32,32))'
+    setup = 'cube,_ = utilities.generate_gaussian_cube(shape=(300,64,64))'
     stmt = 'result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(20.0), num_cores={0}, use_memmap=False)'
 
     rslt = {}
     for ncores in (1,2,3,4):
-        time = timeit.timeit(stmt=stmt.format(ncores), setup=setup, number=3, globals=globals())
+        time = timeit.timeit(stmt=stmt.format(ncores), setup=setup, number=5, globals=globals())
         rslt[ncores] = time
 
     print()
     print("memmap=False")
     print(rslt)
 
-    setup = 'cube,_ = utilities.generate_gaussian_cube(shape=(300,32,32))'
+    setup = 'cube,_ = utilities.generate_gaussian_cube(shape=(300,64,64))'
     stmt = 'result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(20.0), num_cores={0}, use_memmap=True)'
 
     rslt = {}
     for ncores in (1,2,3,4):
-        time = timeit.timeit(stmt=stmt.format(ncores), setup=setup, number=3, globals=globals())
+        time = timeit.timeit(stmt=stmt.format(ncores), setup=setup, number=5, globals=globals())
         rslt[ncores] = time
 
     print()

--- a/spectral_cube/tests/test_performance.py
+++ b/spectral_cube/tests/test_performance.py
@@ -4,9 +4,14 @@ Performance-related tests to make sure we don't use more memory than we should
 
 from __future__ import print_function, absolute_import, division
 
+import pytest
+
 from .test_moments import moment_cube
 from .helpers import assert_allclose
 from ..spectral_cube import SpectralCube
+from . import utilities
+
+from astropy import convolution
 
 def find_base_nbytes(obj):
     # from http://stackoverflow.com/questions/34637875/size-of-numpy-strided-array-broadcast-array-in-memory
@@ -50,3 +55,33 @@ def test_pix_cen():
     assert find_base_nbytes(s) == sc.shape[0]*bytes_per_pix
     assert find_base_nbytes(y) == sc.shape[1]*sc.shape[2]*bytes_per_pix
     assert find_base_nbytes(x) == sc.shape[1]*sc.shape[2]*bytes_per_pix
+
+@pytest.mark.skipif('True')
+def test_parallel_performance_smoothing():
+
+    import timeit
+
+    setup = 'cube,_ = utilities.generate_gaussian_cube(shape=(300,100,100))'
+    stmt = 'result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores={0}, use_memmap=False)'
+
+    rslt = {}
+    for ncores in (1,2,3,4):
+        time = timeit.timeit(stmt=stmt.format(ncores), setup=setup, number=5, globals=globals())
+        rslt[ncores] = time
+
+    print()
+    print("memmap=False")
+    print(rslt)
+
+    setup = 'cube,_ = utilities.generate_gaussian_cube(shape=(300,100,100))'
+    stmt = 'result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores={0}, use_memmap=True)'
+
+    rslt = {}
+    for ncores in (1,2,3,4):
+        time = timeit.timeit(stmt=stmt.format(ncores), setup=setup, number=5, globals=globals())
+        rslt[ncores] = time
+
+    print()
+    print("memmap=True")
+    print(rslt)
+

--- a/spectral_cube/tests/test_performance.py
+++ b/spectral_cube/tests/test_performance.py
@@ -81,6 +81,9 @@ def test_parallel_performance_smoothing():
         time = timeit.timeit(stmt=stmt.format(ncores), setup=setup, number=5, globals=globals())
         rslt[ncores] = time
 
+    stmt = 'result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(20.0), num_cores={0}, use_memmap=True, parallel=False)'
+    rslt[0] = timeit.timeit(stmt=stmt.format(1), setup=setup, number=5, globals=globals())
+
     print()
     print("memmap=True")
     print(rslt)

--- a/spectral_cube/tests/test_performance.py
+++ b/spectral_cube/tests/test_performance.py
@@ -87,3 +87,23 @@ def test_parallel_performance_smoothing():
     print()
     print("memmap=True")
     print(rslt)
+
+
+    if False:
+        for shape in [(300,64,64), (600,64,64), (900,64,64),
+                      (300,128,128), (300,256,256), (900,256,256)]:
+
+            setup = 'cube,_ = utilities.generate_gaussian_cube(shape={0})'.format(shape)
+            stmt = 'result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(20.0), num_cores={0}, use_memmap=True)'
+
+            rslt = {}
+            for ncores in (1,2,3,4):
+                time = timeit.timeit(stmt=stmt.format(ncores), setup=setup, number=5, globals=globals())
+                rslt[ncores] = time
+
+            stmt = 'result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(20.0), num_cores={0}, use_memmap=True, parallel=False)'
+            rslt[0] = timeit.timeit(stmt=stmt.format(1), setup=setup, number=5, globals=globals())
+
+            print()
+            print("memmap=True shape={0}".format(shape))
+            print(rslt)

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -21,6 +21,12 @@ try:
 except ImportError:
     REPROJECT_INSTALLED = False
 
+try:
+    import joblib
+    JOBLIB_INSTALLED = True
+except ImportError:
+    JOBLIB_INSTALLED = False
+
 
 def test_convolution():
     cube, data = cube_and_raw('255_delta.fits')
@@ -107,7 +113,7 @@ def test_spectral_smooth():
 
     cube, data = cube_and_raw('522_delta.fits')
 
-    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0))
+    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), use_memmap=False)
 
     np.testing.assert_almost_equal(result[:,0,0].value,
                                    convolution.Gaussian1DKernel(1.0,
@@ -123,11 +129,12 @@ def test_spectral_smooth():
 
 
 # TODO: uncomment this when we figure out how to make it work
+@pytest.mark.skipif('not JOBLIB_INSTALLED')
 def test_spectral_smooth_4cores():
 
     cube, data = cube_and_raw('522_delta.fits')
 
-    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4)
+    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4, use_memmap=False)
 
     np.testing.assert_almost_equal(result[:,0,0].value,
                                    convolution.Gaussian1DKernel(1.0,

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -134,6 +134,15 @@ def test_spectral_smooth_4cores():
 
     cube, data = cube_and_raw('522_delta.fits')
 
+
+    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4, use_memmap=True)
+
+    np.testing.assert_almost_equal(result[:,0,0].value,
+                                   convolution.Gaussian1DKernel(1.0,
+                                                                x_size=5).array,
+                                   4)
+
+    # this is one way to test non-parallel mode
     result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4, use_memmap=False)
 
     np.testing.assert_almost_equal(result[:,0,0].value,
@@ -141,7 +150,9 @@ def test_spectral_smooth_4cores():
                                                                 x_size=5).array,
                                    4)
 
-    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4, use_memmap=True)
+    # num_cores = 4 is a contradiction with parallel=False, but we want to make
+    # sure it does the same thing
+    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4, parallel=False)
 
     np.testing.assert_almost_equal(result[:,0,0].value,
                                    convolution.Gaussian1DKernel(1.0,

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -114,18 +114,32 @@ def test_spectral_smooth():
                                                                 x_size=5).array,
                                    4)
 
+    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), use_memmap=True)
+
+    np.testing.assert_almost_equal(result[:,0,0].value,
+                                   convolution.Gaussian1DKernel(1.0,
+                                                                x_size=5).array,
+                                   4)
+
 
 # TODO: uncomment this when we figure out how to make it work
-#def test_spectral_smooth_4cores():
-#
-#    cube, data = cube_and_raw('522_delta.fits')
-#
-#    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4)
-#
-#    np.testing.assert_almost_equal(result[:,0,0].value,
-#                                   convolution.Gaussian1DKernel(1.0,
-#                                                                x_size=5).array,
-#                                   4)
+def test_spectral_smooth_4cores():
+
+    cube, data = cube_and_raw('522_delta.fits')
+
+    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4)
+
+    np.testing.assert_almost_equal(result[:,0,0].value,
+                                   convolution.Gaussian1DKernel(1.0,
+                                                                x_size=5).array,
+                                   4)
+
+    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4, use_memmap=True)
+
+    np.testing.assert_almost_equal(result[:,0,0].value,
+                                   convolution.Gaussian1DKernel(1.0,
+                                                                x_size=5).array,
+                                   4)
 
 
 

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -115,6 +115,20 @@ def test_spectral_smooth():
                                    4)
 
 
+# TODO: uncomment this when we figure out how to make it work
+#def test_spectral_smooth_4cores():
+#
+#    cube, data = cube_and_raw('522_delta.fits')
+#
+#    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4)
+#
+#    np.testing.assert_almost_equal(result[:,0,0].value,
+#                                   convolution.Gaussian1DKernel(1.0,
+#                                                                x_size=5).array,
+#                                   4)
+
+
+
 def test_spectral_smooth_fail():
 
     cube, data = cube_and_raw('522_delta_beams.fits')

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1680,6 +1680,17 @@ def test_spectral_smooth_median():
 
     np.testing.assert_almost_equal(cube_spectral_median[:,1,1].value, result)
 
+@pytest.mark.skipif('not SCIPYOK')
+def test_spectral_smooth_median_4cores():
+    cube, data = cube_and_raw('adv.fits')
+
+    cube_spectral_median = cube.spectral_smooth_median(3, num_cores=4)
+
+    # Check first slice
+    result = np.array([0.77513282,  0.35675333,  0.35675333,  0.98688694])
+
+    np.testing.assert_almost_equal(cube_spectral_median[:,1,1].value, result)
+
 def test_initialization_from_units():
     """
     Regression test for issue 447

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -36,6 +36,12 @@ warnings.simplefilter('error', utils.NotImplementedWarning)
 warnings.simplefilter('error', utils.WCSMismatchWarning)
 
 try:
+    import joblib
+    JOBLIB_INSTALLED = True
+except ImportError:
+    JOBLIB_INSTALLED = False
+
+try:
     import scipy.ndimage
     SCIPYOK = True
 except ImportError:
@@ -1681,6 +1687,7 @@ def test_spectral_smooth_median():
     np.testing.assert_almost_equal(cube_spectral_median[:,1,1].value, result)
 
 @pytest.mark.skipif('not SCIPYOK')
+@pytest.mark.skipif('not JOBLIB_INSTALLED')
 def test_spectral_smooth_median_4cores():
     cube, data = cube_and_raw('adv.fits')
 


### PR DESCRIPTION
The previous implementation stored the full cube in memory as a list of spectra without ever checking the cube size (bad!) and duplicated that object in memory a second time when doing `np.array([list of spectra])`.

This is an attempt to work around that using memory maps by default and allocating the full memory otherwise.