### PR TITLE
Add details to moments.rst documentation

### DIFF
--- a/docs/moments.rst
+++ b/docs/moments.rst
@@ -70,7 +70,7 @@ positive integer, is as follows:
 
 Descriptions for the three most common moments used are as follows:
 
-* 0th moment - the integrated flux over the spectral line, can be used for computing some line ratios
+* 0th moment - the integrated intensity over the spectral line, and is often used for computing line ratios
 * 1st moment - the the intensity-weighted velocity of the spectral line; can be taken as a measure for the mean velocity of the gas
 * 2nd moment - a measure for the velocity dispersion of the gas along the line of sight, or the width of the spectral line, and is defined by the intensity-weighted square of the velocity
 
@@ -83,6 +83,16 @@ astronomy), you can use::
 
     >>> sigma_map = cube.linewidth_sigma()  # doctest: +SKIP
     >>> fwhm_map = cube.linewidth_fwhm()  # doctest: +SKIP
+
+The ``linewdith_sigma`` computes a sigma linewidth map along the spectral axis, whereas
+the ``linewidth_fwhm`` function computes a FWHM linewidth map along the same spectral axis.
+
+The relations between the linewidth maps and the second moment are as follows:
+
+Suppose the 2nd moment is denoted by :math:`x`>
+
+.. math:: linewidth_{sigma} = \sqrt{`x`} \\
+          linewidth_{fwhm} = 2.35 * \sqrt{x}
 
 These also return :class:`~spectral_cube.lower_dimensional_structures.Projection` instances as for the
 `Moment maps`_.

--- a/docs/moments.rst
+++ b/docs/moments.rst
@@ -20,7 +20,7 @@ axis::
 
 .. note:: These follow the mathematical definition of moments, so the second
           moment is computed as the variance. For the actual formulas used for
-          the moments, please see :method:`~spectral_cube.SpectralCube.moment`.
+          the moments, please see :class:`~spectral_cube.SpectralCube.moment`.
           For linewidth maps, see the `Linewidth maps`_ section.
           
 You may also want to convert the unit of the datacube into a velocity one before

--- a/docs/moments.rst
+++ b/docs/moments.rst
@@ -84,15 +84,16 @@ astronomy), you can use::
     >>> sigma_map = cube.linewidth_sigma()  # doctest: +SKIP
     >>> fwhm_map = cube.linewidth_fwhm()  # doctest: +SKIP
 
-The ``linewdith_sigma`` computes a sigma linewidth map along the spectral axis, whereas
-the ``linewidth_fwhm`` function computes a FWHM linewidth map along the same spectral axis.
+The ``~spectral_cube.SpectralCube.linewidth_sigma`` computes a sigma linewidth map
+along the spectral axis, whereas the ``~spectral_cube.SpectralCube.linewidth_fwhm``
+function computes a FWHM linewidth map along the same spectral axis.
 
 The relations between the linewidth maps and the second moment are as follows:
 
 Suppose the 2nd moment is denoted by :math:`x`>
 
 .. math:: linewidth_{sigma} = \sqrt{`x`} \\
-          linewidth_{fwhm} = 2.35 * \sqrt{x}
+          linewidth_{fwhm} = \sqrt{8*ln{2}} * \sqrt{x}
 
 These also return :class:`~spectral_cube.lower_dimensional_structures.Projection` instances as for the
 `Moment maps`_.

--- a/docs/moments.rst
+++ b/docs/moments.rst
@@ -29,14 +29,18 @@ You may also want to convert the unit of the datacube into a velocity one before
 you can obtain a genuine velocity map via a 1st moment map. So first it will be necessary to 
 apply the :class:`~spectral_cube.SpectralCube.with_spectral_unit` method from this package with the proper attribute settings::
 
-    >>> nii_cube = cube.with_spectral_unit(u.km/u.s, velocity_convention='optical', rest_value=6584*u.AA)  # doctest: +SKIP
+    >>> nii_cube = cube.with_spectral_unit(u.km/u.s,
+                                           velocity_convention='optical',
+                                           rest_value=6584*u.AA)  # doctest: +SKIP
 
 Note that the ``rest_value`` in the above code refers to the wavelength of the targeted line 
 in the 1D spectrum corresponding to the 3rd dimension. Also, since not all velocity values are relevant, 
 next we will use the :class:`~spectral_cube.SpectralCube.spectral_slab` method to slice out the chunk of 
 the cube that actually contains the line::
 
