### PR TITLE
Keep Beam in LDOs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
         - CONDA_CHANNELS='astropy-ci-extras astropy glueviz'
         - PIP_DEPENDENCIES='matplotlib<2 Cython https://github.com/radio-astro-tools/pvextractor/archive/master.zip radio_beam https://github.com/astropy/regions/archive/master.zip'
         - SETUP_XVFB=True
-        - MPLBACKEND="Agg"
 
     matrix:
         - SETUP_CMD='egg_info'
@@ -62,7 +61,7 @@ matrix:
           env: PIP_DEPENDENCIES='https://github.com/radio-astro-tools/pvextractor/archive/master.zip radio_beam'
 
         - python: 3.6
-          env: NUMPY_VERSION=1.11 CONDA_DEPENDENCIES='matplotlib aplpy bottleneck pytest pytest-xdist astropy-helpers'
+          env: NUMPY_VERSION=1.11 ASTROPY_VERSION=LTS CONDA_DEPENDENCIES='matplotlib aplpy bottleneck pytest pytest-xdist astropy-helpers'
 
         # Test with development versions
         - python: 3.5

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 0.4.4 (unreleased)
 ------------------
+ - Refactor all beam parameters into mix-in classes; added BaseOneDSpectrum
+   for common functionality between OneDSpectrum and VaryingResolutionOneDSpectrum.
+   Retain beam objects when doing arithmetic with LDOs/
+   (https://github.com/radio-astro-tools/spectral-cube/pull/521)
  - Refactor OneDSpectrum objects to include a single beam if they
    were produced from a cube with a single beam to enable K<->Jy
    conversions

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -9,7 +9,7 @@ py:class spectral_cube.base_class.MaskableArrayMixinClass
 py:class spectral_cube.base_class.MultiBeamMixinClass
 py:class spectral_cube.base_class.BeamMixinClass
 py:class spectral_cube.base_class.HeaderMixinClass
-py:class spectral_cube.base_class.BaseOneDSpectrum
+py:class spectral_cube.lower_dimensional_structures.BaseOneDSpectrum
 
 # yt references
 py:obj yt.surface.export_sketchfab

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -10,6 +10,7 @@ py:class spectral_cube.base_class.MultiBeamMixinClass
 py:class spectral_cube.base_class.BeamMixinClass
 py:class spectral_cube.base_class.HeaderMixinClass
 py:class spectral_cube.lower_dimensional_structures.BaseOneDSpectrum
+py:obj spectral_cube.lower_dimensional_structures.OneDSpectrum.quicklook
 
 # yt references
 py:obj yt.surface.export_sketchfab

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -7,7 +7,9 @@ py:class spectral_cube.base_class.SpectralAxisMixinClass
 py:class spectral_cube.base_class.SpatialCoordMixinClass
 py:class spectral_cube.base_class.MaskableArrayMixinClass
 py:class spectral_cube.base_class.MultiBeamMixinClass
+py:class spectral_cube.base_class.BeamMixinClass
 py:class spectral_cube.base_class.HeaderMixinClass
+py:class spectral_cube.base_class.BaseOneDSpectrum
 
 # yt references
 py:obj yt.surface.export_sketchfab

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -9,6 +9,8 @@ from . import wcs_utils
 from . import cube_utils
 from .utils import cached, WCSCelestialError
 
+from radio_beam import Beam, Beams
+
 __doctest_skip__ = ['SpatialCoordMixinClass.world']
 
 DOPPLER_CONVENTIONS = {}
@@ -385,3 +387,41 @@ class MultiBeamMixinClass(object):
         factor = np.array(factors)
 
         return factor
+
+    @property
+    def beams(self):
+        return self._beams
+
+    @beams.setter
+    def beams(self, obj):
+
+        if not isinstance(obj, Beams):
+            raise TypeError("beam must be a radio_beam.Beams object.")
+
+        if not obj.size == self.shape[0]:
+            raise ValueError("The Beams object must have the same size as the "
+                             "data. Found a size of {0} and the data have a "
+                             "size of {1}".format(obj.size, self.size))
+
+        self._beams = obj
+
+
+class BeamMixinClass(object):
+    """
+    Functionality for objects with a single beam.
+
+    Specific objects (cubes, LDOs) still need to define their own `with_beam`
+    methods.
+    """
+
+    @property
+    def beam(self):
+        return self._beam
+
+    @beam.setter
+    def beam(self, obj):
+
+        if not isinstance(obj, Beam):
+            raise TypeError("beam must be a radio_beam.Beam object.")
+
+        self._beam = obj

--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -4,7 +4,19 @@
 
 from __future__ import print_function, absolute_import, division
 
-from astropy.tests.pytest_plugins import *
+from astropy.version import version as astropy_version
+if astropy_version < '3.0':
+    # With older versions of Astropy, we actually need to import the pytest
+    # plugins themselves in order to make them discoverable by pytest.
+    from astropy.tests.pytest_plugins import *
+else:
+    # As of Astropy 3.0, the pytest plugins provided by Astropy are
+    # automatically made available when Astropy is installed. This means it's
+    # not necessary to import them here, but we still need to import global
+    # variables that are used for configuration.
+    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+
+from astropy.tests.helper import enable_deprecations_as_exceptions
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -133,9 +133,6 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass, HeaderMixinClass):
         new._mask=(self._mask[key] if self._mask is not nomask else nomask)
         new._header = self._header
 
