### PR TITLE
Add `use_memmap` argument for `reproject` and boost minimum required reproject version

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2502,12 +2502,13 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         # (see FITS_tools.regrid_cube for a guide on how to do this)
 
         newwcs = wcs.WCS(header)
-        shape_out = [header['NAXIS{0}'.format(i + 1)] for i in range(header['NAXIS'])][::-1]
+        shape_out = tuple([header['NAXIS{0}'.format(i + 1)] for i in
+                           range(header['NAXIS'])][::-1])
 
         if use_memmap:
             # note: requires reproject from December 2018 or later
             outarray = np.memmap(filename='output.np', mode='w+',
-                                 shape=shape_out, dtype='float32')
+                                 shape=tuple(shape_out), dtype='float32')
         else:
             outarray = None
 

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -77,7 +77,7 @@ def test_beams_convolution_equal():
                                    conv_cube.filled_data[0].value)
 
 
-@pytest.mark.parametrize('use_memmap', (True, False)
+@pytest.mark.parametrize('use_memmap', (True, False))
 def test_reproject(use_memmap):
 
     pytest.importorskip('reproject')

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -77,7 +77,8 @@ def test_beams_convolution_equal():
                                    conv_cube.filled_data[0].value)
 
 
-def test_reproject():
+@pytest.mark.parametrize('use_memmap', (True, False)
+def test_reproject(use_memmap):
 
     pytest.importorskip('reproject')
 
@@ -95,7 +96,7 @@ def test_reproject():
     header_out['NAXIS3'] = cube.shape[0]
     header_out.update(wcs_out.to_header())
 
-    result = cube.reproject(header_out)
+    result = cube.reproject(header_out, use_memmap=use_memmap)
 
     assert result.shape == (cube.shape[0], 5, 4)
 


### PR DESCRIPTION
In December 2018, we implemented a not-in-memory version of reproject for cubes.  This PR allows spectral-cube to use that version.