### PR TITLE
Accommodate beamless cubes

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -449,9 +449,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                 if set(axis) == set((1,2)):
                     new_wcs = self._wcs.sub([wcs.WCSSUB_SPECTRAL])
                     header = self._nowcs_header
-                    if hasattr(self, 'beam'):
+                    # check whether the cube has beams at all
+                    if hasattr(self, 'beam') and self._beam is not None:
                         bmarg = {'beam': self.beam}
-                    elif hasattr(self, 'beams'):
+                    elif hasattr(self, 'beams') and self._beams is not None:
                         bmarg = {'beams': self.unmasked_beams}
                     else:
                         bmarg = {}

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -450,9 +450,11 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                     new_wcs = self._wcs.sub([wcs.WCSSUB_SPECTRAL])
                     header = self._nowcs_header
                     # check whether the cube has beams at all
-                    if hasattr(self, 'beam') and self._beam is not None:
+                    # (note that "hasattr(self, 'beam') on an object with no
+                    # _beam will result in an exception....?!?!?!?)
+                    if hasattr(self, '_beam') and self._beam is not None:
                         bmarg = {'beam': self.beam}
-                    elif hasattr(self, 'beams') and self._beams is not None:
+                    elif hasattr(self, '_beams') and self._beams is not None:
                         bmarg = {'beams': self.unmasked_beams}
                     else:
                         bmarg = {}
@@ -603,9 +605,9 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                       unit=self.unit, header=self._nowcs_header)
                 elif axis == (1,2):
                     newwcs = self._wcs.sub([wcs.WCSSUB_SPECTRAL])
-                    if hasattr(self, 'beam'):
+                    if hasattr(self, '_beam') and self._beam is not None:
                         bmarg = {'beam': self.beam}
-                    elif hasattr(self, 'beams'):
+                    elif hasattr(self, '_beams') and self._beams is not None:
                         bmarg = {'beams': self.unmasked_beams}
                     else:
                         bmarg = {}
@@ -1217,11 +1219,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                 newwcs = self._wcs.sub([a
                                         for a in (1,2,3)
                                         if a not in [x+1 for x in intslices]])
-                # As of #561, beam is defined in all cases
-                if self._beam is not None:
+                if hasattr(self, '_beam') and self._beam is not None:
                     bmarg = {'beam': self.beam}
