### PR TITLE
Fix to_glue with recent versions of glue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ env:
         - SETUP_CMD='test -a "--boxed"'
         - NUMPY_VERSION=1.13
         - ASTROPY_VERSION=stable
-        - CONDA_DEPENDENCIES='sip<4.19 matplotlib aplpy pytest pytest-xdist astropy-helpers joblib'
-        - CONDA_CHANNELS='astropy-ci-extras astropy'
+        - CONDA_DEPENDENCIES='sip<4.19 matplotlib aplpy pytest pytest-xdist astropy-helpers joblib glue-core'
+        - CONDA_CHANNELS='astropy-ci-extras astropy glueviz'
         - PIP_DEPENDENCIES='https://github.com/radio-astro-tools/pvextractor/archive/master.zip radio_beam'
         - SETUP_XVFB=True
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 0.4.4 (unreleased)
 ------------------
- - none yet
+ - Bugfix: fix compatibility of to_glue with latest versions of glue.
+   (https://github.com/radio-astro-tools/spectral-cube/pull/491)
 
 0.4.3 (2018-04-05)
 ------------------

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2153,7 +2153,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         from glue.app.qt import GlueApplication
         from glue.core import DataCollection, Data
         from glue.core.coordinates import coordinates_from_header
-        from glue.viewers.image.qt.viewer_widget import ImageWidget
+        try:
+            from glue.viewers.image.qt.data_viewer import ImageViewer
+        except ImportError:
+            from glue.viewers.image.qt.viewer_widget import ImageWidget as ImageViewer
 
         if dataset is not None:
             if name in [d.label for d in dataset.components]:
@@ -2177,7 +2180,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
 
                     #start Glue
                     ga = self._glue_app = GlueApplication(dc)
-                    self._glue_viewer = ga.new_data_viewer(ImageWidget,
+                    self._glue_viewer = ga.new_data_viewer(ImageViewer,
                                                            data=result)
 
                     if start_gui:
@@ -3571,7 +3574,7 @@ class VaryingResolutionSpectralCube(BaseSpectralCube, MultiBeamMixinClass):
                              "spectrally smoothed.  Convolve to a "
                              "common resolution with `convolve_to` before "
                              "attempting spectral smoothed.")
-    
+
     @warn_slow
     def to(self, unit, equivalencies=()):
         """

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -15,18 +15,6 @@ from .test_spectral_cube import cube_and_raw
 from .test_projection import load_projection
 from . import path
 
-try:
-    import reproject
-    REPROJECT_INSTALLED = True
-except ImportError:
-    REPROJECT_INSTALLED = False
-
-try:
-    import joblib
-    JOBLIB_INSTALLED = True
-except ImportError:
-    JOBLIB_INSTALLED = False
-
 
 def test_convolution():
     cube, data = cube_and_raw('255_delta.fits')
@@ -63,7 +51,7 @@ def test_beams_convolution():
 
     pixscale = wcs.utils.proj_plane_pixel_area(cube.wcs.celestial)**0.5*u.deg
 
-    for ii,bm in enumerate(cube.beams):
+    for ii, bm in enumerate(cube.beams):
         expected = target_beam.deconvolve(bm).as_kernel(pixscale, x_size=5,
                                                         y_size=5)
         expected.normalize()
@@ -88,8 +76,10 @@ def test_beams_convolution_equal():
     np.testing.assert_almost_equal(cube.filled_data[0].value,
                                    conv_cube.filled_data[0].value)
 
-@pytest.mark.skipif('not REPROJECT_INSTALLED')
+
 def test_reproject():
+
+    pytest.importorskip('reproject')
 
     cube, data = cube_and_raw('adv.fits')
 
@@ -108,6 +98,7 @@ def test_reproject():
     result = cube.reproject(header_out)
 
     assert result.shape == (cube.shape[0], 5, 4)
+
 
 def test_spectral_smooth():
 
@@ -128,12 +119,11 @@ def test_spectral_smooth():
                                    4)
 
 
-# TODO: uncomment this when we figure out how to make it work
-@pytest.mark.skipif('not JOBLIB_INSTALLED')
 def test_spectral_smooth_4cores():
 
-    cube, data = cube_and_raw('522_delta.fits')
+    pytest.importorskip('joblib')
 
+    cube, data = cube_and_raw('522_delta.fits')
 
     result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4, use_memmap=True)
 
@@ -158,7 +148,6 @@ def test_spectral_smooth_4cores():
                                    convolution.Gaussian1DKernel(1.0,
                                                                 x_size=5).array,
                                    4)
-
 
 
 def test_spectral_smooth_fail():
@@ -205,7 +194,6 @@ def test_spectral_interpolate_with_fillvalue():
                                    np.ones(4)*42)
 
 
-
 def test_spectral_interpolate_fail():
 
     cube, data = cube_and_raw('522_delta_beams.fits')
@@ -242,7 +230,7 @@ def test_spectral_interpolate_with_mask():
 
     # The output makes CDELT3 > 0 (reversed spectral axis) so the masked
     # portion are the final 2 channels.
-    np.testing.assert_almost_equal(result[:,0, 0].value,
+    np.testing.assert_almost_equal(result[:, 0, 0].value,
                                    [0.0, 0.5, np.NaN, np.NaN])
 
     assert cube.wcs.wcs.compare(orig_wcs.wcs)
@@ -260,7 +248,6 @@ def test_spectral_interpolate_reversed():
     result = cube.spectral_interpolate(spectral_grid=sg)
 
     np.testing.assert_almost_equal(sg.value, result.spectral_axis.value)
-
 
 
 def test_convolution_2D():
@@ -300,8 +287,9 @@ def test_nocelestial_convolution_2D_fail():
     assert exc.value.args[0] == ("WCS does not contain two spatial axes.")
 
 
-@pytest.mark.skipif('not REPROJECT_INSTALLED')
 def test_reproject_2D():
+
+    pytest.importorskip('reproject')
 
     proj, hdu = load_projection("55.fits")
 
@@ -322,8 +310,9 @@ def test_reproject_2D():
     assert result.beam == proj.beam
 
 
-@pytest.mark.skipif('not REPROJECT_INSTALLED')
 def test_nocelestial_reproject_2D_fail():
+
+    pytest.importorskip('reproject')
 
     cube, data = cube_and_raw('255_delta.fits')
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -35,17 +35,6 @@ warnings.simplefilter('error', utils.UnsupportedIterationStrategyWarning)
 warnings.simplefilter('error', utils.NotImplementedWarning)
 warnings.simplefilter('error', utils.WCSMismatchWarning)
 
-try:
-    import joblib
-    JOBLIB_INSTALLED = True
-except ImportError:
-    JOBLIB_INSTALLED = False
-
-try:
-    import scipy.ndimage
-    SCIPYOK = True
-except ImportError:
-    SCIPYOK = False
 
 try:
     import yt
@@ -54,12 +43,6 @@ try:
 except ImportError:
     YT_INSTALLED = False
     YT_LT_301 = False
-
-try:
-    import bottleneck
-    BOTTLENECK_INSTALLED = True
-except ImportError:
-    BOTTLENECK_INSTALLED = False
 
 from radio_beam import Beam
 
@@ -860,7 +843,6 @@ def test_preserve_spectral_unit():
     assert new_cube.spectral_axis.unit is u.GHz
 
 
-@pytest.mark.skipif('not BOTTLENECK_INSTALLED')
 def test_endians():
     """
     Test that the endianness checking returns something in Native form
@@ -872,6 +854,7 @@ def test_endians():
     little-endian to native in the dtype parameter; I need a workaround for
     this.
     """
+    pytest.importorskip('bottleneck')
     big = np.array([[[1],[2]]], dtype='>f4')
     lil = np.array([[[1],[2]]], dtype='<f4')
     mywcs = WCS(naxis=3)
@@ -1710,8 +1693,11 @@ def test_spatial_smooth_t2d():
 
     np.testing.assert_almost_equal(cube_t2d[2].value, result2)
 
-@pytest.mark.skipif('not SCIPYOK')
+
 def test_spatial_smooth_median():
+
+    pytest.importorskip('scipy.ndimage')
+
     cube, data = cube_and_raw('adv.fits')
 
     cube_median = cube.spatial_smooth_median(3)
@@ -1730,8 +1716,11 @@ def test_spatial_smooth_median():
 
     np.testing.assert_almost_equal(cube_median[2].value, result2)
 
-@pytest.mark.skipif('not SCIPYOK')
+
 def test_spectral_smooth_median():
+
+    pytest.importorskip('scipy.ndimage')
+
     cube, data = cube_and_raw('adv.fits')
 
     cube_spectral_median = cube.spectral_smooth_median(3)
@@ -1741,9 +1730,12 @@ def test_spectral_smooth_median():
 
     np.testing.assert_almost_equal(cube_spectral_median[:,1,1].value, result)
 
-@pytest.mark.skipif('not SCIPYOK')
-@pytest.mark.skipif('not JOBLIB_INSTALLED')
+
 def test_spectral_smooth_median_4cores():
+
+    pytest.importorskip('joblib')
+    pytest.importorskip('scipy.ndimage')
+
     cube, data = cube_and_raw('adv.fits')
 
     cube_spectral_median = cube.spectral_smooth_median(3, num_cores=4)
@@ -1778,12 +1770,11 @@ def test_varyres_spectra():
     assert isinstance(sp, VaryingResolutionOneDSpectrum)
     assert hasattr(sp, 'beams')
 
+
 def test_median_2axis():
     """
-    As of this writing the bottleneck.nanmedian did not accept an axis that is a tuple/list so this test
-    is to make sure that is properly taken into account.
-
-    :return:
+    As of this writing the bottleneck.nanmedian did not accept an axis that is a
+    tuple/list so this test is to make sure that is properly taken into account.
     """
     cube, data = cube_and_raw('adv.fits')
 

--- a/spectral_cube/tests/test_visualization.py
+++ b/spectral_cube/tests/test_visualization.py
@@ -70,3 +70,9 @@ def test_mask_quicklook():
     cube, data = cube_and_raw('vda_Jybeam_lower.fits')
 
     cube.mask.quicklook(view=(0, slice(None), slice(None)), use_aplpy=True)
+
+
+def test_to_glue():
+    pytest.importorskip('glue')
+    cube, data = cube_and_raw('vda_Jybeam_lower.fits')
+    cube.to_glue(start_gui=False)

--- a/spectral_cube/tests/test_visualization.py
+++ b/spectral_cube/tests/test_visualization.py
@@ -2,73 +2,39 @@ from __future__ import print_function, absolute_import, division
 
 import pytest
 
-try:
-    import pvextractor
-    PVEXTRACTOR_INSTALLED = True
-except ImportError:
-    PVEXTRACTOR_INSTALLED = False
-
-try:
-    import matplotlib.pyplot as plt
-    MATPLOTLIB_INSTALLED = True
-except ImportError:
-    MATPLOTLIB_INSTALLED = False
-
-try:
-    import aplpy
-    APLPY_INSTALLED = True
-except ImportError:
-    APLPY_INSTALLED = False
-
-from .. import (SpectralCube, BooleanArrayMask, FunctionMask, LazyMask,
-                CompositeMask)
-from ..spectral_cube import OneDSpectrum, Projection
-from ..np_compat import allbadtonan
-from .. import spectral_axis
-
 from .test_spectral_cube import cube_and_raw
 
 
-@pytest.mark.skipif("not PVEXTRACTOR_INSTALLED")
 def test_to_pvextractor():
-
+    pytest.importorskip('pvextractor')
     cube, data = cube_and_raw('vda_Jybeam_lower.fits')
+    cube.to_pvextractor()
 
-    pv = cube.to_pvextractor()
 
-
-@pytest.mark.skipif("not MATPLOTLIB_INSTALLED")
 def test_projvis():
-
+    pytest.importorskip('matplotlib')
     cube, data = cube_and_raw('vda_Jybeam_lower.fits')
-
     mom0 = cube.moment0()
     mom0.quicklook(use_aplpy=False)
 
-@pytest.mark.skipif("not MATPLOTLIB_INSTALLED")
+
 def test_proj_imshow():
-
+    plt = pytest.importorskip('matplotlib.pyplot')
     cube, data = cube_and_raw('vda_Jybeam_lower.fits')
-
     mom0 = cube.moment0()
-
-    import pylab as pl
-    pl.imshow(mom0)
+    plt.imshow(mom0)
 
 
-@pytest.mark.skipif("not APLPY_INSTALLED")
 def test_projvis_aplpy():
-
+    pytest.importorskip('aplpy')
     cube, data = cube_and_raw('vda_Jybeam_lower.fits')
-
     mom0 = cube.moment0()
     mom0.quicklook(use_aplpy=True)
 
-@pytest.mark.skipif("not APLPY_INSTALLED")
+
 def test_mask_quicklook():
-
+    pytest.importorskip('aplpy')
     cube, data = cube_and_raw('vda_Jybeam_lower.fits')
-
     cube.mask.quicklook(view=(0, slice(None), slice(None)), use_aplpy=True)
 
 


### PR DESCRIPTION
I've also changed some of the tests to use importorskip to simplify skipping related to whether a package is present. There's some more cleanup I'd like to do but I'll open a separate PR for that.

Fixes https://github.com/radio-astro-tools/spectral-cube/issues/163