### PR TITLE
Futureproofing

### DIFF
--- a/spectral_cube/_moments.py
+++ b/spectral_cube/_moments.py
@@ -49,7 +49,7 @@ def _slice0(cube, axis):
     valid = np.zeros(shp, dtype=np.bool)
     for i in range(cube.shape[axis]):
         view[axis] = i
-        plane = cube._get_filled_data(fill=np.nan, view=view)
+        plane = cube._get_filled_data(fill=np.nan, view=tuple(view))
         valid |= np.isfinite(plane)
         result += np.nan_to_num(plane) * cube._pix_size_slice(axis)
     result[~valid] = np.nan
@@ -79,9 +79,9 @@ def _slice1(cube, axis):
 
     for i in range(cube.shape[axis]):
         view[axis] = i
-        plane = cube._get_filled_data(fill=0, view=view)
+        plane = cube._get_filled_data(fill=0, view=tuple(view))
         result += (plane *
-                   pix_cen[view] *
+                   pix_cen[tuple(view)] *
                    pix_size)
         weights += plane * pix_size
     return result / weights
@@ -110,9 +110,9 @@ def moment_slicewise(cube, order, axis):
 
     for i in range(cube.shape[axis]):
         view[axis] = i
-        plane = cube._get_filled_data(fill=0, view=view)
+        plane = cube._get_filled_data(fill=0, view=tuple(view))
         result += (plane *
-                   (pix_cen[view] - mom1) ** order *
+                   (pix_cen[tuple(view)] - mom1) ** order *
                    pix_size)
         weights += plane * pix_size
 

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -180,8 +180,6 @@ class SpatialCoordMixinClass(object):
 
         self._raise_wcs_no_celestial()
 
-        # note: view is a tuple of view
-
         # the next 3 lines are equivalent to (but more efficient than)
         # inds = np.indices(self._data.shape)
         # inds = [i[view] for i in inds]

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -220,7 +220,7 @@ class SpatialCoordMixinClass(object):
 
     @property
     def spatial_coordinate_map(self):
-        view = [0 for ii in range(self.ndim - 2)] + [slice(None)] * 2
+        view = tuple([0 for ii in range(self.ndim - 2)] + [slice(None)] * 2)
         return self.world[view][self.ndim - 2:]
 
     @property

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -616,7 +616,7 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass,
                 dim = dims[lim[0]]
                 sl = [slice(0, 1)]
                 sl.insert(dim, slice(None))
-                spine = self.world[sl][dim]
+                spine = self.world[tuple(sl)][dim]
                 val = np.argmin(np.abs(limval - spine))
                 if limval > spine.max() or limval < spine.min():
                     pass
@@ -632,7 +632,7 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass,
         slices = [slice(limit_dict[xx + 'lo'], limit_dict[xx + 'hi'])
                   for xx in 'yx']
 
-        return self[slices]
+        return self[tuple(slices)]
 
     def to(self, unit, equivalencies=[], freq=None):
         """

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1761,7 +1761,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         if spatial_only:
             slices = (slice(None), slices[1], slices[2])
 
-        return slices
+        return tuple(slices)
 
     def subcube(self, xlo='min', xhi='max', ylo='min', yhi='max', zlo='min',
                 zhi='max', rest_value=None):
@@ -1840,6 +1840,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
 
         slices = [slice(limit_dict[xx+'lo'], limit_dict[xx+'hi'])
                   for xx in 'zyx']
+        slices = tuple(slices)
 
         log.debug('slices: {0}'.format(slices))
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -968,7 +968,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                 slc = [slice(y, y + 1), slice(x, x + 1), ]
                 # create a length-N slice (all-inclusive) along the selected axis
                 slc.insert(axis, slice(None))
-                yield y, x, slc
+                yield y, x, tuple(slc)
 
     def _iter_slices(self, axis, fill=np.nan, check_endian=False):
         """
@@ -978,7 +978,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         view = [slice(None)] * 3
         for x in range(self.shape[axis]):
             view[axis] = x