-        if hasattr(self, 'beams'):
-            new.beams = self.beams[key]
-
         return new
 
     def __array_finalize__(self, obj):
@@ -151,7 +148,6 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass, HeaderMixinClass):
             self._beams = getattr(obj, '_beams', None)
         else:
             self._beam = getattr(obj, '_beam', None)
-
 
         super(LowerDimensionalObject, self).__array_finalize__(obj)
 
@@ -844,11 +840,11 @@ class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
 
     def __getitem__(self, key, **kwargs):
         try:
-            beams = self.beams[key]
+            kwargs['beams'] = self.beams[key]
         except (AttributeError,TypeError):
-            beams = None
+            pass
 
-        new_qty = super(OneDSpectrum, self).__getitem__(key, beams=beams)
+        new_qty = super(OneDSpectrum, self).__getitem__(key)
 
         if isinstance(key, slice):
 

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -21,7 +21,8 @@ from .masks import BooleanArrayMask, MaskBase
 
 from .base_class import (BaseNDClass, SpectralAxisMixinClass,
                          SpatialCoordMixinClass, MaskableArrayMixinClass,
-                         MultiBeamMixinClass, HeaderMixinClass
+                         MultiBeamMixinClass, BeamMixinClass,
+                         HeaderMixinClass
                         )
 from . import cube_utils
 
@@ -297,20 +298,9 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass, HeaderMixinClass):
 
         self._mask = mask
 