-    >>> nii_cube = cube.with_spectral_unit(u.km/u.s, velocity_convention='optical', rest_value=6584*u.AA)  # doctest: +SKIP
+    >>> nii_cube = cube.with_spectral_unit(u.km/u.s,
+                                           velocity_convention='optical',
+                                           rest_value=6584*u.AA)  # doctest: +SKIP
     >>> nii_subcube = nii_cube.spectral_slab(-60*u.km/u.s,-20*u.km/u.s)  # doctest: +SKIP
     
 Finally, we can now generate the 1st moment map containing the expected velocity structure::
@@ -48,7 +52,7 @@ which act like :class:`~astropy.units.Quantity` objects, and also have
 convenience methods for writing to a file::
 
     >>> moment_0.write('moment0.fits')  # doctest: +SKIP
-    >>> momemt_1.write('moment1.fits')  # doctest: +SKIP
+    >>> moment_1.write('moment1.fits')  # doctest: +SKIP
 
 and converting the data and WCS to a FITS HDU::
 
@@ -56,19 +60,40 @@ and converting the data and WCS to a FITS HDU::
     <astropy.io.fits.hdu.image.PrimaryHDU at 0x10d6ec510>
 
 The conversion to HDU objects makes it very easy to use the moment map with
-plotting packages such as APLpy::
+plotting packages such as `aplpy <https://aplpy.github.io/>`_::
 
     >>> import aplpy  # doctest: +SKIP
     >>> f = aplpy.FITSFigure(moment_0.hdu)  # doctest: +SKIP
     >>> f.show_colorscale()  # doctest: +SKIP
     >>> f.save('moment_0.png')  # doctest: +SKIP
 
-The equation for the N-th moment, where N is a positive integer, usually 0, 1,
-or 2, is:
+There is a shortcut for the above, if you have aplpy_ installed::
 
-.. math:: M_N = \frac{\int I (l - M_l)^N dl}{M_0}
+    >>> moment_0.quicklook('moment_0.png')
 
-Descriptions for the three most common moments used are as follows:
+will create the quicklook grayscale image and save it to a png all in one go.
+
+Moment map equations
+^^^^^^^^^^^^^^^^^^^^
+ 
+The moments are defined below, using :math:`v` for the spectral (velocity,
+frequency, wavelength, or energy) axis and :math:`I_v` as the intensity,
+or otherwise measured flux, value in a given spectral channel.
+
+The equation for the 0th moment is:
+
+.. math:: M_0 = \int I_v  dv
+
+The equation for the 1st moment is:
+
+.. math:: M_1 = \frac{\int v I_v  dv}{\int I_v dv} = \frac{\int v I_v dv}{M_0}
+   
+Higher-order moments (:math:`N\geq2`) are defined as:
+
+.. math:: M_N = \frac{\int I_v (v - M_1)^N dv}{M_0}
+
+
+Descriptions for the three most common moments used are:
 
 * 0th moment - the integrated intensity over the spectral line.  Units are cube
   unit times spectral axis unit (e.g., K km/s).
@@ -95,8 +120,8 @@ linewidth map along the same spectral axis.
 
 The linewidth maps are related to the second moment by
 
-.. math:: linewidth_{sigma} = \sqrt{`M`_2} \\
-          linewidth_{fwhm} = \sqrt{8*ln{2}} * \sqrt{x}
+.. math:: \sigma = \sqrt{M_2} \\
+          FWHM = \sigma \sqrt{8 ln{2}} 
 
 These functions return :class:`~spectral_cube.lower_dimensional_structures.Projection` instances as for the
 `Moment maps`_.

--- a/docs/moments.rst
+++ b/docs/moments.rst
@@ -20,10 +20,8 @@ axis::
 
 .. note:: These follow the mathematical definition of moments, so the second
           moment is computed as the variance. For the actual formulas used for
-          the moments, please see `the api doc 
-          <https://spectral-cube.readthedocs.io/en/latest/api/spectral_cube.SpectralCube.html#spectral_cube.SpectralCube.moment>`_.
-          For linewidth maps, see the
-          `Linewidth maps`_ section.
+          the moments, please see :method:`~spectral_cube.SpectralCube.moment`.
+          For linewidth maps, see the `Linewidth maps`_ section.
           
 You may also want to convert the unit of the datacube into a velocity one before
 you can obtain a genuine velocity map via a 1st moment map. So first it will be necessary to 

