### PR TITLE
Update I/O infrastructure to use Astropy unified I/O

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
 
 - Refactor package infrastructure to no longer use astropy-helpers. #599
 
+- Switch to using unified I/O infrastructure from Astropy. #600
+
 0.4.5 (unreleased)
 ------------------
  - Added support for casatools-based io in #541 and beam reading from CASA

--- a/spectral_cube/__init__.py
+++ b/spectral_cube/__init__.py
@@ -11,6 +11,14 @@ from .masks import (MaskBase, InvertedMask, CompositeMask,
                     FunctionMask)
 from .lower_dimensional_structures import (OneDSpectrum, Projection, Slice)
 
+# Import the following sub-packages to make sure the I/O functions are registered
+from .io import casa_image
+del casa_image
+from .io import class_lmv
+del class_lmv
+from .io import fits
+del fits
+
 __all__ = ['SpectralCube', 'VaryingResolutionSpectralCube',
             'StokesSpectralCube', 'CompositeMask', 'LazyComparisonMask',
             'LazyMask', 'BooleanArrayMask', 'FunctionMask',

--- a/spectral_cube/io/casa_image.py
+++ b/spectral_cube/io/casa_image.py
@@ -342,21 +342,8 @@ def load_casa_image(filename, skipdata=False,
         raise ValueError("CASA image has {0} dimensions, and therefore "
                          "is not readable by spectral-cube.".format(wcs.naxis))
 
-    if target_cls is BaseSpectralCube and isinstance(cube, StokesSpectralCube):
-        if hasattr(cube, 'I'):
-            warnings.warn("Cube is a Stokes cube, "
-                          "returning spectral cube for I component",
-                          StokesWarning)
-            return cube.I
-        else:
-            raise ValueError("Spectral cube is a Stokes cube that "
-                            "does not have an I component")
-    elif target_cls is StokesSpectralCube and isinstance(cube, BaseSpectralCube):
-        cube = StokesSpectralCube({'I': cube})
-    else:
-        return cube
-
-    return cube
+    from .core import normalize_cube_stokes
+    return normalize_cube_stokes(cube, target_cls=target_cls)
 
 
 io_registry.register_reader('casa', BaseSpectralCube, load_casa_image)

--- a/spectral_cube/io/casa_image.py
+++ b/spectral_cube/io/casa_image.py
@@ -9,6 +9,7 @@ from astropy.wcs import WCS
 from astropy import units as u
 from astropy.wcs.wcsapi.sliced_low_level_wcs import sanitize_slices
 from astropy import log
+from astropy.io import registry as io_registry
 import numpy as np
 from radio_beam import Beam, Beams
 
@@ -29,7 +30,7 @@ from .. import wcs_utils
 # yield the same array in memory that we would get from astropy.
 
 
-def is_casa_image(input, **kwargs):
+def is_casa_image(input, *args, **kwargs):
     if isinstance(input, six.string_types):
         if input.endswith('.image'):
             return True
@@ -345,3 +346,7 @@ def load_casa_image(filename, skipdata=False,
 
 
     return cube
+
+
+io_registry.register_reader('casa', SpectralCube, load_casa_image)
+io_registry.register_identifier('casa', SpectralCube, is_casa_image)

--- a/spectral_cube/io/casa_image.py
+++ b/spectral_cube/io/casa_image.py
@@ -16,6 +16,7 @@ from radio_beam import Beam, Beams
 import dask.array
 
 from .. import SpectralCube, StokesSpectralCube, BooleanArrayMask, LazyMask, VaryingResolutionSpectralCube
+from ..spectral_cube import BaseSpectralCube
 from .. import cube_utils
 from .. utils import BeamWarning, cached
 from .. import wcs_utils
@@ -30,11 +31,8 @@ from .. import wcs_utils
 # yield the same array in memory that we would get from astropy.
 
 
-def is_casa_image(input, *args, **kwargs):
-    if isinstance(input, six.string_types):
-        if input.endswith('.image'):
-            return True
-    return False
+def is_casa_image(origin, filepath, fileobj, *args, **kwargs):
+    return filepath is not None and filepath.lower().endswith('.image')
 
 
 def wcs_casa2astropy(ia, coordsys):
@@ -348,5 +346,5 @@ def load_casa_image(filename, skipdata=False,
     return cube
 
 
-io_registry.register_reader('casa', SpectralCube, load_casa_image)
-io_registry.register_identifier('casa', SpectralCube, is_casa_image)
+io_registry.register_reader('casa', BaseSpectralCube, load_casa_image)
+io_registry.register_identifier('casa', BaseSpectralCube, is_casa_image)

--- a/spectral_cube/io/class_lmv.py
+++ b/spectral_cube/io/class_lmv.py
@@ -6,6 +6,8 @@ import struct
 import warnings
 import string
 from astropy import log
+from astropy.io import registry as io_registry
+from ..spectral_cube import SpectralCube
 from .fits import load_fits_cube
 
 """
@@ -40,7 +42,7 @@ _proj_dict = {0:'ARC', 1:'TAN', 2:'SIN', 3:'AZP', 4:'STG', 5:'ZEA', 6:'AIT',
               7:'GLS', 8:'SFL', }
 _bunit_dict = {'k (tmb)': 'K'}
 
-def is_lmv(input, **kwargs):
+def is_lmv(input, *args, **kwargs):
     """
     Determine whether input is in GILDAS CLASS lmv format
     """
@@ -49,6 +51,7 @@ def is_lmv(input, **kwargs):
             return True
     else:
         return False
+
 
 def read_lmv(filename):
     """
@@ -671,3 +674,8 @@ def read_lmv_type2(lf):
     data[data==bval] = np.nan
 
     return data,header
+
+
+io_registry.register_reader('lmv', SpectralCube, load_lmv_cube)
+io_registry.register_reader('class_lmv', SpectralCube, load_lmv_cube)
+io_registry.register_identifier('lmv', SpectralCube, is_lmv)

--- a/spectral_cube/io/core.py
+++ b/spectral_cube/io/core.py
@@ -1,3 +1,10 @@
+# The read and write methods for SpectralCube, StokesSpectralCube, and
+# LowerDimensionalObject are defined in this file and then added to the classes
+# using UnifiedReadWriteMethod. This makes it possible to dynamically add the
+# available formats to the read/write docstrings. For more information about
+# the unified I/O framework from Astropy which is used to implement this, see
+# http://docs.astropy.org/en/stable/io/unified.html
+
 from __future__ import print_function, absolute_import, division
 
 from pathlib import PosixPath
@@ -5,54 +12,90 @@ import warnings
 
 from astropy.io import registry
 
+from ..utils import StokesWarning
+
 __doctest_skip__ = ['SpectralCubeRead',
                     'SpectralCubeWrite',
                     'StokesSpectralCubeRead',
                     'StokesSpectralCubeWrite',
                     'LowerDimensionalObjectWrite']
 
+DOCSTRING_READ_TEMPLATE = """
+Read and parse a dataset and return as a {clsname}
+
+This allows easily reading a dataset in several supported data
+formats using syntax such as::
+
+    >>> from spectral_cube import {clsname}
+    >>> cube1 = {clsname}.read('cube.fits', format='fits')
+    >>> cube2 = {clsname}.read('cube.image', format='casa')
+
+{notes}
+
+Get help on the available readers for {clsname} using the``help()`` method::
+
+    >>> {clsname}.read.help()  # Get help reading {clsname} and list supported formats
+    >>> {clsname}.read.help('fits')  # Get detailed help on {clsname} FITS reader
+    >>> {clsname}.read.list_formats()  # Print list of available formats
+
+See also: http://docs.astropy.org/en/stable/io/unified.html
+
+Parameters
+----------
+*args : tuple, optional
+    Positional arguments passed through to data reader. If supplied the
+    first argument is typically the input filename.
+format : str
+    File format specifier.
+**kwargs : dict, optional
+    Keyword arguments passed through to data reader.
+
+Returns
+-------
+cube : `{clsname}`
+    {clsname} corresponding to dataset
+
+Notes
+-----
+"""
+
+DOCSTRING_WRITE_TEMPLATE = """
+Write this {clsname} object out in the specified format.
+
+This allows easily writing a dataset in many supported data formats
+using syntax such as::
+
+    >>> data.write('data.fits', format='fits')
+
+Get help on the available writers for {clsname} using the``help()`` method::
+
+    >>> {clsname}.write.help()  # Get help writing {clsname} and list supported formats
+    >>> {clsname}.write.help('fits')  # Get detailed help on {clsname} FITS writer
+    >>> {clsname}.write.list_formats()  # Print list of available formats
+
+See also: http://docs.astropy.org/en/stable/io/unified.html
+
+Parameters
+----------
+*args : tuple, optional
+    Positional arguments passed through to data writer. If supplied the
+    first argument is the output filename.
+format : str
+    File format specifier.
+**kwargs : dict, optional
+    Keyword arguments passed through to data writer.
+
+Notes
+-----
+"""
+
 
 class SpectralCubeRead(registry.UnifiedReadWrite):
-    """
-    Read and parse a dataset and return as a SpectralCube
 
-    This allows easily reading a dataset in several supported data
-    formats using syntax such as::
-
-      >>> from spectral_cube import SpectralCube
-      >>> cube1 = SpectralCube.read('cube.fits', format='fits')
-      >>> cube2 = SpectralCube.read('cube.image', format='casa')
-
-    If the file contains Stokes axes, they will automatically be dropped. If
-    you want to read in all Stokes informtion, use
-    :meth:`~spectral_cube.StokesSpectralCube.read` instead.
-
-    Get help on the available readers for ``SpectralCube`` using the``help()`` method::
-
-      >>> SpectralCube.read.help()  # Get help reading SpectralCube and list supported formats
-      >>> SpectralCube.read.help('fits')  # Get detailed help on SpectralCube FITS reader
-      >>> SpectralCube.read.list_formats()  # Print list of available formats
-
-    See also: http://docs.astropy.org/en/stable/io/unified.html
-
-    Parameters
-    ----------
-    *args : tuple, optional
-        Positional arguments passed through to data reader. If supplied the
-        first argument is typically the input filename.
-    format : str
-        File format specifier.
-    **kwargs : dict, optional
-        Keyword arguments passed through to data reader.
-
-    Returns
-    -------
-    cube : `SpectralCube`
-        SpectralCube corresponding to dataset
-
-    Notes
-    -----
-    """
+    __doc__ = DOCSTRING_READ_TEMPLATE.format(clsname='SpectralCube',
+                                             notes="If the file contains Stokes axes, they will automatically be dropped. If "
+                                                    "you want to read in all Stokes informtion, use "
+                                                    ":meth:`~spectral_cube.StokesSpectralCube.read` instead.")
 
     def __init__(self, instance, cls):
         super().__init__(instance, cls, 'read')
@@ -66,35 +109,9 @@ class SpectralCubeRead(registry.UnifiedReadWrite):
 
 
 class SpectralCubeWrite(registry.UnifiedReadWrite):
-    """
-    Write this SpectralCube object out in the specified format.
 
-    This allows easily writing a spectral cube in many supported data formats
-    using syntax such as::
+    __doc__ = DOCSTRING_WRITE_TEMPLATE.format(clsname='SpectralCube')
 
-      >>> cube.write('cube.fits', format='fits')
-
-    Get help on the available writers for ``SpectralCube`` using the``help()`` method::
-
-      >>> SpectralCube.write.help()  # Get help writing SpectralCube and list supported formats
-      >>> SpectralCube.write.help('fits')  # Get detailed help on SpectralCube FITS writer
-      >>> SpectralCube.write.list_formats()  # Print list of available formats
-
-    See also: http://docs.astropy.org/en/stable/io/unified.html
-
-    Parameters
-    ----------
-    *args : tuple, optional
-        Positional arguments passed through to data writer. If supplied the
-        first argument is the output filename.
-    format : str
-        File format specifier.
-    **kwargs : dict, optional
-        Keyword arguments passed through to data writer.
-
-    Notes
-    -----
-    """
     def __init__(self, instance, cls):
         super().__init__(instance, cls, 'write')
 
@@ -103,46 +120,11 @@ class SpectralCubeWrite(registry.UnifiedReadWrite):
 
 
 class StokesSpectralCubeRead(registry.UnifiedReadWrite):
-    """
-    Read and parse a dataset and return as a StokesSpectralCube
 
-    This allows easily reading a dataset in several supported data formats
-    using syntax such as::
-
-      >>> from spectral_cube import StokesSpectralCube
-      >>> cube1 = StokesSpectralCube.read('cube.fits', format='fits')
-      >>> cube2 = StokesSpectralCube.read('cube.image', format='casa')
-
-    If the file contains Stokes axes, they will be read in. If you are only
-    interested in the unpolarized emission (I), you can use
-    :meth:`~spectral_cube.SpectralCube.read` instead.
-
-    Get help on the available readers for ``StokesSpectralCube`` using the``help()`` method::
-
-      >>> StokesSpectralCube.read.help()  # Get help reading StokesSpectralCube and list supported formats
-      >>> StokesSpectralCube.read.help('fits')  # Get detailed help on StokesSpectralCube FITS reader
-      >>> StokesSpectralCube.read.list_formats()  # Print list of available formats
-
-    See also: http://docs.astropy.org/en/stable/io/unified.html
-
-    Parameters
-    ----------
-    *args : tuple, optional
-        Positional arguments passed through to data reader. If supplied the
-        first argument is typically the input filename.
-    format : str
-        File format specifier.
-    **kwargs : dict, optional
-        Keyword arguments passed through to data reader.
-
-    Returns
-    -------
-    cube : `StokesSpectralCube`
-        StokesSpectralCube corresponding to dataset
-
-    Notes
-    -----
-    """
+    __doc__ = DOCSTRING_READ_TEMPLATE.format(clsname='StokesSpectralCube',
+                                             notes="If the file contains Stokes axes, they will be read in. If you are only "
+                                                   "interested in the unpolarized emission (I), you can use "
+                                                   ":meth:`~spectral_cube.SpectralCube.read` instead.")
 
     def __init__(self, instance, cls):
         super().__init__(instance, cls, 'read')
@@ -156,35 +138,9 @@ class StokesSpectralCubeRead(registry.UnifiedReadWrite):
 
 
 class StokesSpectralCubeWrite(registry.UnifiedReadWrite):
-    """
-    Write this StokesSpectralCube object out in the specified format.
 
-    This allows easily writing a spectral cube in many supported data formats
-    using syntax such as::
+    __doc__ = DOCSTRING_WRITE_TEMPLATE.format(clsname='StokesSpectralCube')
 
-      >>> cube.write('cube.fits', format='fits')
-
-    Get help on the available writers for ``StokesSpectralCube`` using the``help()`` method::
-
-      >>> StokesSpectralCube.write.help()  # Get help writing StokesSpectralCube and list supported formats
-      >>> StokesSpectralCube.write.help('fits')  # Get detailed help on StokesSpectralCube FITS writer
-      >>> StokesSpectralCube.write.list_formats()  # Print list of available formats
-
-    See also: http://docs.astropy.org/en/stable/io/unified.html
-
-    Parameters
-    ----------
-    *args : tuple, optional
-        Positional arguments passed through to data writer. If supplied the
-        first argument is the output filename.
-    format : str
-        File format specifier.
-    **kwargs : dict, optional
-        Keyword arguments passed through to data writer.
-
-    Notes
-    -----
-    """
     def __init__(self, instance, cls):
         super().__init__(instance, cls, 'write')
 
@@ -193,37 +149,31 @@ class StokesSpectralCubeWrite(registry.UnifiedReadWrite):
 
 
 class LowerDimensionalObjectWrite(registry.UnifiedReadWrite):
-    """
-    Write this object out in the specified format.
 
-    This allows easily writing a data object in many supported data formats
-    using syntax such as::
+    __doc__ = DOCSTRING_WRITE_TEMPLATE.format(clsname='LowerDimensionalObject')
 
-      >>> data.write('data.fits', format='fits')
-
-    Get help on the available writers using the``help()`` method, e.g.::
-
-      >>> LowerDimensionalObject.write.help()  # Get help writing LowerDimensionalObject and list supported formats
-      >>> LowerDimensionalObject.write.help('fits')  # Get detailed help on LowerDimensionalObject FITS writer
-      >>> LowerDimensionalObject.write.list_formats()  # Print list of available formats
-
-    See also: http://docs.astropy.org/en/stable/io/unified.html
-
-    Parameters
-    ----------
-    *args : tuple, optional
-        Positional arguments passed through to data writer. If supplied the
-        first argument is the output filename.
-    format : str
-        File format specifier.
-    **kwargs : dict, optional
-        Keyword arguments passed through to data writer.
-
-    Notes
-    -----
-    """
     def __init__(self, instance, cls):
         super().__init__(instance, cls, 'write')
 
     def __call__(self, *args, serialize_method=None, **kwargs):
         registry.write(self._instance, *args, **kwargs)
+
+
+def normalize_cube_stokes(cube, target_cls=None):
+
+    from ..spectral_cube import BaseSpectralCube
+    from ..stokes_spectral_cube import StokesSpectralCube
+
+    if target_cls is BaseSpectralCube and isinstance(cube, StokesSpectralCube):
+        if hasattr(cube, 'I'):
+            warnings.warn("Cube is a Stokes cube, "
+                          "returning spectral cube for I component",
+                          StokesWarning)
+            return cube.I
+        else:
+            raise ValueError("Spectral cube is a Stokes cube that "
+                            "does not have an I component")
+    elif target_cls is StokesSpectralCube and isinstance(cube, BaseSpectralCube):
+        cube = StokesSpectralCube({'I': cube})
+    else:
+        return cube

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -209,19 +209,8 @@ def load_fits_cube(input, hdu=0, meta=None, target_cls=None, **kwargs):
 
         raise FITSReadError("Data should be 3- or 4-dimensional")
 
-    if target_cls is BaseSpectralCube and isinstance(cube, StokesSpectralCube):
-        if hasattr(cube, 'I'):
-            warnings.warn("Cube is a Stokes cube, "
-                          "returning spectral cube for I component",
-                          StokesWarning)
-            return cube.I
-        else:
-            raise ValueError("Spectral cube is a Stokes cube that "
-                            "does not have an I component")
-    elif target_cls is StokesSpectralCube and isinstance(cube, BaseSpectralCube):
-        cube = StokesSpectralCube({'I': cube})
-    else:
-        return cube
+    from .core import normalize_cube_stokes
+    return normalize_cube_stokes(cube, target_cls=target_cls)
 
 
 def write_fits_cube(cube, filename, overwrite=False,

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -282,6 +282,9 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
 
         return cube
 
+    read = UnifiedReadWriteMethod(SpectralCubeRead)
+    write = UnifiedReadWriteMethod(SpectralCubeWrite)
+
     @property
     def unit(self):
         """ The flux unit """
@@ -2146,9 +2149,6 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             return self._cube_on_cube_operation(operator.pow, value)
         else:
             return self._apply_everywhere(operator.pow, value)
-
-    read = UnifiedReadWriteMethod(SpectralCubeRead)
-    write = UnifiedReadWriteMethod(SpectralCubeWrite)
 
     def to_yt(self, spectral_factor=1.0, nprocs=None, **kwargs):
         """

--- a/spectral_cube/stokes_spectral_cube.py
+++ b/spectral_cube/stokes_spectral_cube.py
@@ -3,6 +3,8 @@ from __future__ import print_function, absolute_import, division
 import six
 import numpy as np
 
+from astropy.io.registry import UnifiedReadWriteMethod
+from .io.core import StokesSpectralCubeRead, StokesSpectralCubeWrite
 from .spectral_cube import SpectralCube, BaseSpectralCube
 from . import wcs_utils
 from .masks import BooleanArrayMask, is_broadcastable_and_smaller
@@ -152,46 +154,5 @@ class StokesSpectralCube(object):
 
         return self._new_cube_with(stokes_data=stokes_data)
 
-    @classmethod
-    def read(cls, filename, format=None, hdu=None, **kwargs):
-        """
-        Read a spectral cube from a file.
-
-        If the file contains Stokes axes, they will be read in. If you are
-        only interested in the unpolarized emission (I), you can use
-        :meth:`~spectral_cube.SpectralCube.read` instead.
-
-        Parameters
-        ----------
-        filename : str
-            The file to read the cube from
-        format : str
-            The format of the file to read. (Currently limited to 'fits' and 'casa_image')
-        hdu : int or str
-            For FITS files, the HDU to read in (can be the ID or name of an
-            HDU).
-
-        Returns
-        -------
-        cube : :class:`SpectralCube`
-        """
-        from .io.core import read
-        cube = read(filename, format=format, hdu=hdu)
-        if isinstance(cube, BaseSpectralCube):
-            cube = StokesSpectralCube({'I': cube})
-        return cube
-
-    def write(self, filename, overwrite=False, format=None):
-        """
-        Write the spectral cube to a file.
-
-        Parameters
-        ----------
-        filename : str
-            The path to write the file to
-        format : str
-            The format of the file to write. (Currently limited to 'fits')
-        overwrite : bool
-            If True, overwrite ``filename`` if it exists
-        """
-        raise NotImplementedError("")
+    read = UnifiedReadWriteMethod(StokesSpectralCubeRead)
+    write = UnifiedReadWriteMethod(StokesSpectralCubeWrite)

--- a/spectral_cube/tests/test_analysis_functions.py
+++ b/spectral_cube/tests/test_analysis_functions.py
@@ -7,7 +7,7 @@ import astropy.units as u
 
 from ..analysis_utilities import stack_spectra, fourier_shift
 from .utilities import generate_gaussian_cube, gaussian
-
+from ..utils import BadVelocitiesWarning
 
 def test_shift():
 
@@ -106,7 +106,8 @@ def test_stacking_badvels():
 
     test_vels[12,11] = 500*u.km/u.s
 
-    with warnings.catch_warnings(record=True) as wrn:
+    with pytest.warns(BadVelocitiesWarning,
+                      match='Some velocities are outside the allowed range and will be'):
         # Stack the spectra in the cube
         stacked = \
             stack_spectra(test_cube, test_vels, v0=v0,
@@ -114,7 +115,6 @@ def test_stacking_badvels():
                           xy_posns=None, num_cores=1,
                           chunk_size=-1,
                           progressbar=False, pad_edges=False)
-        assert 'Some velocities are outside the allowed range and will be' in str(wrn[-1].message)
 
     # Calculate residuals (the one bad value shouldn't have caused a problem)
     resid = np.abs(stacked.value - true_spectrum)

--- a/spectral_cube/tests/test_io.py
+++ b/spectral_cube/tests/test_io.py
@@ -3,7 +3,6 @@ from __future__ import print_function, absolute_import, division
 import numpy as np
 from astropy.io import fits as pyfits
 from astropy import units as u
-from ..io import class_lmv, fits
 from .. import SpectralCube, StokesSpectralCube
 from ..lower_dimensional_structures import (OneDSpectrum,
                                             VaryingResolutionOneDSpectrum)

--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,10 @@ changedir =
 description =
     run tests with pytest
 deps =
-    dev: git+https://github.com/radio-astro-tools/pvextractor
-    dev: git+https://github.com/radio-astro-tools/radio-beam
-    dev: git+https://github.com/astropy/astropy
-    dev: git+https://github.com/astropy/reproject
+    dev: git+https://github.com/radio-astro-tools/pvextractor#egg=pvextractor
+    dev: git+https://github.com/radio-astro-tools/radio-beam#egg=radio-beam
+    dev: git+https://github.com/astropy/astropy#egg=astropy
+    dev: git+https://github.com/astropy/reproject#egg=reproject
     casa: :NRAO:casatools
     casa: :NRAO:casatasks
 extras =


### PR DESCRIPTION
This updates the I/O in spectral-cube to use the astropy I/O registry machinery. This should in principle make it easier to add new formats in future, and avoids having to have hard-coded if statements to check what format is being used.

At the moment, there is a bit of code/docstring duplication which I hope to get rid of, so this is a work in progress (but I'm opening this to make sure the CI passes as-is already). Note that if we ever switch to inheriting from NDData, a whole bunch of code in ``io.core`` will no longer be needed.

This also fixes the tox configuration which was previously not properly installing the developer version of astropy, and fixes some related issues.