### PR TITLE
bottleneck.nanmedian does not allow axis with a tuple/list.

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -974,7 +974,8 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             bnok = False
 
         # slicewise median is nonsense, must force how = 'cube'
-        if bnok and not iterate_rays:
+        # bottleneck.nanmedian does not allow axis to be a list or tuple
+        if bnok and not iterate_rays and not isinstance(axis, (list, tuple)):
             log.debug("Using bottleneck nanmedian")
             result = self.apply_numpy_function(nanmedian, axis=axis,
                                                projection=True, unit=self.unit,

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1704,3 +1704,19 @@ def test_varyres_spectra():
 
     assert isinstance(sp, VaryingResolutionOneDSpectrum)
     assert hasattr(sp, 'beams')
+
+def test_median_2axis():
+    """
+    As of this writing the bottleneck.nanmedian did not accept an axis that is a tuple/list so this test
+    is to make sure that is properly taken into account.
+
+    :return:
+    """
+    cube, data = cube_and_raw('adv.fits')
+
+    cube_median = cube.median(axis=(1, 2))
+
+    # Check first slice
+    result0 = np.array([0.83498009, 0.2606566 , 0.37271531, 0.48548023])
+
+    np.testing.assert_almost_equal(cube_median.value, result0)


### PR DESCRIPTION
As stated, as of version 1.2.1 of bottleneck it does not allow a tuple/list for the axis.  So, this adds a check to see if that is the case.

Fixes #476 