### PR TITLE
casatools for CASA io

### DIFF
--- a/spectral_cube/io/casa_image.py
+++ b/spectral_cube/io/casa_image.py
@@ -97,10 +97,14 @@ def load_casa_image(filename, skipdata=False,
     """
 
     try:
-        from taskinit import iatool
-        ia = iatool()
+        import casatools
+        ia = casatools.image()
     except ImportError:
-        raise ImportError("Could not import CASA (casac) and therefore cannot read CASA .image files")
+        try:
+            from taskinit import iatool
+            ia = iatool()
+        except ImportError:
+            raise ImportError("Could not import CASA (casac) and therefore cannot read CASA .image files")
 
     # use the ia tool to get the file contents
     ia.open(filename)


### PR DESCRIPTION
casatools is a new package being developed at NRAO to make CASA installable as a library.  It is python3-compatible.  Expected release is October 2019, but hopefully we can get some betas out before then.

This small change is all that's needed to support the new tools (though we might want to put some effort into more efficient IO)