### PR TITLE
Allow unfilled reprojection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ env:
         - SETUP_CMD='test -a "--boxed"'
         - NUMPY_VERSION=1.13
         - ASTROPY_VERSION=stable
-        - CONDA_DEPENDENCIES='sip<4.19 aplpy pytest=3.9.3 pytest-xdist astropy-helpers joblib glue-core scipy reproject'
+        - CONDA_DEPENDENCIES='sip<4.19 aplpy pytest=3.9.3 pytest-xdist astropy-helpers joblib glue-core scipy'
         - CONDA_CHANNELS='astropy-ci-extras astropy glueviz'
-        - PIP_DEPENDENCIES='matplotlib<2 Cython https://github.com/radio-astro-tools/pvextractor/archive/master.zip radio_beam https://github.com/astropy/regions/archive/master.zip'
+        - PIP_DEPENDENCIES='matplotlib<2 Cython https://github.com/radio-astro-tools/pvextractor/archive/master.zip radio_beam https://github.com/astropy/regions/archive/master.zip https://github.com/astropy/reproject/archive/master.zip'
         - SETUP_XVFB=True
 
     matrix:
@@ -47,7 +47,7 @@ matrix:
         - python: 3.6
           env: SETUP_CMD='test --coverage'
                PYTEST_VERSION="<3.10"
-               CONDA_DEPENDENCIES='matplotlib aplpy yt bottleneck pytest pytest-xdist astropy-helpers joblib reproject'
+               CONDA_DEPENDENCIES='matplotlib aplpy yt bottleneck sip<4.19 aplpy pytest=3.9.3 pytest-xdist astropy-helpers joblib glue-core scipy'
                # pytest 3.9.3 suggested by @e-koch, @astrofrog.  3.10.1 doesn't work, 4.x doesn't work
                # overrode python version too, per bsipocz
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         - SETUP_CMD='test -a "--boxed"'
         - NUMPY_VERSION=1.13
         - ASTROPY_VERSION=stable
-        - CONDA_DEPENDENCIES='sip<4.19 aplpy pytest=3.9.3 pytest-xdist astropy-helpers joblib glue-core scipy'
+        - CONDA_DEPENDENCIES='sip<4.19 aplpy pytest=3.9.3 pytest-xdist astropy-helpers joblib glue-core scipy reproject'
         - CONDA_CHANNELS='astropy-ci-extras astropy glueviz'
         - PIP_DEPENDENCIES='matplotlib<2 Cython https://github.com/radio-astro-tools/pvextractor/archive/master.zip radio_beam https://github.com/astropy/regions/archive/master.zip'
         - SETUP_XVFB=True
@@ -47,7 +47,7 @@ matrix:
         - python: 3.6
           env: SETUP_CMD='test --coverage'
                PYTEST_VERSION="<3.10"
-               CONDA_DEPENDENCIES='matplotlib aplpy yt bottleneck pytest pytest-xdist astropy-helpers joblib'
+               CONDA_DEPENDENCIES='matplotlib aplpy yt bottleneck pytest pytest-xdist astropy-helpers joblib reproject'
                # pytest 3.9.3 suggested by @e-koch, @astrofrog.  3.10.1 doesn't work, 4.x doesn't work
                # overrode python version too, per bsipocz
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
+[tool:pytest]
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2463,7 +2463,8 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         return result
 
     @warn_slow
-    def reproject(self, header, order='bilinear', use_memmap=False):
+    def reproject(self, header, order='bilinear', use_memmap=False,
+                  filled=True):
         """
         Spatially reproject the cube into a new header.  Fills the data with
         the cube's ``fill_value`` to replace bad values before reprojection.
@@ -2495,6 +2496,11 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         use_memmap : bool
             If specified, a memory mapped temporary file on disk will be
             written to rather than storing the intermediate spectra in memory.
+        filled : bool
+            Fill the masked values with the cube's fill value before
+            reprojection?  Note that setting ``filled=False`` will use the raw
+            data array, which can be a workaround that prevents loading large
+            data into memory.
         """
 
         try:
