### PR TITLE
Catch kernels defined as a quantity

### DIFF
--- a/docs/smoothing.rst
+++ b/docs/smoothing.rst
@@ -154,6 +154,9 @@ done in the unit of pixel.  In our example, each channel is 0.1 km/s wide::
     pixel_scale = 0.1 * u.km/u.s
     gaussian_width = ((target_resolution**2 - current_resolution**2)**0.5 /
                       pixel_scale / fwhm_factor)
-    kernel = Gaussian1DKernel(gaussian_width)
+    kernel = Gaussian1DKernel(gaussian_width.value)
     new_cube = cube.spectral_smooth(kernel)
     new_cube.write('newfile.fits')
+
+`gaussian_width` is in pixel units but is defined as a unitless `~astropy.units.Quantity`.
+By using `gaussian_width.value`, we convert the pixel width into a float.

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2981,6 +2981,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             Passed to the convolve function
         """
 
+        if isinstance(kernel.array, u.Quantity):
+            raise u.UnitsError("The convolution kernel should be defined "
+                               "without a unit.")
+
         return self.apply_function_parallel_spectral(convolve,
                                                      kernel=kernel,
                                                      normalize_kernel=True,

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -133,6 +133,16 @@ def test_spectral_smooth():
                                                                 x_size=5).array,
                                    4)
 
+def test_catch_kernel_with_units():
+    # Passing a kernel with a unit should raise a u.UnitsError
+
+    cube, data = cube_and_raw('522_delta.fits')
+
+    with pytest.raises(u.UnitsError) as exc:
+        result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0 * u.dimensionless_unscaled),
+                                      use_memmap=False)
+    assert exc.value.args[0] == "The convolution kernel should be defined without a unit."
+
 
 def test_spectral_smooth_4cores():
 


### PR DESCRIPTION
This is a lazy fix for #514 and #577. A `UnitsError` (maybe a different error would be appropriate) is raised when a kernel is defined as a quantity, which runs into issues with the parallel operations that use a unitless version of the cube.