### PR TITLE
minor: change sigma_clip to sigma_clip_spectrally

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2881,10 +2881,11 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                                                  )
 
     @parallel_docstring
-    def sigma_clip(self, threshold, verbose=0, use_memmap=True,
-                   num_cores=None, **kwargs):
+    def sigma_clip_spectrally(self, threshold, verbose=0, use_memmap=True,
+                              num_cores=None, **kwargs):
         """
-        Run astropy's sigma clipper, converting all bad values to NaN.
+        Run astropy's sigma clipper along the spectral axis, converting all bad
+        (excluded) values to NaN.
 
         Parameters
         ----------


### PR DESCRIPTION
Sigma clipping as built can only be run along the spectral axis, so this PR tries to make that clearer