### PR TITLE
Update flattened_world

### DIFF
--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -216,21 +216,7 @@ class SpatialCoordMixinClass(object):
 
         self._raise_wcs_no_celestial()
 
-        if not self.wcs.is_celestial:
-            spec, lon, lat = self.world[view]
-            spec = self._mask._flattened(data=spec, wcs=self._wcs, view=view)
-            lon = self._mask._flattened(data=lon, wcs=self._wcs, view=view)
-            lat = self._mask._flattened(data=lat, wcs=self._wcs, view=view)
-            # Return in reverse numpy ordering,
-            return spec, lon, lat
-
-        else:
-            raise NotImplementedError("flattened_world requires masks to "
-                                      "be implemented for 2D objects.")
-            lon, lat = self.world[view]
-            lon = self._mask._flattened(data=lon, wcs=self._wcs, view=slice)
-            lat = self._mask._flattened(data=lat, wcs=self._wcs, view=slice)
-            return lon, lat
+        return [wd_dim.ravel() for wd_dim in self.world[view]]
 
     def world_spines(self):
         """

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -211,9 +211,6 @@ class SpatialCoordMixinClass(object):
         version of the cube
         """
 
-        # NOTE: this should be moved to SpatialCoordMixinClass once masks
-        # are implemented for lower dim objects - EK
-
         self._raise_wcs_no_celestial()
 
         return [wd_dim.ravel() for wd_dim in self.world[view]]

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -205,6 +205,33 @@ class SpatialCoordMixinClass(object):
 
         return world[::-1]  # reverse WCS -> numpy order
 
+    def flattened_world(self, view=()):
+        """
+        Retrieve the world coordinates corresponding to the extracted flattened
+        version of the cube
+        """
+
+        # NOTE: this should be moved to SpatialCoordMixinClass once masks
+        # are implemented for lower dim objects - EK
+
+        self._raise_wcs_no_celestial()
+
+        if not self.wcs.is_celestial:
+            spec, lon, lat = self.world[view]
+            spec = self._mask._flattened(data=spec, wcs=self._wcs, view=view)
+            lon = self._mask._flattened(data=lon, wcs=self._wcs, view=view)
+            lat = self._mask._flattened(data=lat, wcs=self._wcs, view=view)
+            # Return in reverse numpy ordering,
+            return spec, lon, lat
+
+        else:
+            raise NotImplementedError("flattened_world requires masks to "
+                                      "be implemented for 2D objects.")
+            lon, lat = self.world[view]
+            lon = self._mask._flattened(data=lon, wcs=self._wcs, view=slice)
+            lat = self._mask._flattened(data=lat, wcs=self._wcs, view=slice)
+            return lon, lat
+
     def world_spines(self):
         """
         Returns a list of 1D arrays, for the world coordinates

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1051,21 +1051,6 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         else:
             return u.Quantity(data, self.unit, copy=False)
 
-    def flattened_world(self, view=()):
-        """
-        Retrieve the world coordinates corresponding to the extracted flattened
-        version of the cube
-        """
-
-        # NOTE: this should be moved to SpatialCoordMixinClass once masks
-        # are implemented for lower dim objects - EK
-
-        lon,lat,spec = self.world[view]
-        spec = self._mask._flattened(data=spec, wcs=self._wcs, view=slice)
-        lon = self._mask._flattened(data=lon, wcs=self._wcs, view=slice)
-        lat = self._mask._flattened(data=lat, wcs=self._wcs, view=slice)
-        return lat,lon,spec
-
     def median(self, axis=None, iterate_rays=False, **kwargs):
         """
         Compute the median of an array, optionally along an axis.

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -744,3 +744,41 @@ def test_spatial_world_extrema_2D():
     assert (cube.world_extrema == plane.world_extrema).all()
     assert (cube.longitude_extrema == plane.longitude_extrema).all()
     assert (cube.latitude_extrema == plane.latitude_extrema).all()
+
+
+@pytest.mark.parametrize(('file', 'view'), (
+                         ('adv.fits', np.s_[:, :]),
+                         ('adv.fits', np.s_[::2, :]),
+                         ('adv.fits', np.s_[0]),
+                         ))
+def test_spatial_world(file, view):
+    p = path(file)
+    # d = fits.getdata(p)
+    # wcs = WCS(p)
+    # c = SpectralCube(d, wcs)
+
+    c = SpectralCube.read(p)
+
+    plane = c[0]
+
+    wcs = plane.wcs
+
+    shp = plane.shape
+    inds = np.indices(plane.shape)
+    pix = np.column_stack([i.ravel() for i in inds[::-1]])
+    world = wcs.all_pix2world(pix, 0).T
+
+    world = [w.reshape(shp) for w in world]
+    world = [w[view] * u.Unit(wcs.wcs.cunit[i])
+             for i, w in enumerate(world)][::-1]
+
+    w2 = plane.world[view]
+    for result, expected in zip(w2, world):
+        assert_allclose(result, expected)
+
+    # Test world_flattened here, too
+    # TODO: Enable once 2D masking is a thing
+    # w2_flat = plane.flattened_world(view=view)
+    # for result, expected in zip(w2_flat, world):
+    #     print(result.shape, expected.flatten().shape)
+    #     assert_allclose(result, expected.flatten())

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -778,7 +778,7 @@ def test_spatial_world(file, view):
 
     # Test world_flattened here, too
     # TODO: Enable once 2D masking is a thing
-    # w2_flat = plane.flattened_world(view=view)
-    # for result, expected in zip(w2_flat, world):
-    #     print(result.shape, expected.flatten().shape)
-    #     assert_allclose(result, expected.flatten())
+    w2_flat = plane.flattened_world(view=view)
+    for result, expected in zip(w2_flat, world):
+        print(result.shape, expected.flatten().shape)
+        assert_allclose(result, expected.flatten())

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -170,12 +170,18 @@ class TestSpectralCube(object):
                              ))
     def test_world(self, file, view):
         p = path(file)
-        d = fits.getdata(p)
-        wcs = WCS(p)
-        c = SpectralCube(d, wcs)
+        # d = fits.getdata(p)
+        # wcs = WCS(p)
+        # c = SpectralCube(d, wcs)
 
-        shp = d.shape
-        inds = np.indices(d.shape)
+        c = SpectralCube.read(p)
+
+        wcs = c.wcs
+
+        # shp = d.shape
+        # inds = np.indices(d.shape)
+        shp = c.shape
+        inds = np.indices(c.shape)
         pix = np.column_stack([i.ravel() for i in inds[::-1]])
         world = wcs.all_pix2world(pix, 0).T
 
@@ -186,6 +192,13 @@ class TestSpectralCube(object):
         w2 = c.world[view]
         for result, expected in zip(w2, world):
             assert_allclose(result, expected)
+
+        # Test world_flattened here, too
+        w2_flat = c.flattened_world(view=view)
+        for result, expected in zip(w2_flat, world):
+            print(result.shape, expected.flatten().shape)
+            assert_allclose(result, expected.flatten())
+
 
     @pytest.mark.parametrize('view', (np.s_[:, :,:],
                              np.s_[:2, :3, ::2]))


### PR DESCRIPTION
@keflavich -- I was trying to finish off #279 by adding a `Projection.flattened_world` but the SC version of the function has its own problems.

`cube._mask._flattened` for a cube mask doesn't allow the same slicing as `cube.world`. `flattened_world` could just return the flattened version of whatever `world` returns for consistency.