### PR TITLE
Preserve beams in OneDSpectra

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -84,9 +84,9 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass):
             format = determine_format(filename)
         if format == 'fits':
             try:
-                self.hdu.writeto(filename, overwrite=overwrite)
+                self.hdulist.writeto(filename, overwrite=overwrite)
             except TypeError:
-                self.hdu.writeto(filename, clobber=overwrite)
+                self.hdulist.writeto(filename, clobber=overwrite)
         else:
             raise ValueError("Unknown format '{0}' - the only available "
                              "format at this time is 'fits'")

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -939,7 +939,8 @@ class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
 
     def _new_spectrum_with(self, data=None, wcs=None, mask=None, meta=None,
                            fill_value=None, spectral_unit=None, unit=None,
-                           header=None, wcs_tolerance=None, **kwargs):
+                           header=None, wcs_tolerance=None, beams=None,
+                           **kwargs):
 
         data = self._data if data is None else data
         if unit is None and hasattr(data, 'unit'):
@@ -980,6 +981,7 @@ class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
                                   unit=unit, fill_value=fill_value,
                                   header=header or self._header,
                                   wcs_tolerance=wcs_tolerance or self._wcs_tolerance,
+                                  beams=beams or self.beams,
                                   **kwargs)
         spectrum._spectral_unit = spectral_unit
 


### PR DESCRIPTION
Several steps required:
(1) keep it around when creating a new spectrum
(2) write the HDUList, not the HDU