-                elif hasattr(self, 'beams'):
-                    bmarg = {'beams': self.beams}
+                elif hasattr(self, '_beams') and self._beams is not None:
+                    bmarg = {'beams': self.unmasked_beams}
                 else:
                     bmarg = {}
                 return self._oned_spectrum(value=self._data[view],
@@ -3654,10 +3655,10 @@ class VaryingResolutionSpectralCube(BaseSpectralCube, MultiBeamMixinClass):
                 newwcs = self._wcs.sub([a
                                         for a in (1,2,3)
                                         if a not in [x+1 for x in intslices]])
-                if hasattr(self, 'beam'):
+                if hasattr(self, '_beam') and self._beam is not None:
                     bmarg = {'beam': self.beam}
-                elif hasattr(self, 'beams'):
-                    bmarg = {'beams': self.unmasked_beams[specslice]}
+                elif hasattr(self, '_beams') and self._beams is not None:
+                    bmarg = {'beams': self.unmasked_beams}
                 else:
                     bmarg = {}
                 return self._oned_spectrum(value=self._data[view],

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -607,7 +607,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                     newwcs = self._wcs.sub([wcs.WCSSUB_SPECTRAL])
                     if hasattr(self, '_beam') and self._beam is not None:
                         bmarg = {'beam': self.beam}
-                    elif hasattr(self, '_beams') and self._beams is not None:
+                    elif hasattr(self, 'beams'):
                         bmarg = {'beams': self.unmasked_beams}
                     else:
                         bmarg = {}
@@ -1219,10 +1219,11 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                 newwcs = self._wcs.sub([a
                                         for a in (1,2,3)
                                         if a not in [x+1 for x in intslices]])
+                # As of #561, beam is defined in all cases
                 if hasattr(self, '_beam') and self._beam is not None:
                     bmarg = {'beam': self.beam}
-                elif hasattr(self, '_beams') and self._beams is not None:
-                    bmarg = {'beams': self.unmasked_beams}
+                elif hasattr(self, 'beams'):
+                    bmarg = {'beams': self.beams}
                 else:
                     bmarg = {}
                 return self._oned_spectrum(value=self._data[view],
@@ -2434,7 +2435,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
 
         if self.unit.is_equivalent(u.Jy/u.beam):
             # replace "beam" with the actual beam
-            if not hasattr(self, 'beam'):
+            if not hasattr(self, 'beam') or self._beam is None:
                 raise ValueError("To convert cubes with Jy/beam units, "
                                  "the cube needs to have a beam defined.")
             brightness_unit = self.unit * u.beam
@@ -3657,8 +3658,8 @@ class VaryingResolutionSpectralCube(BaseSpectralCube, MultiBeamMixinClass):
                                         if a not in [x+1 for x in intslices]])
                 if hasattr(self, '_beam') and self._beam is not None:
                     bmarg = {'beam': self.beam}
-                elif hasattr(self, '_beams') and self._beams is not None:
-                    bmarg = {'beams': self.unmasked_beams}
+                elif hasattr(self, 'beams'):
+                    bmarg = {'beams': self.unmasked_beams[specslice]}
                 else:
                     bmarg = {}
                 return self._oned_spectrum(value=self._data[view],

--- a/spectral_cube/tests/data/make_test_cubes.py
+++ b/spectral_cube/tests/data/make_test_cubes.py
@@ -40,7 +40,8 @@ if __name__ == "__main__":
     h['NAXIS2'] = 3
     h['NAXIS3'] = 4
     h['NAXIS4'] = 1
-    d = np.random.random((1, 2, 3, 4))
+    d_advs = d = np.random.random((1, 2, 3, 4))
+
 
     fits.writeto('advs.fits', d, h, overwrite=True)
 
@@ -174,3 +175,16 @@ if __name__ == "__main__":
     hdul = fits.HDUList([fits.PrimaryHDU(data=d, header=h),
                          beams])
     hdul.writeto('5_spectral_beams.fits', overwrite=True)
+
+    # Single Stokes, _no_ beam
+    h = fits.header.Header.fromtextfile(HEADER_FILENAME)
+    h['BUNIT'] = 'K' # Kelvins are a valid unit, JY/BEAM are not: they should be tested separately
+    h['NAXIS1'] = 2
+    h['NAXIS2'] = 3
+    h['NAXIS3'] = 4
+    h['NAXIS4'] = 1
+    del h['BMAJ']
+    del h['BMIN']
+    del h['BPA']
+
+    fits.writeto('advs_nobeam.fits', d_advs, h, overwrite=True)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1067,17 +1067,19 @@ def test_airwave_to_wave():
     np.testing.assert_almost_equal(spectral_axis.air_to_vac(ax1).value,
                                    ax2.value)
 
-@pytest.mark.parametrize(('func','how','axis'),
+
+@pytest.mark.parametrize(('func','how','axis','cubename'),
                          itertools.product(('sum','std','max','min','mean'),
                                            ('slice','cube','auto'),
-                                           (0,1,2)
+                                           (0,1,2),
+                                           ('advs.fits', 'advs_nobeam.fits'),
                                           ))
-def test_twod_numpy(func, how, axis):
+def test_twod_numpy(func, how, axis, cubename):
     # Check that a numpy function returns the correct result when applied along
     # one axis
     # This is partly a regression test for #211
 
-    cube, data = cube_and_raw('advs.fits')
+    cube, data = cube_and_raw(cubename)
     cube._meta['BUNIT'] = 'K'
     cube._unit = u.K
 
@@ -1088,17 +1090,18 @@ def test_twod_numpy(func, how, axis):
     np.testing.assert_equal(proj.value, dproj)
     assert cube.unit == proj.unit
 
-@pytest.mark.parametrize(('func','how','axis'),
+@pytest.mark.parametrize(('func','how','axis','cubename'),
                          itertools.product(('sum','std','max','min','mean'),
                                            ('slice','cube','auto'),
-                                           ((0,1),(1,2),(0,2))
+                                           ((0,1),(1,2),(0,2)),
+                                           ('advs.fits', 'advs_nobeam.fits'),
                                           ))
-def test_twod_numpy_twoaxes(func, how, axis):
+def test_twod_numpy_twoaxes(func, how, axis, cubename):
     # Check that a numpy function returns the correct result when applied along
     # one axis
     # This is partly a regression test for #211
 
-    cube, data = cube_and_raw('advs.fits')
+    cube, data = cube_and_raw(cubename)
     cube._meta['BUNIT'] = 'K'
     cube._unit = u.K
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1160,17 +1160,20 @@ def test_preserves_header_meta_values():
 
 
 
-@pytest.mark.parametrize('func',('sum','std','max','min','mean'))
-def test_oned_numpy(func):
+@pytest.mark.parametrize(('func', 'cubename'),
+                         itertools.product(('sum','std','max','min','mean'),
+                                           ('advs.fits', 'advs_nobeam.fits',),
+                                          ))
+def test_oned_numpy(func, cubename):
     # Check that a numpy function returns an appropriate spectrum
 
-    cube, data = cube_and_raw('advs.fits')
+    cube, data = cube_and_raw(cubename)
     cube._meta['BUNIT'] = 'K'
     cube._unit = u.K
 
     spec = getattr(cube,func)(axis=(1,2))
     dspec = getattr(data,func)(axis=(2,3)).squeeze()
-    assert isinstance(spec, OneDSpectrum)
+    assert isinstance(spec, (OneDSpectrum, VaryingResolutionOneDSpectrum))
     # data has a redundant 1st axis
     np.testing.assert_equal(spec.value, dspec)
     assert cube.unit == spec.unit


### PR DESCRIPTION
Beamless cubes apparently are not adequately tested any more:

```
Traceback (most recent call last):
  File "/orange/adamginsburg/ALMA_IMF/2017.1.01355.L/analysis/line_quicklooks.py", line 68, in <module>
    mxmodspec = modcube.max(axis=(1,2), how='slice')
  File "/orange/adamginsburg/repos/spectral-cube/spectral_cube/spectral_cube.py", line 97, in wrapper
    return func(*args, **kwargs)
  File "/orange/adamginsburg/repos/spectral-cube/spectral_cube/utils.py", line 49, in wrapper
    return function(self, *args, **kwargs)
  File "/orange/adamginsburg/repos/spectral-cube/spectral_cube/spectral_cube.py", line 764, in max
    projection=projection, **kwargs)
  File "/orange/adamginsburg/repos/spectral-cube/spectral_cube/spectral_cube.py", line 452, in apply_numpy_function
    if hasattr(self, 'beam'):
  File "/orange/adamginsburg/repos/spectral-cube/spectral_cube/base_class.py", line 748, in beam
    raise NoBeamError("No beam is defined for this SpectralCube or the"
NoBeamError: No beam is defined for this SpectralCube or the beam information could not be parsed from the header. A `~radio_beam.Beam` object can be added using `cube.with_beam`.
```