### PR TITLE
No longer require CASA for coordsys to WCS conversion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@
 - Refactor package infrastructure to no longer use astropy-helpers. #599
 - Switch to using unified I/O infrastructure from Astropy. #600
 - Refactor CASA I/O to use dask to access the array/mask data directly
-  and to use only Python and Numpy to access image metadata. #607, #609
+  and to use only Python and Numpy to access image metadata. CASA images
+  can now be read without CASA installed. #607, #609, #613
 
 0.4.5 (unreleased)
 ------------------

--- a/spectral_cube/io/casa_image.py
+++ b/spectral_cube/io/casa_image.py
@@ -89,7 +89,7 @@ def load_casa_image(filename, skipdata=False,
     else:
         beam_ = {}
 
-    wcs = wcs_casa2astropy(data.ndim, casa_cs)
+    wcs = wcs_casa2astropy(casa_cs)
 
     del casa_cs
 

--- a/spectral_cube/io/casa_low_level_io.py
+++ b/spectral_cube/io/casa_low_level_io.py
@@ -63,7 +63,7 @@ def read_complex128(f):
 
 def read_string(f):
     value = read_int32(f)
-    return f.read(int(value)).decode('ascii')
+    return f.read(int(value)).replace(b'\x00', b'').decode('ascii')
 
 
 @with_nbytes_prefix

--- a/spectral_cube/io/casa_wcs.py
+++ b/spectral_cube/io/casa_wcs.py
@@ -47,6 +47,8 @@ for system in EQUATORIAL_SYSTEMS:
 def sanitize_unit(unit):
     if unit == "'":
         return 'arcmin'
+    elif unit == '"':
+        return 'arcsec'
     else:
         return unit
 
@@ -114,13 +116,18 @@ def wcs_casa2astropy(coordsys):
 
     for coord_type in ('direction', 'spectral', 'stokes', 'linear'):
 
+        # Each coordinate type is stored with a numerical index,
+        # so for example a cube might have direction0 and
+        # spectral1, or spectral0, direction1, stokes2. The actual
+        # index is irrelevant for the rest of the loop.
         for index in range(len(worldmap)):
             if f'{coord_type}{index}' in coordsys:
+                data = coordsys[f'{coord_type}{index}']
                 break
         else:
+            # Skip the rest of the loop for the current coord_type
+            # since the coord_type wasn't found with any index.
             continue
-
-        data = coordsys[f'{coord_type}{index}']
 
         if coord_type == 'direction':
             idx1, idx2 = worldmap[index] + 1

--- a/spectral_cube/io/casa_wcs.py
+++ b/spectral_cube/io/casa_wcs.py
@@ -106,8 +106,11 @@ def wcs_casa2astropy(coordsys):
             header['RADESYS'] = RADESYS[data['conversionSystem']]
             if data['conversionSystem'] in EQUINOX:
                 header['EQUINOX'] = EQUINOX[data['conversionSystem']]
-            header[f'PV{idx2}_{idx1}'] = 0.
-            header[f'PV{idx2}_{idx2}'] = 0.
+            # NOTE: unclear if it is deliberate that the following is always
+            # ?_2 and ?_1 or whether it should depend on the index of the
+            # longitude.
+            header[f'PV{idx2}_1'] = 0.
+            header[f'PV{idx2}_2'] = 0.
             header[f'PC{idx1}_{idx1}'] = data['pc'][0, 0]
             header[f'PC{idx1}_{idx2}'] = data['pc'][0, 1]
             header[f'PC{idx2}_{idx1}'] = data['pc'][1, 0]

--- a/spectral_cube/io/casa_wcs.py
+++ b/spectral_cube/io/casa_wcs.py
@@ -22,9 +22,6 @@ def wcs_casa2astropy(coordsys):
     # to CASA by getting it to write out a FITS file and reading back in
     # using WCS
 
-    from pprint import pprint
-    pprint(coordsys)
-
     header = fits.Header()
 
     # Observer information (ObsInfo.cc)
@@ -86,6 +83,7 @@ def wcs_casa2astropy(coordsys):
 
         SYSTEM_TO_SPECSYS = {}
         SYSTEM_TO_SPECSYS['BARY'] = 'BARYCENT'
+        SYSTEM_TO_SPECSYS['TOPO'] = 'TOPOCENT'
         SYSTEM_TO_SPECSYS['LSRK'] = 'LSRK'
 
         RADESYS = {}

--- a/spectral_cube/io/casa_wcs.py
+++ b/spectral_cube/io/casa_wcs.py
@@ -5,6 +5,44 @@ from astropy.time import Time
 
 __all__ = ['wcs_casa2astropy']
 
+EQUATORIAL_SYSTEMS = ['B1950', 'B1950_VLA', 'J2000', 'ICRS']
+
+SPECSYS = {}
+SPECSYS['BARY'] = 'BARYCENT'
+SPECSYS['TOPO'] = 'TOPOCENT'
+SPECSYS['LSRK'] = 'LSRK'
+SPECSYS['LSRD'] = 'LSRD'
+SPECSYS['GEO'] = 'GEOCENTR'
+SPECSYS['GALACTO'] = 'GALACTOC'
+SPECSYS['LGROUP'] = 'LOCALGRP'
+SPECSYS['CMB'] = 'CMBDIPOL'
+SPECSYS['REST'] = 'SOURCE'
+
+RADESYS = {}
+RADESYS['J2000'] = 'FK5'
+RADESYS['B1950'] = 'FK4'
+RADESYS['B1950_VLA'] = 'FK4'
+RADESYS['ICRS'] = 'ICRS'
+
+EQUINOX = {}
+EQUINOX['J2000'] = 2000.
+EQUINOX['B1950'] = 1950.
+EQUINOX['B1950_VLA'] = 1979.9
+
+AXES_TO_CTYPE = {
+    'Frequency': 'FREQ',
+    'GALACTIC': {'Longitude': 'GLON',
+                 'Latitude': 'GLAT'},
+    'SUPERGAL': {'Longitude': 'SLON',
+                 'Latitude': 'SLAT'},
+    'ECLIPTIC': {'Longitude': 'ELON',
+                 'Latitude': 'ELAT'}
+}
+
+for system in EQUATORIAL_SYSTEMS:
+    AXES_TO_CTYPE[system] = {'Right Ascension': 'RA--',
+                             'Declination': 'DEC-'}
+
 
 def sanitize_unit(unit):
     if unit == "'":
@@ -84,50 +122,10 @@ def wcs_casa2astropy(coordsys):
 
         data = coordsys[f'{coord_type}{index}']
 
-        EQUATORIAL_SYSTEMS = ['B1950', 'B1950_VLA', 'J2000', 'ICRS']
-
-        AXES_TO_CTYPE = {}
-        AXES_TO_CTYPE['Stokes'] = 'STOKES'
-        AXES_TO_CTYPE['Frequency'] = 'FREQ'
-        if data.get('system') == 'GALACTIC':
-            AXES_TO_CTYPE['Longitude'] = 'GLON'
-            AXES_TO_CTYPE['Latitude'] = 'GLAT'
-        if data.get('system') == 'SUPERGAL':
-            AXES_TO_CTYPE['Longitude'] = 'SLON'
-            AXES_TO_CTYPE['Latitude'] = 'SLAT'
-        if data.get('system') == 'ECLIPTIC':
-            AXES_TO_CTYPE['Longitude'] = 'ELON'
-            AXES_TO_CTYPE['Latitude'] = 'ELAT'
-        else:
-            AXES_TO_CTYPE['Right Ascension'] = 'RA--'
-            AXES_TO_CTYPE['Declination'] = 'DEC-'
-
-        SPECSYS = {}
-        SPECSYS['BARY'] = 'BARYCENT'
-        SPECSYS['TOPO'] = 'TOPOCENT'
-        SPECSYS['LSRK'] = 'LSRK'
-        SPECSYS['LSRD'] = 'LSRD'
-        SPECSYS['GEO'] = 'GEOCENTR'
-        SPECSYS['GALACTO'] = 'GALACTOC'
-        SPECSYS['LGROUP'] = 'LOCALGRP'
-        SPECSYS['CMB'] = 'CMBDIPOL'
-        SPECSYS['REST'] = 'SOURCE'
-
-        RADESYS = {}
-        RADESYS['J2000'] = 'FK5'
-        RADESYS['B1950'] = 'FK4'
-        RADESYS['B1950_VLA'] = 'FK4'
-        RADESYS['ICRS'] = 'ICRS'
-
-        EQUINOX = {}
-        EQUINOX['J2000'] = 2000.
-        EQUINOX['B1950'] = 1950.
-        EQUINOX['B1950_VLA'] = 1979.9
-
         if coord_type == 'direction':
             idx1, idx2 = worldmap[index] + 1
-            header[f'CTYPE{idx1}'] = AXES_TO_CTYPE[data['axes'][0]] + '-' + data['projection']
-            header[f'CTYPE{idx2}'] = AXES_TO_CTYPE[data['axes'][1]] + '-' + data['projection']
+            header[f'CTYPE{idx1}'] = AXES_TO_CTYPE[data['system']][data['axes'][0]] + '-' + data['projection']
+            header[f'CTYPE{idx2}'] = AXES_TO_CTYPE[data['system']][data['axes'][1]] + '-' + data['projection']
             header[f'CRPIX{idx1}'] = data['crpix'][0] + 1
             header[f'CRPIX{idx2}'] = data['crpix'][1] + 1
             header[f'CRVAL{idx1}'] = data['crval'][0]
@@ -154,7 +152,7 @@ def wcs_casa2astropy(coordsys):
             header[f'PC{idx2}_{idx2}'] = data['pc'][1, 1]
         elif coord_type == 'stokes':
             idx = worldmap[index][0] + 1
-            header[f'CTYPE{idx}'] = AXES_TO_CTYPE[data['axes'][0]]
+            header[f'CTYPE{idx}'] = 'STOKES'
             header[f'CRVAL{idx}'] = data['crval'][0]
             header[f'CRPIX{idx}'] = data['crpix'][0] + 1
             header[f'CDELT{idx}'] = data['cdelt'][0]

--- a/spectral_cube/io/casa_wcs.py
+++ b/spectral_cube/io/casa_wcs.py
@@ -1,4 +1,3 @@
-import tempfile
 import numpy as np
 from astropy.wcs import WCS
 from astropy.io import fits

--- a/spectral_cube/io/casa_wcs.py
+++ b/spectral_cube/io/casa_wcs.py
@@ -164,7 +164,14 @@ def wcs_casa2astropy(coordsys):
                 header[f'CTYPE{idx}'] = AXES_TO_CTYPE[data['tabular']['axes'][0]]
                 header[f'CRVAL{idx}'] = data['tabular']['crval'][0]
                 header[f'CRPIX{idx}'] = data['tabular']['crpix'][0] + 1
-                header[f'CDELT{idx}'] = data['tabular']['cdelt'][0]
+                # It looks like we can't just use:
+                # header[f'CDELT{idx}'] = data['tabular']['cdelt'][0]
+                # because this doesn't match what appears in a FITS header
+                # exported from CASA. Instead we use the interval between the
+                # first two tabulated values. See
+                # https://github.com/radio-astro-tools/spectral-cube/issues/614
+                # for more information.
+                header[f'CDELT{idx}'] = np.diff(data['tabular']['worldvalues'][:2])[0]
                 header[f'CUNIT{idx}'] = data['tabular']['units'][0]
             else:
                 header[f'CTYPE{idx}'] = data['wcs']['ctype']

--- a/spectral_cube/io/casa_wcs.py
+++ b/spectral_cube/io/casa_wcs.py
@@ -1,11 +1,13 @@
 import tempfile
 import numpy as np
 from astropy.wcs import WCS
+from astropy.io import fits
+from astropy.time import Time
 
 __all__ = ['wcs_casa2astropy']
 
 
-def wcs_casa2astropy(ndim, coordsys):
+def wcs_casa2astropy(coordsys):
     """
     Convert a casac.coordsys object into an astropy.wcs.WCS object
     """
@@ -14,24 +16,121 @@ def wcs_casa2astropy(ndim, coordsys):
     # to CASA by getting it to write out a FITS file and reading back in
     # using WCS
 
-    try:
-        from casatools import image
-    except ImportError:
-        try:
-            from taskinit import iatool as image
-        except ImportError:
-            raise ImportError("Could not import CASA (casac) and therefore cannot convert csys to WCS")
+    header = fits.Header()
 
-    tmpimagefile = tempfile.mktemp() + '.image'
-    tmpfitsfile = tempfile.mktemp() + '.fits'
-    ia = image()
-    ia.fromarray(outfile=tmpimagefile,
-                 pixels=np.ones([1] * ndim),
-                 csys=coordsys, log=False)
-    ia.done()
+    # Observer information (ObsInfo.cc)
 
-    ia.open(tmpimagefile)
-    ia.tofits(tmpfitsfile, stokeslast=False)
-    ia.done()
+    header['OBSERVER'] = coordsys['observer']
+    header['TELESCOP'] = coordsys['telescope']
+    header['TIMESYS'] = coordsys['obsdate']['refer']
+    header['MJD-OBS'] = coordsys['obsdate']['m0']['value']
 
-    return WCS(tmpfitsfile)
+    dateobs = Time(header['MJD-OBS'],
+                   format='mjd',
+                   scale=coordsys['obsdate']['refer'].lower())
+    dateobs.precision = 6
+    header['DATE-OBS'] = dateobs.isot
+
+    obsgeo_lon = coordsys['telescopeposition']['m0']['value']
+    obsgeo_lat = coordsys['telescopeposition']['m1']['value']
+    obsgeo_alt = coordsys['telescopeposition']['m2']['value']
+
+    header['OBSGEO-X'] = obsgeo_alt * np.cos(obsgeo_lon) * np.cos(obsgeo_lat)
+    header['OBSGEO-Y'] = obsgeo_alt * np.sin(obsgeo_lon) * np.cos(obsgeo_lat)
+    header['OBSGEO-Z'] = obsgeo_alt * np.sin(obsgeo_lat)
+
+    # World coordinates
+
+    # Find worldmap entries
+
+    worldmap = {}
+
+    for key, value in coordsys.items():
+        if key.startswith('worldmap'):
+            index = int(key[8:])
+            worldmap[index] = value
+
+    # Now iterate through the different coordinate types to populate the WCS
+
+    header['WCSAXES'] = np.max([np.max(idx) + 1 for idx in worldmap.values()])
+
+    # Initialize PC
+    for i in range(header['WCSAXES']):
+        for j in range(header['WCSAXES']):
+            header[f'PC{i+1}_{j+1}'] = 0.
+
+    for coord_type in ('direction', 'spectral', 'stokes'):
+
+        for index in range(len(worldmap)):
+            if f'{coord_type}{index}' in coordsys:
+                break
+        else:
+            continue
+
+        data = coordsys[f'{coord_type}{index}']
+
+        AXES_TO_CTYPE = {}
+        AXES_TO_CTYPE['Right Ascension'] = 'RA--'
+        AXES_TO_CTYPE['Declination'] = 'DEC-'
+        AXES_TO_CTYPE['Stokes'] = 'STOKES'
+        AXES_TO_CTYPE['Frequency'] = 'FREQ'
+
+        SYSTEM_TO_SPECSYS = {}
+        SYSTEM_TO_SPECSYS['BARY'] = 'BARYCENT'
+
+        RADESYS = {}
+        RADESYS['J2000'] = 'FK5'
+        RADESYS['B1950'] = 'FK4'
+        RADESYS['B1950_VLA'] = 'FK4'
+        RADESYS['ICRS'] = 'ICRS'
+
+        EQUINOX = {}
+        EQUINOX['J2000'] = 2000.
+        EQUINOX['B1950'] = 1950.
+        EQUINOX['B1950_VLA'] = 1979.9
+
+        if coord_type == 'direction':
+            idx1, idx2 = worldmap[index] + 1
+            header[f'CTYPE{idx1}'] = AXES_TO_CTYPE[data['axes'][0]] + '-' + data['projection']
+            header[f'CTYPE{idx2}'] = AXES_TO_CTYPE[data['axes'][1]] + '-' + data['projection']
+            header[f'CRVAL{idx1}'] = round(np.degrees(data['crval'][0]), 10)
+            header[f'CRVAL{idx2}'] = round(np.degrees(data['crval'][1]), 10)
+            header[f'CRPIX{idx1}'] = data['crpix'][0] + 1
+            header[f'CRPIX{idx2}'] = data['crpix'][1] + 1
+            header[f'CDELT{idx1}'] = np.degrees(data['cdelt'][0])
+            header[f'CDELT{idx2}'] = np.degrees(data['cdelt'][1])
+            header[f'CUNIT{idx1}'] = 'deg'
+            header[f'CUNIT{idx2}'] = 'deg'
+            header['LONPOLE'] = data['longpole']
+            header['LATPOLE'] = data['latpole']
+            header['RADESYS'] = RADESYS[data['conversionSystem']]
+            if data['conversionSystem'] in EQUINOX:
+                header['EQUINOX'] = EQUINOX[data['conversionSystem']]
+            header[f'PV{idx2}_{idx1}'] = 0.
+            header[f'PV{idx2}_{idx2}'] = 0.
+            header[f'PC{idx1}_{idx1}'] = data['pc'][0, 0]
+            header[f'PC{idx1}_{idx2}'] = data['pc'][0, 1]
+            header[f'PC{idx2}_{idx1}'] = data['pc'][1, 0]
+            header[f'PC{idx2}_{idx2}'] = data['pc'][1, 1]
+        elif coord_type == 'stokes':
+            idx = worldmap[index][0] + 1
+            header[f'CTYPE{idx}'] = AXES_TO_CTYPE[data['axes'][0]]
+            header[f'CRVAL{idx}'] = data['crval'][0]
+            header[f'CRPIX{idx}'] = data['crpix'][0] + 1
+            header[f'CDELT{idx}'] = data['cdelt'][0]
+            header[f'CUNIT{idx}'] = ''
+            header[f'PC{idx}_{idx}'] = data['pc'][0][0]
+        elif coord_type == 'spectral':
+            idx = worldmap[index][0] + 1
+            header[f'CTYPE{idx}'] = AXES_TO_CTYPE[data['tabular']['axes'][0]]
+            header[f'CRVAL{idx}'] = data['tabular']['crval'][0]
+            header[f'CRPIX{idx}'] = data['tabular']['crpix'][0] + 1
+            header[f'CDELT{idx}'] = data['tabular']['cdelt'][0]
+            header[f'CUNIT{idx}'] = data['tabular']['units'][0]
+            header[f'PC{idx}_{idx}'] = 1.0
+            header[f'RESTFRQ'] = data['restfreq']
+            header[f'SPECSYS'] = SYSTEM_TO_SPECSYS[data['system']]
+        else:
+            raise NotImplementedError(f'coord_type is {coord_type}')
+
+    return WCS(header)

--- a/spectral_cube/io/casa_wcs.py
+++ b/spectral_cube/io/casa_wcs.py
@@ -108,9 +108,9 @@ def wcs_casa2astropy(coordsys):
     header['WCSAXES'] = np.max([np.max(idx) + 1 for idx in worldmap.values()])
 
     # Initialize PC
-    for i in range(header['WCSAXES']):
-        for j in range(header['WCSAXES']):
-            header[f'PC{i+1}_{j+1}'] = 0.
+    for ii in range(header['WCSAXES']):
+        for jj in range(header['WCSAXES']):
+            header[f'PC{ii+1}_{jj+1}'] = 0.
 
     for coord_type in ('direction', 'spectral', 'stokes', 'linear'):
 

--- a/spectral_cube/io/tests/test_casa_wcs.py
+++ b/spectral_cube/io/tests/test_casa_wcs.py
@@ -1,8 +1,11 @@
 from __future__ import print_function, absolute_import, division
 
+import tempfile
+
 import pytest
 import numpy as np
 from astropy.wcs import WCS
+from astropy.io import fits
 
 from numpy.testing import assert_allclose
 
@@ -10,6 +13,7 @@ from ..casa_low_level_io import getdesc
 from ..casa_wcs import wcs_casa2astropy
 from ...tests.test_casafuncs import make_casa_testimage
 from .test_casa_low_level_io import ALL_DATA_FIXTURES
+from ...conftest import HEADER_FILENAME
 
 try:
     from casatools import image
@@ -23,13 +27,9 @@ def filename(request):
     return request.getfixturevalue(request.param)
 
 
-@pytest.mark.skipif('not CASATOOLS_INSTALLED')
-@pytest.mark.parametrize('filename', ALL_DATA_FIXTURES, indirect=['filename'])
-def test_wcs_casa2astropy(tmp_path, filename):
+def assert_header_correct(casa_filename):
 
-    casa_filename = str(tmp_path / 'casa.image')
-    fits_filename = str(tmp_path / 'casa.fits')
-    make_casa_testimage(filename, casa_filename)
+    fits_filename = tempfile.mktemp()
 
     # Use CASA to convert back to FITS and use that header as the reference
 
@@ -58,9 +58,17 @@ def test_wcs_casa2astropy(tmp_path, filename):
         else:
             if 'CDELT' in key:
                 # FIXME:For some reason the CDELT for spectral axes disagree
-                assert_allclose(actual_header[key], reference_header[key], rtol=1.e-4)
+                assert_allclose(actual_header[key], reference_header[key], rtol=1.e-2)
             else:
                 assert_allclose(actual_header[key], reference_header[key])
+
+
+@pytest.mark.skipif('not CASATOOLS_INSTALLED')
+@pytest.mark.parametrize('filename', ALL_DATA_FIXTURES, indirect=['filename'])
+def test_wcs_casa2astropy(tmp_path, filename):
+    casa_filename = str(tmp_path / 'casa.image')
+    make_casa_testimage(filename, casa_filename)
+    assert_header_correct(casa_filename)
 
 
 @pytest.mark.skipif('not CASATOOLS_INSTALLED')
@@ -69,7 +77,6 @@ def test_wcs_casa2astropy_linear(tmp_path):
     # Test that things work properly when the WCS coordinates aren't set
 
     casa_filename = str(tmp_path / 'test.image')
-    fits_filename = str(tmp_path / 'test.fits')
 
     data = np.random.random((3, 4, 5, 6, 7))
 
@@ -77,29 +84,55 @@ def test_wcs_casa2astropy_linear(tmp_path):
     ia.fromarray(outfile=casa_filename, pixels=data, log=False)
     ia.close()
 
-    # Use CASA to convert back to FITS and use that header as the reference
+    assert_header_correct(casa_filename)
 
-    ia = image()
-    ia.open(casa_filename)
-    ia.tofits(fits_filename, stokeslast=False)
-    ia.done()
 
-    # Parse header with WCS - for the purposes of this function
-    # we are not interested in keywords/values not in WCS
-    reference_wcs = WCS(fits_filename)
-    reference_header = reference_wcs.to_header()
+def header_copy_with(**kwargs):
+    header = fits.Header.fromtextfile(HEADER_FILENAME).copy()
+    header.update(kwargs)
+    return header
 
-    # Now use our wcs_casa2astropy function to create the header and compare
-    # the results.
-    desc = getdesc(casa_filename)
-    actual_wcs = wcs_casa2astropy(desc['_keywords_']['coords'])
-    actual_header = actual_wcs.to_header()
 
-    assert sorted(actual_header) == sorted(reference_header)
+ALL_HEADERS = [
+    header_copy_with(CTYPE1='GLON-TAN', CTYPE2='GLAT-TAN'),
+    header_copy_with(CTYPE1='SLON-TAN', CTYPE2='SLAT-TAN'),
+    header_copy_with(CTYPE1='ELON-TAN', CTYPE2='ELAT-TAN'),
+    header_copy_with(CTYPE1='HLON-TAN', CTYPE2='HLAT-TAN'),
+    header_copy_with(SPECSYS='TOPOCENT'),
+    header_copy_with(SPECSYS='GEOCENTR'),
+    header_copy_with(SPECSYS='BARYCENT'),
+    header_copy_with(SPECSYS='HELIOCEN'),
+    header_copy_with(SPECSYS='LSRK'),
+    header_copy_with(SPECSYS='LSRD'),
+    header_copy_with(SPECSYS='GALACTOC'),
+    header_copy_with(SPECSYS='LOCALGRP'),
+    header_copy_with(SPECSYS='CMBDIPOL'),
+    header_copy_with(SPECSYS='SOURCE'),
+    header_copy_with(RADESYS='FK4'),
+    header_copy_with(RADESYS='FK4-NO-E'),
+    header_copy_with(RADESYS='FK5'),
+    header_copy_with(RADESYS='ICRS'),
+    header_copy_with(EQUINOX=1950.),
+    header_copy_with(EQUINOX=1979.9),
+    header_copy_with(EQUINOX=2000),
+    header_copy_with(EQUINOX=2010),
+    header_copy_with(CTYPE3='FREQ', CUNIT3='GHz', CRVAL3=100., CDELT3=1.),
+    header_copy_with(CTYPE3='WAVE', CUNIT3='m', CRVAL3=1e-6, CDELT3=1e-8),
+    header_copy_with(CTYPE3='VOPT'),
+    header_copy_with(CTYPE3='VRAD'),
+]
 
-    for key in reference_header:
-        print(key)
-        if isinstance(actual_header[key], str):
-            assert actual_header[key] == reference_header[key]
-        else:
-            assert_allclose(actual_header[key], reference_header[key])
+@pytest.mark.skipif('not CASATOOLS_INSTALLED')
+@pytest.mark.parametrize('header', ALL_HEADERS)
+def test_wcs_casa2astropy_additional(tmp_path, header):
+
+    # More cases to improve coverage
+
+    casa_filename = str(tmp_path / 'casa.image')
+    fits_filename = str(tmp_path / 'casa.fits')
+
+    fits.writeto(fits_filename, np.ones((2, 3, 4, 5)), header)
+
+    make_casa_testimage(fits_filename, casa_filename)
+
+    assert_header_correct(casa_filename)

--- a/spectral_cube/io/tests/test_casa_wcs.py
+++ b/spectral_cube/io/tests/test_casa_wcs.py
@@ -61,4 +61,8 @@ def test_wcs_casa2astropy(tmp_path, filename):
         if isinstance(actual_header[key], str):
             assert actual_header[key] == reference_header[key]
         else:
-            assert_allclose(actual_header[key], reference_header[key])
+            if 'CDELT' in key:
+                # FIXME:For some reason the CDELT for spectral axes disagree
+                assert_allclose(actual_header[key], reference_header[key], rtol=1.e-4)
+            else:
+                assert_allclose(actual_header[key], reference_header[key])

--- a/spectral_cube/io/tests/test_casa_wcs.py
+++ b/spectral_cube/io/tests/test_casa_wcs.py
@@ -56,11 +56,7 @@ def assert_header_correct(casa_filename):
         if isinstance(actual_header[key], str):
             assert actual_header[key] == reference_header[key]
         else:
-            if 'CDELT' in key:
-                # FIXME:For some reason the CDELT for spectral axes disagree
-                assert_allclose(actual_header[key], reference_header[key], rtol=1.e-2)
-            else:
-                assert_allclose(actual_header[key], reference_header[key])
+            assert_allclose(actual_header[key], reference_header[key])
 
 
 @pytest.mark.skipif('not CASATOOLS_INSTALLED')

--- a/spectral_cube/io/tests/test_casa_wcs.py
+++ b/spectral_cube/io/tests/test_casa_wcs.py
@@ -115,7 +115,7 @@ ALL_HEADERS = [
     header_copy_with(CTYPE3='FREQ', CUNIT3='GHz', CRVAL3=100., CDELT3=1.),
     header_copy_with(CTYPE3='WAVE', CUNIT3='m', CRVAL3=1e-6, CDELT3=1e-8),
     header_copy_with(CTYPE3='VOPT'),
-    header_copy_with(CTYPE3='VRAD'),
+    header_copy_with(CTYPE3='VRAD')
 ]
 
 @pytest.mark.skipif('not CASATOOLS_INSTALLED')

--- a/spectral_cube/io/tests/test_casa_wcs.py
+++ b/spectral_cube/io/tests/test_casa_wcs.py
@@ -37,6 +37,7 @@ def test_wcs_casa2astropy(tmp_path, filename):
     ia.open(casa_filename)
     ia.tofits(fits_filename, stokeslast=False)
     ia.done()
+    ia.close()
 
     # Parse header with WCS - for the purposes of this function
     # we are not interested in keywords/values not in WCS

--- a/spectral_cube/tests/test_casafuncs.py
+++ b/spectral_cube/tests/test_casafuncs.py
@@ -164,18 +164,16 @@ def test_casa_mask(data_adv, tmp_path):
     # Test WCS info
 
     # Convert back to an astropy wcs object so transforms are dealt with.
-    casa_wcs = wcs_casa2astropy(coords.naxes(), coords.torecord())
+    casa_wcs = wcs_casa2astropy(coords.torecord())
     header = casa_wcs.to_header()  # Invokes transform
 
     # Compare some basic properties EXCLUDING the spectral axis
-    assert np.allclose(cube.wcs.wcs.crval[:2], casa_wcs.wcs.crval[:2])
-    assert np.all(cube.wcs.wcs.cdelt[:2] == casa_wcs.wcs.cdelt[:2])
+    assert_allclose(cube.wcs.wcs.crval[:2], casa_wcs.wcs.crval[:2])
+    assert_allclose(cube.wcs.wcs.cdelt[:2], casa_wcs.wcs.cdelt[:2])
     assert np.all(list(cube.wcs.wcs.cunit)[:2] == list(casa_wcs.wcs.cunit)[:2])
     assert np.all(list(cube.wcs.wcs.ctype)[:2] == list(casa_wcs.wcs.ctype)[:2])
 
-    # Reference pixels in CASA are 1 pixel off.
-    assert_allclose(cube.wcs.wcs.crpix, casa_wcs.wcs.crpix,
-                    atol=1.0)
+    assert_allclose(cube.wcs.wcs.crpix, casa_wcs.wcs.crpix)
 
 
 @pytest.mark.skipif(not CASA_INSTALLED, reason='CASA tests must be run in a CASA environment.')


### PR DESCRIPTION
This is a work in progress which makes it so that we no longer need CASA to convert the CASA coordsys to Astropy WCS. Remaining to-dos:

* [x] Add changelog entry
* [x] Try and add some more test cases
* [x] Add support for the 'linear' axis type, which is relevant if no WCS is set
* [x] Check casacore code for other supported spectral systems (there are a few in ``FITSCoordinateUtil.cc``)
* [x] Determine why CDELT disagrees at the 1e-5 relative level for spectral axis (see #614)
* [x] Rebase once https://github.com/radio-astro-tools/spectral-cube/pull/609 is merged

With this PR it's now possible to fully load CASA spectral cubes without CASA!