@@ -2525,7 +2531,12 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         else:
             outarray = None
 
-        newcube, newcube_valid = reproject_interp((self.filled_data[:],
+        if filled:
+            data = self.filled_data[:]
+        else:
+            data = self._data
+
+        newcube, newcube_valid = reproject_interp((data,
                                                    self.header),
                                                   newwcs,
                                                   output_array=outarray,

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -424,25 +424,59 @@ def test_reproject_3D_memory():
 
     header_out = (wcs_out.to_header())
     header_out['NAXIS'] = 3
-    header_out['NAXIS1'] = cube.shape[2]
-    header_out['NAXIS2'] = cube.shape[1]
+    header_out['NAXIS1'] = int(cube.shape[2]/2)
+    header_out['NAXIS2'] = int(cube.shape[1]/2)
     header_out['NAXIS3'] = cube.shape[0]
 
+    # First the unfilled reprojection test: new memory is allocated for
+    # `result`, but nowhere else
     result = cube.reproject(header_out, filled=False)
 
     snap3 = tracemalloc.take_snapshot()
     diff = snap3.compare_to(snap2, 'lineno')
     diffvals = np.array([dd.size_diff for dd in diff])
-    # No additional memory should have been allocated in the above step
-    assert diffvals.max()*u.B <= 1000*u.B
+    # result should have the same size as the input data, except smaller in two dims
+    # make sure that's all that's allocated
+    assert diffvals.max()*u.B >= 200*100**2*sz*u.B
+    assert diffvals.max()*u.B < 200*110**2*sz*u.B
 
-    result = cube.reproject(header_out, filled=False)
+    # without masking the cube, nothing should change
+    result = cube.reproject(header_out, filled=True)
 
     snap4 = tracemalloc.take_snapshot()
     diff = snap4.compare_to(snap3, 'lineno')
     diffvals = np.array([dd.size_diff for dd in diff])
+    assert diffvals.max()*u.B <= 1*u.MB
+
+    assert result.wcs.wcs.crval[0] == 0.001
+    assert result.wcs.wcs.crpix[0] == 2.
+
+
+    # masking the cube will force the fill to create a new in-memory copy
+    mcube = cube.with_mask(cube > 0.1*cube.unit)
+    # `_is_huge` would trigger a use_memmap
+    assert not mcube._is_huge
+    assert mcube.mask.any()
+
+    # take a new snapshot because we're not testing the mask creation
+    snap5 = tracemalloc.take_snapshot()
+    tracemalloc.stop()
+    tracemalloc.start() # stop/start so we can check peak mem use from here
+    current_b4, peak_b4 = tracemalloc.get_traced_memory()
+    result = mcube.reproject(header_out, filled=True)
+    current_aftr, peak_aftr = tracemalloc.get_traced_memory()
+
+
+    snap6 = tracemalloc.take_snapshot()
+    diff = snap6.compare_to(snap5, 'lineno')
+    diffvals = np.array([dd.size_diff for dd in diff])
     # a duplicate of the cube should have been created by filling masked vals
-    assert diffvals.max()*u.B >= 200**3*sz*u.B
+    # (this should be near-exact since 'result' should occupy exactly the
+    # same amount of memory)
+    assert diffvals.max()*u.B <= 1*u.MB #>= 200**3*sz*u.B
+    # the peak memory usage *during* reprojection will have that duplicate,
+    # but the memory gets cleaned up afterward
+    assert (peak_aftr-peak_b4)*u.B >= (200**3*sz*u.B + 200*100**2*sz*u.B)
 
     assert result.wcs.wcs.crval[0] == 0.001
     assert result.wcs.wcs.crpix[0] == 2.


### PR DESCRIPTION
Presently, reprojection defaults to using the filled data, which requires loading the array into memory and filling the masked elements.  This PR allows ``filled=False`` to be specified, using the raw data in the reprojection.