### PR TITLE
Add 'beam' attribute to 1dSpectrum

### DIFF
--- a/docs/spectral_extraction.rst
+++ b/docs/spectral_extraction.rst
@@ -45,7 +45,7 @@ Aperture and spectral extraction using regions
 
 Spectral-cube supports ds9 and crtf regions, so you can use them to create a
 mask.  The ds9/crtf region support relies on `regions
-<https://astropy-regions.readthedocs.io/en/latest/>`, which supports most
+<https://astropy-regions.readthedocs.io/en/latest/>`_, which supports most
 shapes in ds9 and crtf, so you are not limited to circular apertures.
 
 In this example, we'll extract a subcube from ds9 region string using

--- a/spectral_cube/analysis_utilities.py
+++ b/spectral_cube/analysis_utilities.py
@@ -9,7 +9,7 @@ import warnings
 
 from .utils import BadVelocitiesWarning
 from .cube_utils import _map_context
-from .lower_dimensional_structures import OneDSpectrum
+from .lower_dimensional_structures import VaryingResolutionOneDSpectrum, OneDSpectrum
 from .spectral_cube import VaryingResolutionSpectralCube
 
 
@@ -302,11 +302,17 @@ def stack_spectra(cube, velocity_surface, v0=None,
 
     stacked = stack_function(shifted_spectra_array, axis=0)
 
-    stack_spec = \
-        OneDSpectrum(stacked, unit=cube.unit, wcs=WCS(new_header),
-                     header=new_header,
-                     meta=cube.meta, spectral_unit=vel_unit,
-                     beams=cube.beams if hasattr(cube, "beams") else None)
+    if hasattr(cube, 'beams'):
+        stack_spec = VaryingResolutionOneDSpectrum(stacked, unit=cube.unit,
+                                                   wcs=WCS(new_header),
+                                                   header=new_header,
+                                                   meta=cube.meta,
+                                                   spectral_unit=vel_unit,
+                                                   beams=cube.beams)
+    else:
+        stack_spec = OneDSpectrum(stacked, unit=cube.unit, wcs=WCS(new_header),
+                                  header=new_header, meta=cube.meta,
+                                  spectral_unit=vel_unit, beam=cube.beam)
 
     return stack_spec
 

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -701,9 +701,6 @@ class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
                                  )
 
         if beam is not None:
-            if beams is not None:
-                raise ValueError("Both 'beam' and 'beams' specified when "
-                                 "creating 1dspec")
             self.beam = beam
             self.meta['beam'] = beam
 
@@ -1063,7 +1060,10 @@ class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
 
         if beams is None:
             if hasattr(self, 'beams'):
-                beams = self.beams
+                kwargs['beams'] = beams
+        elif beam is None:
+            if hasattr(self, 'beam'):
+                kwargs['beam'] = beam
 
         if beams is not None:
             cls = VaryingResolutionOneDSpectrum
@@ -1074,7 +1074,7 @@ class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
         spectrum = cls(value=data, wcs=wcs, mask=mask, meta=meta, unit=unit,
                        fill_value=fill_value, header=header or self._header,
                        wcs_tolerance=wcs_tolerance or self._wcs_tolerance,
-                       beams=beams, beam=beam, **kwargs)
+                       **kwargs)
         spectrum._spectral_unit = spectral_unit
 
         return spectrum
@@ -1095,5 +1095,4 @@ class VaryingResolutionOneDSpectrum(OneDSpectrum, MultiBeamMixinClass):
     def __new__(cls, value, beams=None, **kwargs):
         if beams is not None:
             cls.beams = beams
-        return super(OneDSpectrum, cls).__new__(value, **kwargs)
-
+        return super(VaryingResolutionOneDSpectrum, cls).__new__(cls, value, **kwargs)

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -411,7 +411,7 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass,
                                  unit=unit, fill_value=fill_value,
                                  header=header or self._header,
                                  wcs_tolerance=wcs_tolerance or self._wcs_tolerance,
-                                 beams=beam,
+                                 beam=beam,
                                  **kwargs)
 
         return newproj

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -1024,7 +1024,7 @@ class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
     def _new_spectrum_with(self, data=None, wcs=None, mask=None, meta=None,
                            fill_value=None, spectral_unit=None, unit=None,
                            header=None, wcs_tolerance=None, beams=None,
-                           **kwargs):
+                           beam=None, **kwargs):
 
         data = self._data if data is None else data
         if unit is None and hasattr(data, 'unit'):
@@ -1065,12 +1065,16 @@ class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
             if hasattr(self, 'beams'):
                 beams = self.beams
 