--- a/docs/moments.rst
+++ b/docs/moments.rst
@@ -63,37 +63,40 @@ plotting packages such as APLpy::
     >>> f.show_colorscale()  # doctest: +SKIP
     >>> f.save('moment_0.png')  # doctest: +SKIP
 
-The equation for the N-th moment, where N is usually an integer between -1 and some arbitrary
-positive integer, is as follows:
+The equation for the N-th moment, where N is a positive integer, usually 0, 1,
+or 2, is:
 
 .. math:: M_N = \frac{\int I (l - M_l)^N dl}{M_0}
 
 Descriptions for the three most common moments used are as follows:
 
-* 0th moment - the integrated intensity over the spectral line, and is often used for computing line ratios
-* 1st moment - the the intensity-weighted velocity of the spectral line; can be taken as a measure for the mean velocity of the gas
-* 2nd moment - a measure for the velocity dispersion of the gas along the line of sight, or the width of the spectral line, and is defined by the intensity-weighted square of the velocity
+* 0th moment - the integrated intensity over the spectral line.  Units are cube
+  unit times spectral axis unit (e.g., K km/s).
+* 1st moment - the the intensity-weighted velocity of the spectral line.  The
+  unit is the same as the spectral axis unit (e.g., km/s)
+* 2nd moment - the velocity dispersion or the width of the spectral line.  The
+  unit is the spectral axis unit squared (e.g., :math:`km^2/s^2`).  To obtain measurements
+  of the linewidth in spectral axis units, see `Linewidth maps`_ below
 
 
 Linewidth maps
 --------------
 
-Making linewidth maps (sometimes referred to as second moment maps in radio
-astronomy), you can use::
+Line width maps based on the 2nd moment maps, as defined above, can be made
+with either of these two commands::
 
     >>> sigma_map = cube.linewidth_sigma()  # doctest: +SKIP
     >>> fwhm_map = cube.linewidth_fwhm()  # doctest: +SKIP
 
-The ``~spectral_cube.SpectralCube.linewidth_sigma`` computes a sigma linewidth map
-along the spectral axis, whereas the ``~spectral_cube.SpectralCube.linewidth_fwhm``
-function computes a FWHM linewidth map along the same spectral axis.
+``~spectral_cube.SpectralCube.linewidth_sigma`` computes a sigma linewidth map
+along the spectral axis, where sigma is the width of a Gaussian, while 
+``~spectral_cube.SpectralCube.linewidth_fwhm`` computes a FWHM
+linewidth map along the same spectral axis.
 
-The relations between the linewidth maps and the second moment are as follows:
+The linewidth maps are related to the second moment by
 
-Suppose the 2nd moment is denoted by :math:`x`>
-
-.. math:: linewidth_{sigma} = \sqrt{`x`} \\
+.. math:: linewidth_{sigma} = \sqrt{`M`_2} \\
           linewidth_{fwhm} = \sqrt{8*ln{2}} * \sqrt{x}
 
-These also return :class:`~spectral_cube.lower_dimensional_structures.Projection` instances as for the
+These functions return :class:`~spectral_cube.lower_dimensional_structures.Projection` instances as for the
 `Moment maps`_.

--- a/docs/moments.rst
+++ b/docs/moments.rst
@@ -63,6 +63,28 @@ plotting packages such as APLpy::
     >>> f.show_colorscale()  # doctest: +SKIP
     >>> f.save('moment_0.png')  # doctest: +SKIP
 
+The equation for the N-th moment, where N is usually an integer between -1 and some arbitrary
+positive integer say 11, is as follows:
+
+.. math:: M_N = \frac{\int I (l - M_l)^N dl}{M_0}
+
+Descriptions for the twelve most common moments used are as follows:
+
+moments=-1 - the mean value of the spectrum  
+moments=0  - the integrated value of the spectrum, can be used for computing line ratios
+moments=1  - the intensity weighted coordinate; by convention used to get the ’velocity fields’
+moments=2  - the intensity weighted dispersion of the coordinate; by convention used to get the ’velocity dispersion’  
+moments=3  - the median of the cube I
+moments=4  - the median coordinate  
+moments=5  - the standard deviation (SD) about the mean of the spectrum  
+moments=6  - the root mean square of the spectrum  
+moments=7  - the absolute mean deviation of the spectrum  
+moments=8  - the maximum value of the spectrum  
+moments=9  - the coordinate of the maximum value of the spectrum  
+moments=10 - the minimum value of the spectrum  
+moments=11 - the coordinate of the minimum value of the spectrum
+
+
 Linewidth maps
 --------------
 

