### PR TITLE
Test equivalence of reprojected cube WCS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time.
-        - env: SETUP_CMD='build_sphinx -w' NUMPY_VERSION=1.15
+        - env: SETUP_CMD='build_sphinx -w' NUMPY_VERSION=1.16
                PIP_DEPENDENCIES="Cython $PVEXTRACTOR $RADIOBEAM $REGIONS $REPROJECT sphinx-astropy"
           name: docs
 

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -113,6 +113,11 @@ def test_reproject(use_memmap):
     result = cube.reproject(header_out, use_memmap=use_memmap)
 
     assert result.shape == (cube.shape[0], 5, 4)
+    # Check WCS in reprojected matches wcs_out
+    assert wcs_out.wcs.compare(result.wcs.wcs)
+    # And that the headers have equivalent WCS info.
+    result_wcs_from_header = WCS(result.header)
+    assert result_wcs_from_header.wcs.compare(wcs_out.wcs)
 
 
 def test_spectral_smooth():
@@ -339,6 +344,12 @@ def test_reproject_2D():
 
     assert result.shape == (5, 4)
     assert result.beam == proj.beam
+
+    # Check WCS in reprojected matches wcs_out
+    assert wcs_out.wcs.compare(result.wcs.wcs)
+    # And that the headers have equivalent WCS info.
+    result_wcs_from_header = WCS(result.header)
+    assert result_wcs_from_header.wcs.compare(wcs_out.wcs)
 
 
 def test_nocelestial_reproject_2D_fail():


### PR DESCRIPTION
reproject tests were not checking the output WCS. See #588, though I wasn't able to reproduce the error locally.