### PR TITLE
add a python2.7 test that is not locked to numpy 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,11 @@ matrix:
         - python: 2.7
           env: NUMPY_VERSION=1.9 CONDA_DEPENDENCIES='matplotlib aplpy bottleneck pytest pytest-xdist astropy-helpers'
                PIP_DEPENDENCIES='https://github.com/radio-astro-tools/pvextractor/archive/master.zip radio_beam'
+
+        # test python2.7 with recent numpy version
+        - python: 2.7
+          env: PIP_DEPENDENCIES='https://github.com/radio-astro-tools/pvextractor/archive/master.zip radio_beam'
+
         - python: 3.6
           env: NUMPY_VERSION=1.11 CONDA_DEPENDENCIES='matplotlib aplpy bottleneck pytest pytest-xdist astropy-helpers'
 


### PR DESCRIPTION
there are two python2.7 tests running with numpy 1.9, but none with more recent versions of numpy.  This is partly so we can test bottleneck, but I'm not clear whether some other errors might come from using an old numpy