### PR TITLE
fix for issue where num_cores = None (default?) raises an exception

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2698,6 +2698,16 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                  "override this restriction.")
             outcube = np.empty(shape=self.shape, dtype=np.float)
 
+        if num_cores == 1 and parallel:
+            warnings.warn("parallel=True was specified but num_cores=1. "
+                          "Joblib will be used to run the task with a "
+                          "single thread.")
+        elif num_cores is not None and num_cores > 1 and not parallel:
+            raise ValueError("parallel execution was not requested, but "
+                             "multiple cores were: these are incompatible "
+                             "options.  Either specify num_cores=1 or "
+                             "parallel=True")
+
         if parallel and use_memmap:
             # it is not possible to run joblib parallelization without memmap
             try:

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1828,13 +1828,14 @@ def test_spatial_smooth_median():
     np.testing.assert_almost_equal(cube_median[2].value, result2)
 
 
-def test_spectral_smooth_median():
+@pytest.mark.parametrize('num_cores', (None, 1))
+def test_spectral_smooth_median(num_cores):
 
     pytest.importorskip('scipy.ndimage')
 
     cube, data = cube_and_raw('adv.fits')
 
-    cube_spectral_median = cube.spectral_smooth_median(3)
+    cube_spectral_median = cube.spectral_smooth_median(3, num_cores=num_cores)
 
     # Check first slice
     result = np.array([0.77513282,  0.35675333,  0.35675333,  0.98688694])


### PR DESCRIPTION
Some previous PR... maybe even an unmerged one? broke the handling of `num_cores=None`