-    @property
-    def beam(self):
-        return self._beam
-
-    @beam.setter
-    def beam(self, obj):
-
-        if not isinstance(obj, Beam):
-            raise TypeError("beam must be a radio_beam.Beam object.")
-
-        self._beam = obj
 
 class Projection(LowerDimensionalObject, SpatialCoordMixinClass,
-                 MaskableArrayMixinClass):
+                 MaskableArrayMixinClass, BeamMixinClass):
 
     def __new__(cls, value, unit=None, dtype=None, copy=True, wcs=None,
                 meta=None, mask=None, header=None, beam=None,
@@ -654,7 +644,7 @@ class Slice(Projection):
 
 
 class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
-                   SpectralAxisMixinClass):
+                   SpectralAxisMixinClass, BeamMixinClass):
 
     def __new__(cls, value, unit=None, dtype=None, copy=True, wcs=None,
                 meta=None, mask=None, header=None, spectral_unit=None,
@@ -1140,31 +1130,14 @@ class VaryingResolutionOneDSpectrum(OneDSpectrum, MultiBeamMixinClass):
 
         return self._new_spectrum_with(beams=beams, meta=meta)
 
-    def with_beam(self, beam):
-        '''
-        Re-define here so a single Beam cannot be passed.
-        '''
-        raise ValueError("For VaryingResolutionOneDSpectrum's, use with_beams "
-                         "instead of with_beam.")
+    # def with_beam(self, beam):
+    #     '''
+    #     Re-define here so a single Beam cannot be passed.
+    #     '''
+    #     raise ValueError("For VaryingResolutionOneDSpectrum's, use with_beams "
+    #                      "instead of with_beam.")
 
-    @property
-    def beams(self):
-        return self._beams
-
-    @beams.setter
-    def beams(self, obj):
-
-        if not isinstance(obj, Beams):
-            raise TypeError("beam must be a radio_beam.Beams object.")
-
-        if not obj.size == self.size:
-            raise ValueError("The Beams object must have the same size as the "
-                             "data. Found a size of {0} and the data have a "
-                             "size of {1}".format(obj.size, self.size))
-
-        self._beams = obj
-
-    @property
-    def beam(self):
-        raise ValueError("For VaryingResolutionOneDSpectrum's, use beams "
-                         "instead of beam.")
+    # @property
+    # def beam(self):
+    #     raise ValueError("For VaryingResolutionOneDSpectrum's, use beams "
+    #                      "instead of beam.")

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -742,9 +742,17 @@ class OneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
         else:
             unit = None
 
-        beams = cube_utils.try_load_beams(hdul)
+        beams_table = cube_utils.try_load_beams(hdul)
 
-        if beams is not None:
+        if beams_table is not None:
+            # Convert to a beams object from the table
+            beams = Beams(major=u.Quantity(beams_table['BMAJ'], u.arcsec),
+                          minor=u.Quantity(beams_table['BMIN'], u.arcsec),
+                          pa=u.Quantity(beams_table['BPA'], u.deg),
+                          meta=[{key: row[key] for key in beams_table.names
+                                 if key not in ('BMAJ', 'BPA', 'BMIN')}
+                                for row in beams_table],
+                         )
             self = VaryingResolutionOneDSpectrum(hdu.data, unit=unit,
                                                  wcs=mywcs, meta=meta,
                                                  header=hdu.header,

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -1109,7 +1109,7 @@ class VaryingResolutionOneDSpectrum(BaseOneDSpectrum, MultiBeamMixinClass):
 
     def with_beams(self, beams):
         '''
-        Attach a new beam object to the OneDSpectrum.
+        Attach a new beams object to the VaryingResolutionOneDSpectrum.
 
         Parameters
         ----------

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -147,10 +147,10 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass, HeaderMixinClass):
         self._fill_value = getattr(obj, '_fill_value', np.nan)
         self._wcs_tolerance = getattr(obj, '_wcs_tolerance', 0.0)
 
-        # if isinstance(obj, VaryingResolutionOneDSpectrum):
-        #     self._beams = getattr(obj, '_beams', None)
-        # else:
-        self._beam = getattr(obj, '_beam', None)
+        if isinstance(obj, VaryingResolutionOneDSpectrum):
+            self._beams = getattr(obj, '_beams', None)
+        else:
+            self._beam = getattr(obj, '_beam', None)
 
 
         super(LowerDimensionalObject, self).__array_finalize__(obj)

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -3531,7 +3531,7 @@ class VaryingResolutionSpectralCube(BaseSpectralCube, MultiBeamMixinClass):
         if goodbeams_mask is not None:
             newcube._goodbeams_mask = goodbeams_mask
         else:
-            newcube._goodbeams_mask = newcube.beams.isfinite
+            newcube._goodbeams_mask = np.isfinite(newcube.beams)
 
         return newcube
 
@@ -3976,6 +3976,21 @@ class VaryingResolutionSpectralCube(BaseSpectralCube, MultiBeamMixinClass):
                              "spectrally smoothed.  Convolve to a "
                              "common resolution with `convolve_to` before "
                              "attempting spectral smoothed.")
+
+    def with_beams(self, beams, goodbeams_mask=None,):
+        '''
+        Attach a new beams object to the VaryingResolutionSpectralCube.
+
+        Parameters
+        ----------
+        beams : `~radio_beam.Beams`
+            A new beams object.
+        '''
+
+        meta = self.meta.copy()
+        meta['beams'] = beams
+
+        return self._new_cube_with(beams=beams, meta=meta)
 
 
 def _regionlist_to_single_region(region_list):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -42,7 +42,7 @@ from .lower_dimensional_structures import (Projection, Slice, OneDSpectrum,
 from .base_class import (BaseNDClass, SpectralAxisMixinClass,
                          DOPPLER_CONVENTIONS, SpatialCoordMixinClass,
                          MaskableArrayMixinClass, MultiBeamMixinClass,
-                         HeaderMixinClass
+                         HeaderMixinClass, BeamMixinClass
                         )
 from .utils import (cached, warn_slow, VarianceWarning, BeamAverageWarning,
                     UnsupportedIterationStrategyWarning, WCSMismatchWarning,
@@ -3213,7 +3213,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         return self._new_cube_with(data=dsarr, wcs=newwcs,
                                    mask=BooleanArrayMask(mask, wcs=newwcs))
 
-class SpectralCube(BaseSpectralCube):
+class SpectralCube(BaseSpectralCube, BeamMixinClass):
 
     __name__ = "SpectralCube"
 
@@ -3376,12 +3376,8 @@ class VaryingResolutionSpectralCube(BaseSpectralCube, MultiBeamMixinClass):
             raise ValueError("Beam list must have same size as spectral "
                              "dimension")
 
-        self._beams = beams
+        self.beams = beams
         self.beam_threshold = beam_threshold
-
-    @property
-    def beams(self):
-        return self._beams
 
     def __getitem__(self, view):
 

--- a/spectral_cube/tests/test_performance.py
+++ b/spectral_cube/tests/test_performance.py
@@ -16,6 +16,12 @@ try:
 except ImportError:
     tracemallocOK = False
 
+# The comparison of Quantities in test_memory_usage
+# fail with older versions of numpy
+from distutils.version import LooseVersion
+
+NPY_VERSION_CHECK = LooseVersion(np.version.version) >= "1.13"
+
 from .test_moments import moment_cube
 from .helpers import assert_allclose
 from ..spectral_cube import SpectralCube
@@ -119,7 +125,7 @@ def test_parallel_performance_smoothing():
             print(rslt)
 
 # python 2.7 doesn't have tracemalloc
-@pytest.mark.skipif('not tracemallocOK or (sys.version_info.major==3 and sys.version_info.minor<6)')
+@pytest.mark.skipif('not tracemallocOK or (sys.version_info.major==3 and sys.version_info.minor<6) or not NPY_VERSION_CHECK')
 def test_memory_usage():
     """
     Make sure that using memmaps happens where expected, for the most part, and

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -180,6 +180,17 @@ def test_VRODS_wrong_beams_shape():
                                       beams=exp_beams)
 
 
+def test_VRODS_with_beams():
+
+    exp_beams = Beams(np.arange(twelve_qty_1d.size) * u.arcsec)
+
+    p = VaryingResolutionOneDSpectrum(twelve_qty_1d, copy=False, beams=exp_beams)
+    assert (p.beams == exp_beams).all()
+
+    p = p.with_beams(exp_beams * 2)
+    assert(p.beams == (exp_beams * 2)).all()
+
+
 def test_VRODS_slice_with_beams():
 
     exp_beams = Beams(np.arange(twelve_qty_1d.size) * u.arcsec)

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -141,6 +141,31 @@ def test_self_arith(LDO, data):
     assert p2.wcs == p.wcs
     assert np.all(p2.value==0)
 
+
+@pytest.mark.parametrize(('LDO', 'data'),
+                         zip(LDOs, data_twelve))
+def test_self_arith_with_beam(LDO, data):
+
+    exp_beam = Beam(1.0 * u.arcsec)
+
+    image = data
+    p = LDO(image, copy=False)
+    p = p.with_beam(exp_beam)
+
+    p2 = p + p
+
+    assert hasattr(p2, '_wcs')
+    assert p2.wcs == p.wcs
+    assert np.all(p2.value==2)
+    assert p2.beam == exp_beam
+
+    p2 = p - p
+
+    assert hasattr(p2, '_wcs')
+    assert p2.wcs == p.wcs
+    assert np.all(p2.value==0)
+    assert p2.beam == exp_beam
+
 def test_onedspectrum_specaxis_units():
 
     test_wcs = WCS(naxis=1)
@@ -281,21 +306,64 @@ def test_projection_with_beam():
     assert new_proj.beam == exp_beam
     assert new_proj.meta['beam'] == exp_beam
 
+    # Slice the projection with a beam and check it's still there
+    assert new_proj[:1, :1].beam == exp_beam
 
-def test_projection_attach_beam():
+
+def test_ondespectrum_with_beam():
+
+    exp_beam = Beam(1.0 * u.arcsec)
+
+    test_wcs_1 = WCS(naxis=1)
+    spec = OneDSpectrum(twelve_qty_1d, wcs=test_wcs_1)
+
+    # load beam from meta
+    meta = {"beam": exp_beam}
+    new_spec = OneDSpectrum(spec.data, wcs=spec.wcs, meta=meta)
+
+    assert new_spec.beam == exp_beam
+    assert new_spec.meta['beam'] == exp_beam
+
+    # load beam from given header
+    hdu = spec.hdu
+    exp_beam = Beam(2.0 * u.arcsec)
+    header = hdu.header.copy()
+    header = exp_beam.attach_to_header(header)
+    new_spec = OneDSpectrum(hdu.data, wcs=spec.wcs, header=header)
+
+    assert new_spec.beam == exp_beam
+    assert new_spec.meta['beam'] == exp_beam
+
+    # load beam from beam object
+    exp_beam = Beam(3.0 * u.arcsec)
+    header = hdu.header.copy()
+    del header["BMAJ"], header["BMIN"], header["BPA"]
+    new_spec = OneDSpectrum(hdu.data, wcs=spec.wcs, header=header,
+                            beam=exp_beam)
+
+    assert new_spec.beam == exp_beam
+    assert new_spec.meta['beam'] == exp_beam
+
+    # Slice the spectrum with a beam and check it's still there
+    assert new_spec[:1].beam == exp_beam
+
+
+@pytest.mark.parametrize(('LDO', 'data'),
+                         zip(LDOs, data_twelve))
+def test_ldo_attach_beam(LDO, data):
 
     exp_beam = Beam(1.0 * u.arcsec)
     newbeam = Beam(2.0 * u.arcsec)
 
-    proj, hdu = load_projection("55.fits")
+    p = LDO(data, copy=False, beam=exp_beam)
 
-    new_proj = proj.with_beam(newbeam)
+    new_p = p.with_beam(newbeam)
 
-    assert proj.beam == exp_beam
-    assert proj.meta['beam'] == exp_beam
+    assert p.beam == exp_beam
+    assert p.meta['beam'] == exp_beam
 
-    assert new_proj.beam == newbeam
-    assert new_proj.meta['beam'] == newbeam
+    assert new_p.beam == newbeam
+    assert new_p.meta['beam'] == newbeam
 
 
 @pytest.mark.parametrize(('LDO', 'data'),
@@ -311,24 +379,6 @@ def test_projection_from_hdu(LDO, data):
     assert (p == p_new).all()
 
 
-@pytest.mark.parametrize(('LDO', 'data'),
-                         zip(LDOs_2d, data_two_2d))
-def test_projection_from_hdu_with_beam(LDO, data):
-
-    p = LDO(data, copy=False)
-
-    hdu = p.hdu
-
-    beam = Beam(1 * u.arcsec)
-    hdu.header = beam.attach_to_header(hdu.header)
-
-    p_new = LDO.from_hdu(hdu)
-
-    assert (p == p_new).all()
-    assert beam == p_new.meta['beam']
-    assert beam == p_new.beam
-
-
 def test_projection_subimage():
 
     proj, hdu = load_projection("55.fits")
@@ -340,6 +390,8 @@ def test_projection_subimage():
     assert proj1.shape == (5, 2)
     assert proj2.shape == (5, 2)
     assert proj1.wcs.wcs.compare(proj2.wcs.wcs)
+    assert proj.beam == proj1.beam
+    assert proj.beam == proj2.beam
 
     proj3 = proj.subimage(ylo=1, yhi=3)
     proj4 = proj.subimage(ylo=29.93464 * u.deg,

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -174,7 +174,7 @@ def test_VRODS_wrong_beams_shape():
     Check that passing Beams with a different shape than the data
     is caught.
     '''
-    exp_beams = Beams(np.arange(3) * u.arcsec)
+    exp_beams = Beams(np.arange(1, 4) * u.arcsec)
 
     p = VaryingResolutionOneDSpectrum(twelve_qty_1d, copy=False,
                                       beams=exp_beams)
@@ -182,7 +182,7 @@ def test_VRODS_wrong_beams_shape():
 
 def test_VRODS_with_beams():
 
-    exp_beams = Beams(np.arange(twelve_qty_1d.size) * u.arcsec)
+    exp_beams = Beams(np.arange(1, twelve_qty_1d.size + 1) * u.arcsec)
 
     p = VaryingResolutionOneDSpectrum(twelve_qty_1d, copy=False, beams=exp_beams)
     assert (p.beams == exp_beams).all()
@@ -193,7 +193,7 @@ def test_VRODS_with_beams():
 
 def test_VRODS_slice_with_beams():
 
-    exp_beams = Beams(np.arange(twelve_qty_1d.size) * u.arcsec)
+    exp_beams = Beams(np.arange(1, twelve_qty_1d.size + 1) * u.arcsec)
 
     p = VaryingResolutionOneDSpectrum(twelve_qty_1d, copy=False,
                                       wcs=WCS(naxis=1),
@@ -204,10 +204,9 @@ def test_VRODS_slice_with_beams():
 
 def test_VRODS_arith_with_beams():
 
-    exp_beams = Beams(np.arange(twelve_qty_1d.size) * u.arcsec)
+    exp_beams = Beams(np.arange(1, twelve_qty_1d.size + 1) * u.arcsec)
 
     p = VaryingResolutionOneDSpectrum(twelve_qty_1d, copy=False, beams=exp_beams)
-    p = p.with_beams(exp_beams)
 
     p2 = p + p
 

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -329,7 +329,8 @@ def test_ondespectrum_with_beam():
     exp_beam = Beam(2.0 * u.arcsec)
     header = hdu.header.copy()
     header = exp_beam.attach_to_header(header)
-    new_spec = OneDSpectrum(hdu.data, wcs=spec.wcs, header=header)
+    new_spec = OneDSpectrum(hdu.data, wcs=spec.wcs, header=header,
+                            read_beam=True)
 
     assert new_spec.beam == exp_beam
     assert new_spec.meta['beam'] == exp_beam
@@ -337,7 +338,6 @@ def test_ondespectrum_with_beam():
     # load beam from beam object
     exp_beam = Beam(3.0 * u.arcsec)
     header = hdu.header.copy()
-    del header["BMAJ"], header["BMIN"], header["BPA"]
     new_spec = OneDSpectrum(hdu.data, wcs=spec.wcs, header=header,
                             beam=exp_beam)
 

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -214,14 +214,14 @@ def test_VRODS_arith_with_beams():
     assert hasattr(p2, '_wcs')
     assert p2.wcs == p.wcs
     assert np.all(p2.value==2)
-    assert p2.beams == exp_beams
+    assert np.all(p2.beams == exp_beams)
 
     p2 = p - p
 
     assert hasattr(p2, '_wcs')
     assert p2.wcs == p.wcs
     assert np.all(p2.value==0)
-    assert p2.beams == exp_beams
+    assert np.all(p2.beams == exp_beams)
 
 
 def test_onedspectrum_specaxis_units():

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -187,8 +187,10 @@ def test_VRODS_with_beams():
     p = VaryingResolutionOneDSpectrum(twelve_qty_1d, copy=False, beams=exp_beams)
     assert (p.beams == exp_beams).all()
 
-    p = p.with_beams(exp_beams * 2)
-    assert(p.beams == (exp_beams * 2)).all()
+    new_beams = Beams(np.arange(2, twelve_qty_1d.size + 2) * u.arcsec)
+
+    p = p.with_beams(new_beams)
+    assert np.all(p.beams == new_beams)
 
 
 def test_VRODS_slice_with_beams():

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1180,7 +1180,7 @@ def test_oned_slice_beams():
     cube._unit = u.K
 
     spec = cube[:,0,0]
-    assert isinstance(spec, OneDSpectrum)
+    assert isinstance(spec, VaryingResolutionOneDSpectrum)
     # data has a redundant 1st axis
     np.testing.assert_equal(spec.value, data[:,0,0,0])
     assert cube.unit == spec.unit
@@ -1224,7 +1224,7 @@ def test_oned_collapse_beams():
     cube._unit = u.K
 
     spec = cube.mean(axis=(1,2))
-    assert isinstance(spec, OneDSpectrum)
+    assert isinstance(spec, VaryingResolutionOneDSpectrum)
     # data has a redundant 1st axis
     np.testing.assert_equal(spec.value, data.mean(axis=(1,2,3)))
     assert cube.unit == spec.unit

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -46,7 +46,7 @@ except ImportError:
     YT_INSTALLED = False
     YT_LT_301 = False
 
-from radio_beam import Beam
+from radio_beam import Beam, Beams
 
 NUMPY_LT_19 = LooseVersion(np.__version__) < LooseVersion('1.9.0')
 
@@ -1196,6 +1196,9 @@ def test_subcube_slab_beams():
 
     assert all(slcube.hdulist[1].data['CHAN'] == np.arange(slcube.shape[0]))
 
+    # Make sure Beams has been sliced correctly
+    assert all(cube.beams[1:] == slcube.beams)
+
 # collapsing to one dimension raywise doesn't make sense and is therefore
 # not supported.
 @pytest.mark.parametrize('how', ('auto', 'cube', 'slice'))
@@ -1314,6 +1317,31 @@ def test_beam_custom():
 
     # Should be in meta too
     assert newcube2.meta['beam'] == newbeam
+
+
+def test_multibeam_custom():
+
+    cube, data = cube_and_raw('vda_beams.fits')
+
+    # Make a new set of beams that differs from the original.
+    new_beams = Beams([1.] * cube.shape[0] * u.deg)
+
+    # Attach the beam
+    newcube = cube.with_beams(new_beams)
+
+    assert all(new_beams == newcube.beams)
+
+
+@pytest.mark.xfail(raises=ValueError, strict=True)
+def test_multibeam_custom_wrongshape():
+
+    cube, data = cube_and_raw('vda_beams.fits')
+
+    # Make a new set of beams that differs from the original.
+    new_beams = Beams([1.] * cube.shape[0] * u.deg)
+
+    # Attach the beam
+    cube.with_beams(new_beams[:1])
 
 
 def test_multibeam_slice():


### PR DESCRIPTION
I encountered arithmetic cases where `OneDSpectrum`s were not keeping the beam information. The beam needed to be kept in `__array_finalize__`.

I added the same fix for the `VaryingResolutionOneDSpectrum` (VRODS), but the fix is a bit messy (@keflavich, see comments). Also added a check for whether the beams table equals the data shape.

Also added a bunch of tests for whether LDO classes are keeping the beams correctly. There are separate tests for VRODSs.