-            yield self._get_filled_data(view=view, fill=fill,
+            yield self._get_filled_data(view=tuple(view), fill=fill,
                                         check_endian=check_endian)
 
     def _iter_mask_slices(self, axis):
@@ -3185,7 +3185,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             view = [slice(None) for ii in range(self.ndim)]
             # then fill the appropriate slice
             view[axis] = slice(startpoint,None,step)
-            return view
+            return tuple(view)
 
         # size of the dimension of interest
         xs = self.shape[axis]
@@ -3195,6 +3195,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                 if truncate:
                     view = [slice(None) for ii in range(self.ndim)]
                     view[axis] = slice(None,xs-(xs % int(factor)))
+                    view = tuple(view)
                     crarr = self.filled_data[view]
                     mask = self.mask[view].include()
                 else:
@@ -3228,7 +3229,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                 view = [slice(None) for ii in range(self.ndim)]
                 # then fill the appropriate slice
                 view[axis] = slice(startpoint,startpoint+nsteps,1)
-                return view
+                return tuple(view)
 
             newshape = list(self.shape)
             newshape[axis] = (newshape[axis]//factor +
@@ -3243,6 +3244,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             # Create a view that will add a blank newaxis at the right spot
             view_newaxis = [slice(None) for ii in range(self.ndim)]
             view_newaxis[axis] = None
+            view_newaxis = tuple(view_newaxis)
 
             ntf = tempfile.NamedTemporaryFile()
             dsarr = np.memmap(ntf, mode='w+', shape=newshape, dtype=np.float)

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -990,7 +990,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         for x in range(self.shape[axis]):
             view[axis] = x
             yield self._mask.include(data=self._data,
-                                     view=view,
+                                     view=tuple(view),
                                      wcs=self._wcs,
                                      wcs_tolerance=self._wcs_tolerance,
                                     )

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1811,6 +1811,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                 dim = dims[lim[0]]
                 sl = [slice(0,1)]*2
                 sl.insert(dim, slice(None))
+                sl = tuple(sl)
                 spine = self.world[sl][dim]
                 val = np.argmin(np.abs(limval-spine))
                 if limval > spine.max() or limval < spine.min():

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -37,6 +37,9 @@ warnings.simplefilter('always', UserWarning)
 warnings.simplefilter('error', utils.UnsupportedIterationStrategyWarning)
 warnings.simplefilter('error', utils.NotImplementedWarning)
 warnings.simplefilter('error', utils.WCSMismatchWarning)
+warnings.simplefilter('error', FutureWarning)
+warnings.filterwarnings(action='ignore', category=FutureWarning,
+                        module='reproject')
 
 
 try:

--- a/spectral_cube/tests/test_subcubes.py
+++ b/spectral_cube/tests/test_subcubes.py
@@ -76,12 +76,12 @@ def test_ds9region_255(regfile):
 @pytest.mark.skipif('not regionsOK', reason='Could not import regions')
 @pytest.mark.skipif('not REGIONS_GT_03', reason='regions version should be >= 0.3')
 @pytest.mark.parametrize(('regfile', 'result'),
-                             (('fk5.reg', [slice(None), 1, 1]),
-                              ('image.reg', [slice(None), 1, slice(None)]),
+                             (('fk5.reg', (slice(None), 1, 1)),
+                              ('image.reg', (slice(None), 1, slice(None))),
                               (
-                              'partial_overlap_image.reg', [slice(None), 1, 1]),
+                              'partial_overlap_image.reg', (slice(None), 1, 1)),
                               ('no_overlap_image.reg', ValueError),
-                              ('partial_overlap_fk5.reg', [slice(None), 1, 1]),
+                              ('partial_overlap_fk5.reg', (slice(None), 1, 1)),
                               ('no_overlap_fk5.reg', ValueError),
                               ))
 def test_ds9region_new(regfile, result):


### PR DESCRIPTION
Fixes for a whole bunch of future warnings:
```
FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
```
which is really annoying, since we _extensively_ use mutable view creation in this package.