--- a/docs/moments.rst
+++ b/docs/moments.rst
@@ -64,25 +64,15 @@ plotting packages such as APLpy::
     >>> f.save('moment_0.png')  # doctest: +SKIP
 
 The equation for the N-th moment, where N is usually an integer between -1 and some arbitrary
-positive integer say 11, is as follows:
+positive integer, is as follows:
 
 .. math:: M_N = \frac{\int I (l - M_l)^N dl}{M_0}
 
-Descriptions for the twelve most common moments used are as follows:
+Descriptions for the three most common moments used are as follows:
 
-moments=-1 - the mean value of the spectrum  
-moments=0  - the integrated value of the spectrum, can be used for computing line ratios
-moments=1  - the intensity weighted coordinate; by convention used to get the ’velocity fields’
-moments=2  - the intensity weighted dispersion of the coordinate; by convention used to get the ’velocity dispersion’  
-moments=3  - the median of the cube I
-moments=4  - the median coordinate  
-moments=5  - the standard deviation (SD) about the mean of the spectrum  
-moments=6  - the root mean square of the spectrum  
-moments=7  - the absolute mean deviation of the spectrum  
-moments=8  - the maximum value of the spectrum  
-moments=9  - the coordinate of the maximum value of the spectrum  
-moments=10 - the minimum value of the spectrum  
-moments=11 - the coordinate of the minimum value of the spectrum
+* 0th moment - the integrated flux over the spectral line, can be used for computing some line ratios
+* 1st moment - the the intensity-weighted velocity of the spectral line; can be taken as a measure for the mean velocity of the gas
+* 2nd moment - a measure for the velocity dispersion of the gas along the line of sight, or the width of the spectral line, and is defined by the intensity-weighted square of the velocity
 
 
 Linewidth maps

--- a/docs/moments.rst
+++ b/docs/moments.rst
@@ -20,7 +20,7 @@ axis::
 
 .. note:: These follow the mathematical definition of moments, so the second
           moment is computed as the variance. For the actual formulas used for
-          the moments, please see `the relevant documentation here 
+          the moments, please see `the api doc 
           <https://spectral-cube.readthedocs.io/en/latest/api/spectral_cube.SpectralCube.html#spectral_cube.SpectralCube.moment>`_.
           For linewidth maps, see the
           `Linewidth maps`_ section.

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1497,19 +1497,20 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         """
         Compute moments along the spectral axis.
 
-        Moments are defined as follows:
+        Moments are defined as follows, where :math:`I` is the intensity
+        in a channel and :math:`x` is the spectral coordinate:
 
         Moment 0:
 
-        .. math:: M_0 \\int I dl
+        .. math:: M_0 \\int I dx
 
         Moment 1:
 
-        .. math:: M_1 = \\frac{\\int I l dl}{M_0}
+        .. math:: M_1 = \\frac{\\int I x dx}{M_0}
 
         Moment N:
 
-        .. math:: M_N = \\frac{\\int I (l - M_1)^N dl}{M_0}
+        .. math:: M_N = \\frac{\\int I (x - M_1)^N dx}{M_0}
 
         .. warning:: Note that these follow the mathematical definitions of
                      moments, and therefore the second moment will return a

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1497,8 +1497,8 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         """
         Compute moments along the spectral axis.
 
-        Moments are defined as follows, where :math:`I` is the intensity
-        in a channel and :math:`x` is the spectral coordinate:
+        Moments are defined as follows, where :math:`I` is the intensity in a
+        channel and :math:`x` is the spectral coordinate:
 
         Moment 0:
 


### PR DESCRIPTION
Fixes #554. 

Add details to the "moments.rst" in "docs" in order to better explain possible use of the `moment` function. Hoping this could clarify things for the new/beginning user while adding to the completeness of the relevant documentation. 