### PR TITLE
Fix more parameter options in mad_std

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -655,13 +655,13 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         projection = self._naxes_dropped(axis) in (1,2)
         if how == 'ray' and not hasattr(axis, '__len__'):
             # no need for fill here; masked-out data are simply not included
-            return self.apply_function(stats.mad_std,
-                                       axis=axis,
-                                       how='ray',
-                                       unit=self.unit,
-                                       projection=projection,
-                                       ignore_nan=True,
-                                      )
+            return self.apply_numpy_function(stats.mad_std,
+                                             axis=axis,
+                                             how='ray',
+                                             unit=self.unit,
+                                             projection=projection,
+                                             ignore_nan=True,
+                                            )
         elif how == 'slice' and hasattr(axis, '__len__') and len(axis) == 2:
             return self.apply_numpy_function(stats.mad_std,
                                              axis=axis,

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -653,18 +653,32 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         if int(astropy.__version__[0]) < 2:
             raise NotImplementedError("mad_std requires astropy >= 2")
         projection = self._naxes_dropped(axis) in (1,2)
-        if how == 'ray':
+        if how == 'ray' and not hasattr(axis, '__len__'):
             # no need for fill here; masked-out data are simply not included
             return self.apply_function(stats.mad_std,
                                        axis=axis,
+                                       how='ray',
                                        unit=self.unit,
                                        projection=projection,
+                                       ignore_nan=True,
                                       )
-        elif how == 'slice':
-            raise NotImplementedError('Cannot run mad_std slicewise')
+        elif how == 'slice' and hasattr(axis, '__len__') and len(axis) == 2:
+            return self.apply_numpy_function(stats.mad_std,
+                                             axis=axis,
+                                             how='slice',
+                                             projection=projection,
+                                             unit=self.unit,
+                                             fill=np.nan,
+                                             ignore_nan=True,
+                                             **kwargs)
+        elif how in ('ray', 'slice'):
+            raise NotImplementedError('Cannot run mad_std slicewise or raywise '
+                                      'unless the dimensionality is also reduced in the same direction.')
         else:
-            return self.apply_numpy_function(stats.mad_std, fill=np.nan,
-                                             axis=axis, unit=self.unit,
+            return self.apply_numpy_function(stats.mad_std,
+                                             fill=np.nan,
+                                             axis=axis,
+                                             unit=self.unit,
                                              ignore_nan=True,
                                              how=how,
                                              projection=projection, **kwargs)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1630,6 +1630,30 @@ def test_mad_std():
 
         np.testing.assert_almost_equal(mcube.mad_std(axis=0).value, result2)
 
+def test_mad_std_params():
+    cube, data = cube_and_raw('adv.fits')
+
+    # mad_std run manually on data
+    result = np.array([[0.15509701,  0.45763670],
+                       [0.55907956,  0.42932451],
+                       [0.48819454,  0.25499305]])
+
+    np.testing.assert_almost_equal(cube.mad_std(axis=0, how='cube').value, result)
+    np.testing.assert_almost_equal(cube.mad_std(axis=0, how='ray').value, result)
+
+    with pytest.raises(NotImplementedError) as exc:
+        cube.mad_std(axis=0, how='slice')
+
+    with pytest.raises(NotImplementedError) as exc:
+        cube.mad_std(axis=1, how='slice')
+
+    with pytest.raises(NotImplementedError) as exc:
+        cube.mad_std(axis=(1,2), how='ray')
+
+    # stats.mad_std(data, axis=(1,2))
+    np.testing.assert_almost_equal(cube.mad_std(axis=0, how='ray').value, result)
+
+
 def test_caching():
 
     cube, data = cube_and_raw('adv.fits')


### PR DESCRIPTION
mad_std can operate along axes, but can't do global calculations slicewise/raywise