### PR TITLE
pass keyword arguments to convolve

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2878,7 +2878,7 @@ class SpectralCube(BaseSpectralCube):
 
         return newcube
 
-    def convolve_to(self, beam, convolve=convolution.convolve_fft, update_function=None):
+    def convolve_to(self, beam, convolve=convolution.convolve_fft, update_function=None, **kwargs):
         """
         Convolve each channel in the cube to a specified beam
 
@@ -2893,6 +2893,8 @@ class SpectralCube(BaseSpectralCube):
         update_function : method
             Method that is called to update an external progressbar
             If provided, it disables the default `astropy.utils.console.ProgressBar`
+        kwargs : dict
+            Keyword arguments to pass to the convolution function
 
         Returns
         -------
@@ -2911,7 +2913,7 @@ class SpectralCube(BaseSpectralCube):
         newdata = np.empty(self.shape)
         for ii,img in enumerate(self.filled_data[:]):
             newdata[ii,:,:] = convolve(img, convolution_kernel,
-                                       normalize_kernel=True)
+                                       normalize_kernel=True, **kwargs)
             update_function()
 
         newcube = self._new_cube_with(data=newdata, beam=beam)


### PR DESCRIPTION
Simple oversight; there are lots of things you might want to pass to convolve, such as `allow_huge=True`