### PR TITLE
Pinning sip to fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         - SETUP_CMD='test -a "--boxed"'
         - NUMPY_VERSION=1.13
         - ASTROPY_VERSION=stable
-        - CONDA_DEPENDENCIES='matplotlib aplpy pytest pytest-xdist astropy-helpers joblib'
+        - CONDA_DEPENDENCIES='sip<4.19 matplotlib aplpy pytest pytest-xdist astropy-helpers joblib'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
         - PIP_DEPENDENCIES='https://github.com/radio-astro-tools/pvextractor/archive/master.zip radio_beam'
         - SETUP_XVFB=True


### PR DESCRIPTION
The sip conda build has some issues, and the current workaround is to limit the version number (as it was suggested by anaconda people for ci-helpers here https://github.com/astropy/ci-helpers/pull/289)