### PR TITLE
Avoid creating full spatial coordinate map in world_extrema

### DIFF
--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -193,7 +193,14 @@ class SpatialCoordMixinClass(object):
     @property
     @cached
     def world_extrema(self):
-        lat, lon = self.spatial_coordinate_map
+        corners = [(0, self.shape[2]-1),
+                   (self.shape[1]-1, 0),
+                   (self.shape[1]-1, self.shape[2]-1),
+                   (0,0)]
+        latlon_corners = [self.world[0, y, x] for y,x in corners]
+        lon = u.Quantity([x for z,y,x in latlon_corners])
+        lat = u.Quantity([y for z,y,x in latlon_corners])
+
         _lon_min = lon.min()
         _lon_max = lon.max()
         _lat_min = lat.min()

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1196,8 +1196,13 @@ def test_subcube_slab_beams():
 
     assert all(slcube.hdulist[1].data['CHAN'] == np.arange(slcube.shape[0]))
 
-    # Make sure Beams has been sliced correctly
-    assert all(cube.beams[1:] == slcube.beams)
+    try:
+        # Make sure Beams has been sliced correctly
+        assert all(cube.beams[1:] == slcube.beams)
+    except TypeError:
+        # in 69eac9241220d3552c06b173944cb7cdebeb47ef, radio_beam switched to
+        # returning a single value
+        assert cube.beams[1:] == slcube.beams
 
 # collapsing to one dimension raywise doesn't make sense and is therefore
 # not supported.
@@ -1329,7 +1334,12 @@ def test_multibeam_custom():
     # Attach the beam
     newcube = cube.with_beams(new_beams)
 
-    assert all(new_beams == newcube.beams)
+    try:
+        assert all(new_beams == newcube.beams)
+    except TypeError:
+        # in 69eac9241220d3552c06b173944cb7cdebeb47ef, radio_beam switched to
+        # returning a single value
+        assert new_beams == newcube.beams
 
 
 @pytest.mark.xfail(raises=ValueError, strict=True)

--- a/spectral_cube/tests/utilities.py
+++ b/spectral_cube/tests/utilities.py
@@ -86,6 +86,8 @@ def generate_gaussian_cube(shape=(100, 25, 25), sigma=8., amp=1.,
     with NumpyRNGContext(seed):
 
         spec_inds = np.mgrid[-spec_middle:spec_middle] * spec_scale.value
+        if len(spec_inds) == 0:
+            spec_inds = np.array([0])
         spat_inds = np.indices(shape[1:])
         for y, x in zip(spat_inds[0].flatten(), spat_inds[1].flatten()):
             # Lock the mean to within 25% from the centre


### PR DESCRIPTION
I just tested __repr__'ing a 28k x 28k cube, and it's really slow for no good reason: it's creating multiple gigabyte arrays just to find the extrema.  Simply indexing the corners is much faster.