### PR TITLE
Fix warnings when a beam is not defined

### DIFF
--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -745,7 +745,7 @@ class BeamMixinClass(object):
             raise NoBeamError("No beam is defined for this SpectralCube or the"
                               " beam information could not be parsed from the"
                               " header. A `~radio_beam.Beam` object can be"
-                              " defined using `cube.with_beam`.")
+                              " added using `cube.with_beam`.")
 
         return self._beam
 

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -10,7 +10,7 @@ from radio_beam import Beam, Beams
 
 from . import wcs_utils
 from . import cube_utils
-from .utils import cached, WCSCelestialError, BeamAverageWarning
+from .utils import cached, WCSCelestialError, BeamAverageWarning, NoBeamError
 from .masks import BooleanArrayMask
 
 
@@ -740,12 +740,20 @@ class BeamMixinClass(object):
 
     @property
     def beam(self):
+        if self._beam is None:
+            # print warning
+            raise NoBeamError("No beam is defined for this SpectralCube or the"
+                              " beam information could not be parsed from the"
+                              " header. A `~radio_beam.Beam` object can be"
+                              " defined using `cube.with_beam`.")
+
         return self._beam
 
     @beam.setter
     def beam(self, obj):
 
-        if not isinstance(obj, Beam):
+        if not isinstance(obj, Beam) and obj is not None:
+            print(obj)
             raise TypeError("beam must be a radio_beam.Beam object.")
 
         self._beam = obj

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -741,7 +741,6 @@ class BeamMixinClass(object):
     @property
     def beam(self):
         if self._beam is None:
-            # print warning
             raise NoBeamError("No beam is defined for this SpectralCube or the"
                               " beam information could not be parsed from the"
                               " header. A `~radio_beam.Beam` object can be"
@@ -753,7 +752,6 @@ class BeamMixinClass(object):
     def beam(self, obj):
 
         if not isinstance(obj, Beam) and obj is not None:
-            print(obj)
             raise TypeError("beam must be a radio_beam.Beam object.")
 
         self._beam = obj

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -275,11 +275,17 @@ def try_load_beam(header):
     except Exception as ex:
         # We don't emit a warning if no beam was found since it's ok for
         # cubes to not have beams
-        if 'No BMAJ' not in str(ex):
-            warnings.warn("Could not parse beam information from header."
-                          "  Exception was: {0}".format(ex.__repr__()),
-                          FITSWarning
-                         )
+        # if 'No BMAJ' not in str(ex):
+        #     warnings.warn("Could not parse beam information from header."
+        #                   "  Exception was: {0}".format(ex.__repr__()),
+        #                   FITSWarning
+        #                  )
+
+        # Avoid warning since cubes don't have a beam
+        # Warning now provided when `SpectralCube.beam` is None
+        beam = None
+
+    return beam
 
 def try_load_beams(data):
     '''
@@ -322,10 +328,14 @@ def try_load_beams(data):
             beam = Beam.from_fits_header(data)
             return beam
         except Exception as ex:
-            warnings.warn("Could not parse beam information from header."
-                          "  Exception was: {0}".format(ex.__repr__()),
-                          FITSWarning
-                         )
+            # warnings.warn("Could not parse beam information from header."
+            #               "  Exception was: {0}".format(ex.__repr__()),
+            #               FITSWarning
+            #              )
+
+            # Avoid warning since cubes don't have a beam
+            # Warning now provided when `SpectralCube.beam` is None
+            beam = None
     else:
         raise ValueError("How did you get here?  This is some sort of error.")
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -3289,8 +3289,12 @@ class SpectralCube(BaseSpectralCube, BeamMixinClass):
             if not isinstance(beam, Beam):
                 raise TypeError("beam must be a radio_beam.Beam object.")
 
+        # Allow setting the beam attribute even if there is no beam defined
+        # Accessing `SpectralCube.beam` without a beam defined raises a
+        # `NoBeamError` with an informative message.
+        self.beam = beam
+
         if beam is not None:
-            self.beam = beam
             self._meta['beam'] = beam
             self._header.update(beam.to_header_keywords())
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1301,7 +1301,11 @@ def test_beam_custom():
     newcube = SpectralCube(data=data, wcs=cube.wcs, header=header)
 
     # newcube should now not have a beam
-    assert not hasattr(newcube, "beam")
+    # Should raise exception
+    try:
+        newcube.beam
+    except utils.NoBeamError:
+        pass
 
     # Attach the beam
     newcube = newcube.with_beam(beam=beam)
@@ -1331,6 +1335,34 @@ def test_beam_custom():
     # Should be in meta too
     assert newcube2.meta['beam'] == newbeam
 
+
+def test_cube_with_no_beam():
+
+    cube, data = cube_and_raw('adv.fits')
+
+    header = cube._header.copy()
+    beam = Beam.from_fits_header(header)
+    del header["BMAJ"], header["BMIN"], header["BPA"]
+
+    newcube = SpectralCube(data=data, wcs=cube.wcs, header=header)
+
+    # Accessing beam raises an error
+    try:
+        newcube.beam
+    except utils.NoBeamError:
+        pass
+
+    # But is still has a beam attribute
+    assert hasattr(newcube, "_beam")
+
+    # Attach the beam
+    newcube = newcube.with_beam(beam=beam)
+
+    # But now it should have an accessible beam
+    try:
+        newcube.beam
+    except utils.NoBeamError as exc:
+        raise exc
 
 def test_multibeam_custom():
 

--- a/spectral_cube/utils.py
+++ b/spectral_cube/utils.py
@@ -95,3 +95,6 @@ class BadVelocitiesWarning(SpectralCubeWarning):
 
 class FITSReadError(Exception):
     pass
+
+class NoBeamError(Exception):
+    pass


### PR DESCRIPTION
Addresses #560. 

Changes the behaviour such that `SpectralCube.beam` raises a `NoBeamError` if a beam object is not defined. Removes the UserWarning in 560 that wasn't very helpful/informative.