### PR TITLE
Adjust callback to handle multiple sets of jobs

### DIFF
--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1897,7 +1897,6 @@ def update_function():
     print("Update Function Call")
 
 
-@pytest.mark.skipif('on_travis')
 def test_smooth_update_function_parallel(capsys):
 
     pytest.importorskip('joblib')
@@ -1916,7 +1915,6 @@ def test_smooth_update_function_parallel(capsys):
     assert captured.out == "Update Function Call\n"*6
 
 
-@pytest.mark.skipif('on_travis')
 def test_smooth_update_function_serial(capsys):
 
     pytest.importorskip('scipy.ndimage')


### PR DESCRIPTION
Parallel runs w/ `njobs > ncores` and an `update_function` were hanging (`test_spectral_cube.test_smooth_update_function_parallel`). Fixed by adjustments from https://stackoverflow.com/questions/38483874/intermediate-results-from-joblib