-        spectrum = self.__class__(value=data, wcs=wcs, mask=mask, meta=meta,
-                                  unit=unit, fill_value=fill_value,
-                                  header=header or self._header,
-                                  wcs_tolerance=wcs_tolerance or self._wcs_tolerance,
-                                  beams=beams,
-                                  **kwargs)
+        if beams is not None:
+            cls = VaryingResolutionOneDSpectrum
+        else:
+            cls = OneDSpectrum
+            
+
+        spectrum = cls(value=data, wcs=wcs, mask=mask, meta=meta, unit=unit,
+                       fill_value=fill_value, header=header or self._header,
+                       wcs_tolerance=wcs_tolerance or self._wcs_tolerance,
+                       beams=beams, beam=beam, **kwargs)
         spectrum._spectral_unit = spectral_unit
 
         return spectrum

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -395,6 +395,12 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                 if set(axis) == set((1,2)):
                     new_wcs = self._wcs.sub([wcs.WCSSUB_SPECTRAL])
                     header = self._nowcs_header
+                    if hasattr(self, 'beam'):
+                        bmarg = {'beam': self.beam}
+                    elif hasattr(self, 'beams'):
+                        bmarg = {'beams': self.beams}
+                    else:
+                        bmarg = {}
                     return self._oned_spectrum(value=out,
                                                wcs=new_wcs,
                                                copy=False,
@@ -402,9 +408,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                                header=header,
                                                meta=meta,
                                                spectral_unit=self._spectral_unit,
-                                               beams=(self.beams
-                                                      if hasattr(self,'beams')
-                                                      else None),
+                                               **bmarg
                                               )
                 else:
                     warnings.warn("Averaging over a spatial and a spectral "
@@ -544,15 +548,20 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                       unit=self.unit, header=self._nowcs_header)
                 elif axis == (1,2):
                     newwcs = self._wcs.sub([wcs.WCSSUB_SPECTRAL])
+                    if hasattr(self, 'beam'):
+                        bmarg = {'beam': self.beam}
+                    elif hasattr(self, 'beams'):
+                        bmarg = {'beams': self.beams}
+                    else:
+                        bmarg = {}
                     return self._oned_spectrum(value=out,
                                                wcs=newwcs,
                                                copy=False,
                                                unit=self.unit,
                                                spectral_unit=self._spectral_unit,
-                                               beams=(self.beams
-                                                      if hasattr(self, 'beams')
-                                                      else None),
-                                               meta=self.meta)
+                                               meta=self.meta,
+                                               **bmarg
+                                              )
                 else:
                     # this is a weird case, but even if projection is
                     # specified, we can't return a Quantity here because of WCS
@@ -1153,6 +1162,12 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                 newwcs = self._wcs.sub([a
                                         for a in (1,2,3)
                                         if a not in [x+1 for x in intslices]])
+                if hasattr(self, 'beam'):
+                    bmarg = {'beam': self.beam}
+                elif hasattr(self, 'beams'):
+                    bmarg = {'beams': self.beams}
+                else:
+                    bmarg = {}
                 return self._oned_spectrum(value=self._data[view],
                                            wcs=newwcs,
                                            copy=False,
@@ -1160,6 +1175,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                            spectral_unit=self._spectral_unit,
                                            mask=self.mask[view],
                                            meta=meta,
+                                           **bmarg
                                           )
 
             # only one element, so drop an axis
@@ -3351,14 +3367,21 @@ class VaryingResolutionSpectralCube(BaseSpectralCube, MultiBeamMixinClass):
                 newwcs = self._wcs.sub([a
                                         for a in (1,2,3)
                                         if a not in [x+1 for x in intslices]])
+                if hasattr(self, 'beam'):
+                    bmarg = {'beam': self.beam}
+                elif hasattr(self, 'beams'):
+                    bmarg = {'beams': self.beams[specslice]}
+                else:
+                    bmarg = {}
                 return self._oned_spectrum(value=self._data[view],
                                            wcs=newwcs,
                                            copy=False,
                                            unit=self.unit,
                                            spectral_unit=self._spectral_unit,
                                            mask=self.mask[view],
-                                           beams=self.beams[specslice],
-                                           meta=meta)
+                                           meta=meta,
+                                           **bmarg
+                                          )
 
             # only one element, so drop an axis
             newwcs = wcs_utils.drop_axis(self._wcs, intslices[0])


### PR DESCRIPTION
There may be a cleaner way to do this, e.g., split out 1DSpectrum and VaryingSpatialResolution1DSpectrum, but for now we're taking the quick & easy & dirty approach.