### PR TITLE
LDOs deserve ppbeams too

### DIFF
--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -4,6 +4,7 @@ import numpy as np
 import warnings
 import abc
 
+import astropy
 from astropy.io.fits import Card
 from radio_beam import Beam, Beams
 
@@ -714,3 +715,11 @@ class BeamMixinClass(object):
             raise TypeError("beam must be a radio_beam.Beam object.")
 
         self._beam = obj
+
+
+    @property
+    @cached
+    def pixels_per_beam(self):
+        return (self.beam.sr /
+                (astropy.wcs.utils.proj_plane_pixel_area(self.wcs) *
+                 u.deg**2)).to(u.dimensionless_unscaled).value

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -3294,10 +3294,6 @@ class SpectralCube(BaseSpectralCube, BeamMixinClass):
             self._meta['beam'] = beam
             self._header.update(beam.to_header_keywords())
 
-            self.pixels_per_beam = (self.beam.sr /
-                                    (astropy.wcs.utils.proj_plane_pixel_area(self.wcs) *
-                                     u.deg**2)).to(u.dimensionless_unscaled).value
-
     def _new_cube_with(self, **kwargs):
         beam = kwargs.pop('beam', None)
         if 'beam' in self._meta and beam is None:


### PR DESCRIPTION
`ppbeam` was only defined for `SpectralCube`, but it applies to LDOs with the beam mixin too, so I added it as a cached property