### PR TITLE
Add spectral-axis sigma clipping

### DIFF
--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -280,6 +280,19 @@ class MaskableArrayMixinClass(object):
                               self.unit, copy=False)
         return self.filled_data[:]
 
+    @cube_utils.slice_syntax
+    def unitless_filled_data(self, view):
+        """
+        Return a portion of the data array, with excluded mask values
+        replaced by :meth:`fill_value`.
+
+        Returns
+        -------
+        data : numpy.array
+            The masked data.
+        """
+        return self._get_filled_data(view, fill=self._fill_value)
+
     @property
     def fill_value(self):
         """ The replacement value used by :meth:`filled_data`.

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2742,8 +2742,9 @@ class SpectralCube(BaseSpectralCube):
         function : function
             The function to apply in the spectral dimension.  It must take
             two arguments: an array representing a spectrum and a boolean array
-            representing the mask.  It may also accept **kwargs.  The function
-            must return an object with the same shape as the input spectrum.
+            representing the mask.  It may also accept ``**kwargs``.  The
+            function must return an object with the same shape as the input
+            spectrum.
         num_cores : int or None
             The number of cores to use if running in parallel
         verbose : int
@@ -2830,7 +2831,9 @@ class SpectralCube(BaseSpectralCube):
         """
         Run astropy's sigma clipper, converting all bad values to NaN
 
-        TODO: Come up with a more friendly masking approach
+        .. TODO::
+            Come up with a more friendly masking approach?  This comment has
+            been edited to say "I don't really know what this means."
         """
 
         return self.apply_function_parallel_spectral(stats.sigma_clip,

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2829,11 +2829,21 @@ class SpectralCube(BaseSpectralCube):
     def sigma_clip(self, threshold, verbose=0, use_memmap=True,
                    num_cores=None, **kwargs):
         """
-        Run astropy's sigma clipper, converting all bad values to NaN
+        Run astropy's sigma clipper, converting all bad values to NaN.
 
-        .. TODO::
-            Come up with a more friendly masking approach?  This comment has
-            been edited to say "I don't really know what this means."
+        Parameters
+        ----------
+        threshold : float
+            The ``sigma`` parameter in `astropy.stats.sigma_clip`, which refers
+            to the number of sigma above which to cut.
+        verbose : int
+            Verbosity level to pass to joblib
+        num_cores : int or None
+            The number of cores to use when applying this function in parallel
+            across the cube.
+        use_memmap : bool
+            If specified, a memory mapped temporary file on disk will be
+            written to rather than storing the intermediate spectra in memory.
         """
 
         return self.apply_function_parallel_spectral(stats.sigma_clip,

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2725,13 +2725,13 @@ class SpectralCube(BaseSpectralCube):
                                                      **kwargs)
 
     def apply_function_parallel_spectral(self,
-                                          function,
-                                          num_cores=None,
-                                          verbose=0,
-                                          use_memmap=True,
-                                          parallel=True,
-                                          **kwargs
-                                         ):
+                                         function,
+                                         num_cores=None,
+                                         verbose=0,
+                                         use_memmap=True,
+                                         parallel=True,
+                                         **kwargs
+                                        ):
         """
         Apply a function in parallel along the spectral dimension.  The
         function will be performed on data with masked values replaced with the
@@ -2872,7 +2872,6 @@ class SpectralCube(BaseSpectralCube):
         """
 
         return self.apply_function_parallel_spectral(convolve,
-                                                     data=self.filled_data,
                                                      kernel=kernel,
                                                      normalize_kernel=True,
                                                      num_cores=num_cores,

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2718,16 +2718,14 @@ class SpectralCube(BaseSpectralCube):
         if not scipyOK:
             raise ImportError("Scipy could not be imported: this function won't work.")
 
-        return self._apply_function_parallel_spectral(ndimage.filters.median_filter,
-                                                      data=self.filled_data,
-                                                      size=ksize,
-                                                      num_cores=num_cores,
-                                                      use_memmap=use_memmap,
-                                                      **kwargs)
+        return self.apply_function_parallel_spectral(ndimage.filters.median_filter,
+                                                     size=ksize,
+                                                     num_cores=num_cores,
+                                                     use_memmap=use_memmap,
+                                                     **kwargs)
 
-    def _apply_function_parallel_spectral(self,
+    def apply_function_parallel_spectral(self,
                                           function,
-                                          data,
                                           num_cores=None,
                                           verbose=0,
                                           use_memmap=True,
@@ -2746,13 +2744,13 @@ class SpectralCube(BaseSpectralCube):
             two arguments: an array representing a spectrum and a boolean array
             representing the mask.  It may also accept **kwargs.  The function
             must return an object with the same shape as the input spectrum.
+        num_cores : int or None
+            The number of cores to use if running in parallel
         verbose : int
             Verbosity level to pass to joblib
         use_memmap : bool
             If specified, a memory mapped temporary file on disk will be
             written to rather than storing the intermediate spectra in memory.
-        num_cores : int or None
-            The number of cores to use if running in parallel
         parallel : bool
             If set to ``False``, will force the use of a single core without
             using ``joblib``.
@@ -2760,6 +2758,8 @@ class SpectralCube(BaseSpectralCube):
             Passed to ``function``
         """
         shape = self.shape
+
+        data = self.unitless_filled_data
 
         # 'spectra' is a generator
         # the boolean check will skip the function for bad spectra
@@ -2825,6 +2825,22 @@ class SpectralCube(BaseSpectralCube):
         return newcube
 
 
+    def sigma_clip(self, threshold, verbose=0, use_memmap=True,
+                   num_cores=None, **kwargs):
+        """
+        Run astropy's sigma clipper, converting all bad values to NaN
+
+        TODO: Come up with a more friendly masking approach
+        """
+
+        return self.apply_function_parallel_spectral(stats.sigma_clip,
+                                                     sigma=threshold,
+                                                     axis=0, # changes behavior of sigmaclip
+                                                     num_cores=num_cores,
+                                                     use_memmap=use_memmap,
+                                                     verbose=verbose,
+                                                     **kwargs)
+
     def spectral_smooth(self, kernel,
                         convolve=convolution.convolve,
                         verbose=0,
@@ -2855,14 +2871,14 @@ class SpectralCube(BaseSpectralCube):
             Passed to the convolve function
         """
 
-        return self._apply_function_parallel_spectral(convolve,
-                                                      data=self.filled_data,
-                                                      kernel=kernel,
-                                                      normalize_kernel=True,
-                                                      num_cores=num_cores,
-                                                      use_memmap=use_memmap,
-                                                      verbose=verbose,
-                                                      **kwargs)
+        return self.apply_function_parallel_spectral(convolve,
+                                                     data=self.filled_data,
+                                                     kernel=kernel,
+                                                     normalize_kernel=True,
+                                                     num_cores=num_cores,
+                                                     use_memmap=use_memmap,
+                                                     verbose=verbose,
+                                                     **kwargs)
 
     def spectral_interpolate(self, spectral_grid,
                              suppress_smooth_warning=False,


### PR DESCRIPTION
This is a tool needed in statcont, and it can use the parallelization we have built in spectral cube.

This PR also smuggles in:
 
 * exposure of the parallel-apply-along-axis method
 * a new unitless_filled_data view