### PR TITLE
Re-implement spectral-cube methods with dask

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,16 +1,16 @@
 [run]
-source = {packagename}
+source = spectral_cube
 omit =
-   {packagename}/_astropy_init*
-   {packagename}/conftest*
-   {packagename}/cython_version*
-   {packagename}/setup_package*
-   {packagename}/*/setup_package*
-   {packagename}/*/*/setup_package*
-   {packagename}/tests/*
-   {packagename}/*/tests/*
-   {packagename}/*/*/tests/*
-   {packagename}/version*
+   spectral_cube/_astropy_init*
+   spectral_cube/conftest*
+   spectral_cube/cython_version*
+   spectral_cube/setup_package*
+   spectral_cube/*/setup_package*
+   spectral_cube/*/*/setup_package*
+   spectral_cube/tests/*
+   spectral_cube/*/tests/*
+   spectral_cube/*/*/tests/*
+   spectral_cube/version*
 
 [report]
 exclude_lines =

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@
 - Refactor CASA I/O to use dask to access the array/mask data directly
   and to use only Python and Numpy to access image metadata. CASA images
   can now be read without CASA installed. #607, #609, #613
+- Add new dask-friendly classes ``DaskSpectralCube`` and
+  ``DaskVaryingResolutionSpectralCube`` which use dask to efficiently
+  carry out calculations. #618
 
 0.4.5 (unreleased)
 ------------------

--- a/docs/dask.rst
+++ b/docs/dask.rst
@@ -36,7 +36,7 @@ as a context manager, to temporarily change the scheduler::
 
 You can optionally specify the number of threads/processes to use with ``num_workers``::
 
-    >>> with cube.use_dask_scheduler('threads', num_threads=4):  # doctest: +IGNORE_OUTPUT
+    >>> with cube.use_dask_scheduler('threads', num_workers=4):  # doctest: +IGNORE_OUTPUT
     ...     cube.max()
 
 If you don't specify the number of threads, this could end up being quite large, and cause you to

--- a/docs/dask.rst
+++ b/docs/dask.rst
@@ -34,6 +34,14 @@ as a context manager, to temporarily change the scheduler::
     >>> with cube.use_dask_scheduler('threads'):  # doctest: +IGNORE_OUTPUT
     ...     cube.max()
 
+You can optionally specify the number of threads/processes to use with ``num_workers``::
+
+    >>> with cube.use_dask_scheduler('threads', num_threads=4):  # doctest: +IGNORE_OUTPUT
+    ...     cube.max()
+
+If you don't specify the number of threads, this could end up being quite large, and cause you to
+run out of memory for certain operations.
+
 If you want to see a progress bar when carrying out calculations, you can make use of the
 `dask.diagnostics <https://docs.dask.org/en/latest/diagnostics-local.html>`_ sub-package - run
 the following at the start of your script/session, and all subsequent calculations will display

--- a/docs/dask.rst
+++ b/docs/dask.rst
@@ -22,7 +22,7 @@ To read in a FITS cube using the dask-enabled classes, you can do::
 Most of the properties and methods that normally work with :class:`~spectral_cube.SpectralCube`
 should continue to work with :class:`~spectral_cube.DaskSpectralCube`.
 
-By default, we use the ``'synchronous'`` `dask scheduler <https://docs.dask.org/en/latest/scheduler-overview.html>`
+By default, we use the ``'synchronous'`` `dask scheduler <https://docs.dask.org/en/latest/scheduler-overview.html>`_
 which means that calculations are run in a single process/thread. However, you can control this using the
 :meth:`~spectral_cube.DaskSpectralCube.use_dask_scheduler` method:
 
@@ -33,3 +33,15 @@ as a context manager, to temporarily change the scheduler::
 
     >>> with cube.use_dask_scheduler('threads'):  # doctest: +IGNORE_OUTPUT
     ...     cube.max()
+
+If you want to see a progress bar when carrying out calculations, you can make use of the
+`dask.diagnostics <https://docs.dask.org/en/latest/diagnostics-local.html>`_ sub-package - run
+the following at the start of your script/session, and all subsequent calculations will display
+a progress bar:
+
+    >>> from dask.diagnostics import ProgressBar
+    >>> pbar = ProgressBar()
+    >>> pbar.register()
+    >>> cube.max()  # doctest: +IGNORE_OUTPUT
+    [########################################] | 100% Completed |  0.1s
+    <Quantity 0.01936739 Jy / beam>

--- a/docs/dask.rst
+++ b/docs/dask.rst
@@ -1,0 +1,35 @@
+Integration with dask
+=====================
+
+When loading a cube with the :class:`~spectral_cube.SpectralCube` class, it is possible to optionally
+specify the ``use_dask`` keyword argument to control whether or not to use new experimental classes
+(:class:`~spectral_cube.DaskSpectralCube` and :class:`~spectral_cube.DaskVaryingResolutionSpectralCube`)
+that use `dask <https://dask.org/>`_ for representing cubes and carrying out computations efficiently. The default is
+``use_dask=True`` when reading in CASA spectral cubes, but not when loading cubes from other formats.
+
+To read in a FITS cube using the dask-enabled classes, you can do::
+
+    >>> from astropy.utils import data
+    >>> from spectral_cube import SpectralCube
+    >>> fn = data.get_pkg_data_filename('tests/data/example_cube.fits', 'spectral_cube')
+    >>> cube = SpectralCube.read(fn, use_dask=True)
+    >>> cube
+    DaskSpectralCube with shape=(7, 4, 3) and unit=Jy / beam:
+     n_x:      3  type_x: RA---ARC  unit_x: deg    range:    52.231466 deg:   52.231544 deg
+     n_y:      4  type_y: DEC--ARC  unit_y: deg    range:    31.243639 deg:   31.243739 deg
+     n_s:      7  type_s: VRAD      unit_s: m / s  range:    14322.821 m / s:   14944.909 m / s
+
+Most of the properties and methods that normally work with :class:`~spectral_cube.SpectralCube`
+should continue to work with :class:`~spectral_cube.DaskSpectralCube`.
+
+By default, we use the ``'synchronous'`` `dask scheduler <https://docs.dask.org/en/latest/scheduler-overview.html>`
+which means that calculations are run in a single process/thread. However, you can control this using the
+:meth:`~spectral_cube.DaskSpectralCube.use_dask_scheduler` method:
+
+    >>> cube.use_dask_scheduler('threads')  # doctest: +IGNORE_OUTPUT
+
+Any calculation after this will then use the multi-threaded scheduler. It is also possible to use this
+as a context manager, to temporarily change the scheduler::
+
+    >>> with cube.use_dask_scheduler('threads'):  # doctest: +IGNORE_OUTPUT
+    ...     cube.max()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,6 +72,7 @@ Getting started
    continuum_subtraction.rst
    examples.rst
    visualization.rst
+   dask.rst
 
 There is also an `astropy tutorial
 <http://learn.astropy.org/rst-tutorials/FITS-cubes.html>`__ on accessing and

--- a/spectral_cube/__init__.py
+++ b/spectral_cube/__init__.py
@@ -21,6 +21,7 @@ from .io import fits
 del fits
 
 __all__ = ['SpectralCube', 'VaryingResolutionSpectralCube',
+           'DaskSpectralCube', 'DaskVaryingResolutionSpectralCube',
             'StokesSpectralCube', 'CompositeMask', 'LazyComparisonMask',
             'LazyMask', 'BooleanArrayMask', 'FunctionMask',
             'OneDSpectrum', 'Projection', 'Slice'

--- a/spectral_cube/__init__.py
+++ b/spectral_cube/__init__.py
@@ -5,6 +5,7 @@ from ._astropy_init import __version__, test
 from pkg_resources import get_distribution, DistributionNotFound
 
 from .spectral_cube import (SpectralCube, VaryingResolutionSpectralCube)
+from .dask_spectral_cube import (DaskSpectralCube, DaskVaryingResolutionSpectralCube)
 from .stokes_spectral_cube import StokesSpectralCube
 from .masks import (MaskBase, InvertedMask, CompositeMask,
                     BooleanArrayMask, LazyMask, LazyComparisonMask,

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -7,6 +7,7 @@ import abc
 import astropy
 from astropy.io.fits import Card
 from radio_beam import Beam, Beams
+import dask.array as da
 
 from . import wcs_utils
 from . import cube_utils

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -584,7 +584,7 @@ class MultiBeamMixinClass(object):
             if use_dask:
                 # If we are dealing with dask arrays, we compute the beam
                 # mask once and for all since it is used multiple times in its
-                # entirity in the remainder of this method.
+                # entirety in the remainder of this method.
                 beam_mask = da.any(da.logical_and(self._mask_include,
                                                   self.goodbeams_mask[:, None, None]),
                                    axis=(1, 2))

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -582,14 +582,14 @@ class MultiBeamMixinClass(object):
 
         if mask == 'compute':
             if use_dask:
-            # If we are dealing with dask arrays, we compute the beam
-            # mask once and for all since it is used multiple times in its
-            # entirity in the remainder of this method.
+                # If we are dealing with dask arrays, we compute the beam
+                # mask once and for all since it is used multiple times in its
+                # entirity in the remainder of this method.
                 beam_mask = da.any(da.logical_and(self._mask_include,
                                                   self.goodbeams_mask[:, None, None]),
                                    axis=(1, 2))
                 beam_mask = self._compute(beam_mask)
-        else:
+            else:
                 beam_mask = np.any(np.logical_and(self.mask.include(),
                                                   self.goodbeams_mask[:, None, None]),
                                    axis=(1, 2))

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -578,11 +578,16 @@ class MultiBeamMixinClass(object):
         """
         if mask == 'compute':
             beam_mask = np.any(np.logical_and(self.mask.include(),
-                                              self.goodbeams_mask[:,None,None]),
-                               axis=(1,2))
+                                              self.goodbeams_mask[:, None, None]),
+                               axis=(1, 2))
+            # If we are dealing with dask arrays, we compute the beam
+            # mask once and for all since it is used multiple times in its
+            # entirity in the remainder of this method.
+            if isinstance(beam_mask, da.Array):
+                beam_mask = self._compute(beam_mask)
         else:
             if mask.ndim > 1:
-                beam_mask = np.logical_and(mask, self.goodbeams_mask[:,None,None])
+                beam_mask = np.logical_and(mask, self.goodbeams_mask[:, None, None])
             else:
                 beam_mask = np.logical_and(mask, self.goodbeams_mask)
 

--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -172,6 +172,14 @@ def data_adv(tmp_path):
 
 
 @pytest.fixture
+def data_adv_simple(tmp_path):
+    d, h = prepare_adv_data()
+    d.flat[:] = np.arange(d.size)
+    fits.writeto(tmp_path / 'adv_simple.fits', d, h)
+    return tmp_path / 'adv_simple.fits'
+
+
+@pytest.fixture
 def data_adv_jybeam_upper(tmp_path):
     d, h = prepare_adv_data()
     h['BUNIT'] = 'JY/BEAM'

--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -29,6 +29,13 @@ else:
     from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 
 
+@pytest.fixture(params=[False, True])
+def use_dask(request):
+    # Fixture to run tests that use this fixture with both SpectralCube and
+    # DaskSpectralCube
+    return request.param
+
+
 def pytest_configure(config):
 
     config.option.astropy_header = True

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -229,6 +229,18 @@ class SliceIndexer(object):
             result = result.compute()
         return result
 
+    @property
+    def size(self):
+        return self._other.size
+
+    @property
+    def ndim(self):
+        return self._other.ndim
+
+    @property
+    def shape(self):
+        return self._other.shape
+
     def __iter__(self):
         raise Exception("You need to specify a slice (e.g. ``[:]`` or "
                         "``[0,:,:]`` in order to access this property.")

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -8,6 +8,7 @@ except ImportError:
     # python2
     import __builtin__ as builtins
 
+import dask.array as da
 import numpy as np
 from astropy.wcs import (WCSSUB_SPECTRAL, WCSSUB_LONGITUDE, WCSSUB_LATITUDE)
 from . import wcs_utils
@@ -220,7 +221,10 @@ class SliceIndexer(object):
         self._other = _other
 
     def __getitem__(self, view):
-        return self._func(self._other, view)
+        result = self._func(self._other, view)
+        if isinstance(result, da.Array):
+            result = result.compute()
+        return result
 
     def __iter__(self):
         raise Exception("You need to specify a slice (e.g. ``[:]`` or "

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -173,7 +173,10 @@ def _orient(array, wcs):
         raise ValueError("Input WCS should not contain stokes")
 
     t = [types.index('spectral'), nums.index(1), nums.index(0)]
-    result_array = array.transpose(t)
+    if t == [0, 1, 2]:
+        result_array = array
+    else:
+        result_array = array.transpose(t)
 
     result_wcs = wcs.sub([WCSSUB_LONGITUDE, WCSSUB_LATITUDE, WCSSUB_SPECTRAL])
 

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -1196,6 +1196,12 @@ class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolution
         if self._unit is None and unit is not None:
             self._unit = unit
 
+    @classmethod
+    def read(cls, *args, **kwargs):
+        if kwargs.get('use_dask') is None:
+            kwargs['use_dask'] = True
+        return super().read(*args, **kwargs)
+
     def write(self, *args, **kwargs):
         with dask.config.set(scheduler=self._scheduler):
             super().write(*args, **kwargs)

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -398,6 +398,11 @@ class DaskSpectralCubeMixin:
         if not SCIPY_INSTALLED:
             raise ImportError("Scipy could not be imported: this function won't work.")
 
+        if float(ksize).is_integer():
+            ksize = int(ksize)
+        else:
+            raise TypeError('ksize should be an integer (got {0})'.format(ksize))
+
         def median_filter_wrapper(img, **kwargs):
             return ndimage.median_filter(img, (ksize, 1, 1), **kwargs)
 

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -15,6 +15,8 @@ from astropy.io.fits import PrimaryHDU, HDUList
 from astropy.wcs.utils import proj_plane_pixel_area
 
 import numpy as np
+
+import dask
 import dask.array as da
 
 from astropy import stats
@@ -1122,6 +1124,10 @@ class DaskSpectralCube(DaskSpectralCubeMixin, SpectralCube):
             kwargs['use_dask'] = True
         return super().read(*args, **kwargs)
 
+    def write(self, *args, **kwargs):
+        with dask.config.set(scheduler=self._scheduler):
+            super().write(*args, **kwargs)
+
     @property
     def hdu(self):
         """
@@ -1189,6 +1195,10 @@ class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolution
         super().__init__(data, *args, **kwargs)
         if self._unit is None and unit is not None:
             self._unit = unit
+
+    def write(self, *args, **kwargs):
+        with dask.config.set(scheduler=self._scheduler):
+            super().write(*args, **kwargs)
 
     @property
     def hdu(self):

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -755,11 +755,14 @@ class DaskSpectralCubeMixin:
             Passed to the convolve function
         """
 
-        kernel = kernel.array.reshape((1,) + kernel.array.shape)
+        kernel = kernel.array
 
-        def convolve_wrapper(img, **kwargs):
+        def convolve_wrapper(img):
             if img.size > 0:
-                return convolve(img, kernel, normalize_kernel=True, **kwargs)
+                out = np.zeros(img.shape, dtype=img.dtype)
+                for index in range(img.shape[0]):
+                    out[index] = convolve(img[index], kernel, normalize_kernel=True, **kwargs)
+                return out
             else:
                 return img
 

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -743,7 +743,7 @@ class DaskSpectralCube(DaskSpectralCubeMixin, SpectralCube):
 
         pixscale = proj_plane_pixel_area(self.wcs.celestial)**0.5 * u.deg
 
-        convolution_kernel = beam.as_kernel(pixscale)
+        convolution_kernel = beam.deconvolve(self.beam).as_kernel(pixscale)
         kernel = convolution_kernel.array.reshape((1,) + convolution_kernel.array.shape)
 
         def convfunc(img):
@@ -754,7 +754,7 @@ class DaskSpectralCube(DaskSpectralCubeMixin, SpectralCube):
 
         # Rechunk so that there is only one chunk in the image plane
         return self._map_blocks_to_cube(convfunc,
-                                        rechunk=('auto', -1, -1))
+                                        rechunk=('auto', -1, -1)).with_beam(beam)
 
 
 class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolutionSpectralCube):
@@ -877,3 +877,15 @@ class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolution
                                    fill_value=cube.fill_value)
 
         return newcube
+
+    def spectral_interpolate(self, *args, **kwargs):
+        raise AttributeError("VaryingResolutionSpectralCubes can't be "
+                             "spectrally interpolated.  Convolve to a "
+                             "common resolution with `convolve_to` before "
+                             "attempting spectral interpolation.")
+
+    def spectral_smooth(self, *args, **kwargs):
+        raise AttributeError("VaryingResolutionSpectralCubes can't be "
+                             "spectrally smoothed.  Convolve to a "
+                             "common resolution with `convolve_to` before "
+                             "attempting spectral smoothed.")

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -963,6 +963,9 @@ class DaskSpectralCubeMixin:
 
         """
 
+        # TODO: this duplicates SpectralCube.spectral_interpolate, so we should
+        # find a way to avoid that duplication.
+
         inaxis = self.spectral_axis.to(spectral_grid.unit)
 
         indiff = np.mean(np.diff(inaxis))

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -860,7 +860,7 @@ class DaskSpectralCubeMixin:
 
         slices = []
         for axis in range(3):
-            if spatial_only:
+            if axis == 0 and spatial_only:
                 slices.append(slice(None))
                 continue
             collapse_axes = tuple(index for index in range(3) if index != axis)

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -161,17 +161,12 @@ class FilledArrayHandler:
     def __getitem__(self, view):
         if self._cube._data[view].size == 0:
             return 0.
-        result = self._cube._mask._filled(data=self._cube._data,
-                                          view=view,
-                                          wcs=self._cube._wcs,
-                                          fill=self._fill,
-                                          wcs_tolerance=self._cube._wcs_tolerance)
-        if isinstance(result, da.Array):
-            if result.shape == (0, 0, 0):
-                return 0.
-            result = result.compute()
-
-        return result
+        else:
+            return self._cube._mask._filled(data=self._cube._data,
+                                            view=view,
+                                            wcs=self._cube._wcs,
+                                            fill=self._fill,
+                                            wcs_tolerance=self._cube._wcs_tolerance)
 
 
 class MaskHandler:
@@ -278,11 +273,8 @@ class DaskSpectralCubeMixin:
         """
         Convert the mask to a boolean numpy array
         """
-        result = self._mask.include(data=self._data, wcs=self._wcs,
-                                    wcs_tolerance=self._wcs_tolerance)
-        if isinstance(result, da.Array):
-            result = result.compute()
-        return result
+        return self._mask.include(data=self._data, wcs=self._wcs,
+                                  wcs_tolerance=self._wcs_tolerance)
 
     @projection_if_needed
     def apply_function(self, function, axis=None, weights=None, unit=None,
@@ -517,8 +509,6 @@ class DaskSpectralCubeMixin:
             # Rechunk so that there is only one chunk along the desired axis
             data = data.rechunk([-1 if i == axis else 'auto' for i in range(3)])
             return self._compute(data.map_blocks(np.nanpercentile, q=q, drop_axis=axis, axis=axis, **kwargs))
-
-        return self._compute(da.nanpercentile(self._get_filled_data(fill=np.nan), q, axis=axis))
 
     @projection_if_needed
     @ignore_warnings

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -581,7 +581,7 @@ class DaskSpectralCubeMixin:
         Call dask's map_blocks, returning a new spectral cube.
         """
 
-            data = self._get_filled_data(fill=fill)
+        data = self._get_filled_data(fill=fill)
 
         if rechunk is not None:
             data = self._get_filled_data(fill=fill).rechunk(rechunk)

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -1174,28 +1174,18 @@ class DaskSpectralCubeMixin:
 
 class DaskSpectralCube(DaskSpectralCubeMixin, SpectralCube):
 
+    def __init__(self, data, *args, **kwargs):
+        if not isinstance(data, da.Array):
+            # NOTE: don't be tempted to chunk this image-wise (following the
+            # data storage) because spectral operations will take forever.
+            data = da.asarray(data, name=str(uuid.uuid4()))
+        super().__init__(data, *args, **kwargs)
+
     @classmethod
     def read(cls, *args, **kwargs):
-
-        cube = super().read(*args, **kwargs)
-
-        if not isinstance(cube._data, da.Array):
-            # NOTE: don't be tempted to chunk this image-wise (following the data
-            # storage) because spectral operations will take forever.
-            cube._data = da.asarray(cube._data, name=str(uuid.uuid4()))
-
-        if isinstance(cube, VaryingResolutionSpectralCube):
-            return DaskVaryingResolutionSpectralCube(cube._data, cube.wcs, mask=cube.mask,
-                                                     meta=cube.meta, fill_value=cube.fill_value,
-                                                     header=cube.header,
-                                                     allow_huge_operations=cube.allow_huge_operations,
-                                                     beams=cube.beams, wcs_tolerance=cube._wcs_tolerance)
-        else:
-            return DaskSpectralCube(cube._data, cube.wcs, mask=cube.mask,
-                                    meta=cube.meta, fill_value=cube.fill_value,
-                                    header=cube.header,
-                                    allow_huge_operations=cube.allow_huge_operations,
-                                    beam=cube._beam, wcs_tolerance=cube._wcs_tolerance)
+        if kwargs.get('use_dask') is None:
+            kwargs['use_dask'] = True
+        return super().read(*args, **kwargs)
 
     @property
     def hdu(self):
@@ -1255,6 +1245,13 @@ class DaskSpectralCube(DaskSpectralCubeMixin, SpectralCube):
 
 
 class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolutionSpectralCube):
+
+    def __init__(self, data, *args, **kwargs):
+        if not isinstance(data, da.Array):
+            # NOTE: don't be tempted to chunk this image-wise (following the
+            # data storage) because spectral operations will take forever.
+            data = da.asarray(data, name=str(uuid.uuid4()))
+        super().__init__(data, *args, **kwargs)
 
     @property
     def hdu(self):

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -847,6 +847,10 @@ class DaskSpectralCubeMixin:
             dimension will be left unchanged
         """
 
+        # We need to use a slightly different approach to SpectralCube here
+        # because there isn't yet a dask-friendly version of find_objects
+        # https://github.com/dask/dask-image/issues/96
+
         if isinstance(region_mask, np.ndarray):
             if is_broadcastable_and_smaller(region_mask.shape, self.shape):
                 region_mask = BooleanArrayMask(region_mask, self._wcs)
@@ -857,11 +861,6 @@ class DaskSpectralCubeMixin:
                                       wcs_tolerance=self._wcs_tolerance)
 
         include = da.broadcast_to(include, self.shape)
-
-        # NOTE: the approach in the base SpectralCube class is incorrect, if
-        # there are multiple 'islands' of valid values in the cube, as this will
-        # pick only the first one found by find_objects. Here we use a more
-        # robust approach.
 
         slices = []
         for axis in range(3):

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -877,31 +877,6 @@ class DaskSpectralCubeMixin:
 
         return tuple(slices)
 
-    def flattened(self, slice=(), weights=None):
-        """
-        Return a slice of the cube giving only the valid data (i.e., removing
-        bad values)
-
-        Parameters
-        ----------
-        slice: 3-tuple
-            A length-3 tuple of view (or any equivalent valid slice of a
-            cube)
-        weights: (optional) np.ndarray
-            An array with the same shape (or slicing abilities/results) as the
-            data cube
-        """
-        data = self._mask._flattened(data=self._data, wcs=self._wcs, view=slice)
-        # Quantity does not work well with lazily evaluated data with an
-        # unkonwn shape (which is the case when doing boolean indexing of arrays)
-        if isinstance(data, da.Array):
-            data = self._compute(data)
-        if weights is not None:
-            weights = self._mask._flattened(data=weights, wcs=self._wcs, view=slice)
-            return u.Quantity(data * weights, self.unit, copy=False)
-        else:
-            return u.Quantity(data, self.unit, copy=False)
-
     def downsample_axis(self, factor, axis, estimator=np.nanmean,
                         truncate=False):
         """

--- a/spectral_cube/io/casa_dask.py
+++ b/spectral_cube/io/casa_dask.py
@@ -14,52 +14,74 @@ from .casa_low_level_io import getdminfo
 __all__ = ['casa_image_dask_reader']
 
 
-class MemmapWrapper:
+class CASAArrayWrapper:
     """
-    A wrapper class for dask that opens memmap only when __getitem__ is called,
-    which prevents issues with too many open files if opening a memmap for all
-    chunks at the same time.
+    A wrapper class for dask that accesses chunks from a CASA file on request.
+    It is assumed that this wrapper will be used to construct a dask array that
+    has chunks aligned with the CASA file chunks.
+
+    Having a single wrapper object such as this is far more efficient than
+    having one array wrapper per chunk. This is because the dask graph gets
+    very large if we end up with one dask array per chunk and slows everything
+    down.
     """
 
-    def __init__(self, filename, **kwargs):
+    def __init__(self, filename, totalshape, chunkshape, dtype=None, itemsize=None, memmap=False):
         self._filename = filename
-        self._kwargs = kwargs
-        self.shape = kwargs['shape'][::-1]
-        self.dtype = kwargs['dtype']
+        self._totalshape = totalshape[::-1]
+        self._chunkshape = chunkshape[::-1]
+        self.shape = totalshape[::-1]
+        self.dtype = dtype
         self.ndim = len(self.shape)
-        self._count = np.product(self.shape)
+        self._stacks = np.ceil(np.array(totalshape) / np.array(chunkshape)).astype(int)
+        self._chunksize = np.product(chunkshape)
+        self._itemsize = itemsize
+        self._memmap = memmap
+        if not memmap:
+            if self._itemsize == 1:
+                self._array = np.unpackbits(np.fromfile(filename, dtype='uint8'), bitorder='little').astype(np.bool_)
+            else:
+                self._array = np.fromfile(filename, dtype=dtype)
 
     def __getitem__(self, item):
-        return np.fromfile(self._filename, dtype=self.dtype,
-                           offset=self._kwargs['offset'],
-                           count=self._count).reshape(self.shape[::-1], order='F').T[item]
 
+        # TODO: potentially normalize item, for now assume list of slice objects
 
-class MaskWrapper:
-    """
-    A wrapper class for dask that opens binary masks from file and returns
-    a chunk from it on-the-fly.
-    """
+        indices = np.array([item[dim].start / self._chunkshape[dim] for dim in range(self.ndim)]).astype(int)
 
-    def __init__(self, filename, offset, count, shape):
-        self._filename = filename
-        self._offset = offset
-        self._count = count
-        self.shape = shape[::-1]
-        self.dtype = np.bool_
-        self.ndim = len(self.shape)
+        chunk_number = indices[0]
+        for dim in range(1, self.ndim):
+            chunk_number = chunk_number * self._stacks[::-1][dim] + indices[dim]
 
-    def __getitem__(self, item):
-        # The offset is in the final bit array - but fromfile needs to operate
-        # by reading in uint8, so we need to make sure we align what we read
-        # in to the bytes.
-        start = floor(self._offset / 8)
-        end = ceil((self._offset + self._count) / 8)
-        array_uint8 = np.fromfile(self._filename, dtype=np.uint8,
-                                  offset=start, count=end - start)
-        array_bits = np.unpackbits(array_uint8, bitorder='little')
-        chunk = array_bits[self._offset - start * 8:self._offset + self._count - start * 8]
-        return chunk.reshape(self.shape[::-1], order='F').T[item].astype(np.bool_)
+        offset = chunk_number * self._chunksize * self._itemsize
+
+        item = tuple(slice(item[dim].start - indices[dim] * self._chunkshape[dim],
+                      item[dim].stop - indices[dim] * self._chunkshape[dim],
+                      item[dim].step) for dim in range(self.ndim))
+
+        if self._itemsize == 1:
+
+            if self._memmap:
+                offset = offset // self._chunksize * ceil(self._chunksize / 8) * 8
+                start = floor(offset / 8)
+                end = ceil((offset + self._chunksize) / 8)
+                array_uint8 = np.fromfile(self._filename, dtype=np.uint8,
+                                          offset=start, count=end - start)
+                array_bits = np.unpackbits(array_uint8, bitorder='little')
+                chunk = array_bits[offset - start * 8:offset + self._chunksize - start * 8]
+                return chunk.reshape(self._chunkshape[::-1], order='F').T[item].astype(np.bool_)
+            else:
+                ceil_chunksize = int(ceil(self._chunksize / 8)) * 8
+                return self._array[chunk_number*ceil_chunksize:(chunk_number+1)*ceil_chunksize][:self._chunksize].reshape(self._chunkshape[::-1], order='F').T[item]
+
+        else:
+
+            if self._memmap:
+                return np.fromfile(self._filename, dtype=self.dtype,
+                                   offset=offset,
+                                   count=self._chunksize).reshape(self._chunkshape[::-1], order='F').T[item]
+            else:
+                return self._array[chunk_number*self._chunksize:(chunk_number+1)*self._chunksize].reshape(self._chunkshape[::-1], order='F').T[item]
 
 
 def from_array_fast(arrays, asarray=False, lock=False):
@@ -142,6 +164,8 @@ def casa_image_dask_reader(imagename, memmap=True, mask=False):
         if filesize != expected:
             raise ValueError("Unexpected file size for mask, found {0} but "
                              "expected {1}".format(filesize, expected))
+        dtype = bool
+        itemsize = 1
     else:
         if filesize == totalsize * 4:
             if big_endian:
@@ -159,44 +183,15 @@ def casa_image_dask_reader(imagename, memmap=True, mask=False):
             raise ValueError("Unexpected file size for data, found {0} but "
                              "expected {1} or {2}".format(filesize, totalsize * 4, totalsize * 8))
 
-    if memmap:
-        if mask:
-            chunks = [MaskWrapper(img_fn, offset=ii*ceil(chunksize / 8) * 8, count=chunksize,
-                                  shape=chunkshape)
-                      for ii in range(nchunks)]
-        else:
-            chunks = [MemmapWrapper(img_fn, dtype=dtype, offset=ii*chunksize*itemsize,
-                                    shape=chunkshape)
-                      for ii in range(nchunks)]
-    else:
-        if mask:
-            full_array = np.fromfile(img_fn, dtype='uint8')
-            full_array = np.unpackbits(full_array, bitorder='little').astype(np.bool_)
-            ceil_chunksize = int(ceil(chunksize / 8)) * 8
-            chunks = [full_array[ii*ceil_chunksize:(ii+1)*ceil_chunksize][:chunksize].reshape(chunkshape, order='F').T
-                      for ii in range(nchunks)]
-        else:
-            full_array = np.fromfile(img_fn, dtype=dtype)
-            chunks = [full_array[ii*chunksize:(ii+1)*chunksize].reshape(chunkshape, order='F').T
-                      for ii in range(nchunks)]
+    # CASA does not like numpy ints!
+    chunkshape = tuple(int(x) for x in chunkshape)
+    totalshape = tuple(int(x) for x in totalshape)
 
-    # convert all chunks to dask arrays - and set name and meta appropriately
-    # to prevent dask trying to access the data to determine these
-    # automatically.
-    chunks = from_array_fast(chunks)
+    # Create a wrapper that takes slices and returns the appropriate CASA data
+    wrapper = CASAArrayWrapper(img_fn, totalshape, chunkshape, dtype=dtype, itemsize=itemsize, memmap=memmap)
 
-    # make a nested list of all chunks then use block() to construct the final
-    # dask array.
-    def make_nested_list(chunks, stacks):
-        chunks = [chunks[i*stacks[0]:(i+1)*stacks[0]] for i in range(len(chunks) // stacks[0])]
-        if len(stacks) > 1:
-            return make_nested_list(chunks, stacks[1:])
-        else:
-            return chunks[0]
-
-    chunks = make_nested_list(chunks, stacks)
-
-    dask_array = dask.array.block(chunks)
+    # Convert to a dask array
+    dask_array = dask.array.from_array(wrapper, name='CASA Data ' + str(uuid.uuid4()), chunks=chunkshape[::-1])
 
     # Since the chunks may not divide the array exactly, all the chunks put
     # together may be larger than the array, so we need to get rid of any

--- a/spectral_cube/io/casa_dask.py
+++ b/spectral_cube/io/casa_dask.py
@@ -32,7 +32,7 @@ class MemmapWrapper:
     def __getitem__(self, item):
         return np.fromfile(self._filename, dtype=self.dtype,
                            offset=self._kwargs['offset'],
-                           count=self._count).reshape(self.shape[::-1]).T[item]
+                           count=self._count).reshape(self.shape[::-1], order='F').T[item]
 
 
 class MaskWrapper:

--- a/spectral_cube/io/casa_image.py
+++ b/spectral_cube/io/casa_image.py
@@ -5,7 +5,7 @@ from astropy import units as u
 from astropy.io import registry as io_registry
 from radio_beam import Beam, Beams
 
-from .. import SpectralCube, StokesSpectralCube, BooleanArrayMask, VaryingResolutionSpectralCube
+from .. import DaskSpectralCube, StokesSpectralCube, BooleanArrayMask, DaskVaryingResolutionSpectralCube
 from ..spectral_cube import BaseSpectralCube
 from .. import cube_utils
 from .. utils import BeamWarning
@@ -165,11 +165,11 @@ def load_casa_image(filename, skipdata=False, memmap=True,
             mask = None
 
         if 'beam' in locals():
-            cube = SpectralCube(data, wcs_slice, mask, meta=meta, beam=beam)
+            cube = DaskSpectralCube(data, wcs_slice, mask, meta=meta, beam=beam)
         elif 'beams' in locals():
-            cube = VaryingResolutionSpectralCube(data, wcs_slice, mask, meta=meta, beams=beams)
+            cube = DaskVaryingResolutionSpectralCube(data, wcs_slice, mask, meta=meta, beams=beams)
         else:
-            cube = SpectralCube(data, wcs_slice, mask, meta=meta)
+            cube = DaskSpectralCube(data, wcs_slice, mask, meta=meta)
         # with #592, this is no longer true
         # we've already loaded the cube into memory because of CASA
         # limitations, so there's no reason to disallow operations
@@ -191,17 +191,17 @@ def load_casa_image(filename, skipdata=False, memmap=True,
                 mask[component] = None
 
             if 'beam' in locals():
-                data[component] = SpectralCube(data_, wcs_slice, mask[component],
-                                               meta=meta, beam=beam)
+                data[component] = DaskSpectralCube(data_, wcs_slice, mask[component],
+                                                   meta=meta, beam=beam)
             elif 'beams' in locals():
-                data[component] = VaryingResolutionSpectralCube(data_,
-                                                                wcs_slice,
-                                                                mask[component],
-                                                                meta=meta,
-                                                                beams=beams)
+                data[component] = DaskVaryingResolutionSpectralCube(data_,
+                                                                    wcs_slice,
+                                                                    mask[component],
+                                                                    meta=meta,
+                                                                    beams=beams)
             else:
-                data[component] = SpectralCube(data_, wcs_slice, mask[component],
-                                               meta=meta)
+                data[component] = DaskSpectralCube(data_, wcs_slice, mask[component],
+                                                   meta=meta)
 
             data[component].allow_huge_operations = True
 

--- a/spectral_cube/io/casa_image.py
+++ b/spectral_cube/io/casa_image.py
@@ -39,13 +39,19 @@ def is_casa_image(origin, filepath, fileobj, *args, **kwargs):
 
 
 def load_casa_image(filename, skipdata=False, memmap=True,
-                    skipvalid=False, skipcs=False, target_cls=None, **kwargs):
+                    skipvalid=False, skipcs=False, target_cls=None, use_dask=None, **kwargs):
     """
     Load a cube (into memory?) from a CASA image. By default it will transpose
     the cube into a 'python' order and drop degenerate axes. These options can
     be suppressed. The object holds the coordsys object from the image in
     memory.
     """
+
+    if use_dask is None:
+        use_dask = True
+
+    if not use_dask:
+        raise ValueError("Loading CASA datasets is not possible with use_dask=False")
 
     from .core import StringWrapper
     if isinstance(filename, StringWrapper):

--- a/spectral_cube/io/casa_wcs.py
+++ b/spectral_cube/io/casa_wcs.py
@@ -17,7 +17,6 @@ SPECSYS['GALACTO'] = 'GALACTOC'
 SPECSYS['LGROUP'] = 'LOCALGRP'
 SPECSYS['CMB'] = 'CMBDIPOL'
 SPECSYS['REST'] = 'SOURCE'
-SPECSYS['Unknown'] = 'UKN'
 
 RADESYS = {}
 RADESYS['J2000'] = 'FK5'
@@ -189,7 +188,8 @@ def wcs_casa2astropy(coordsys):
                 header[f'CUNIT{idx}'] = data['unit']
             header[f'PC{idx}_{idx}'] = 1.0
             header[f'RESTFRQ'] = data['restfreq']
-            header[f'SPECSYS'] = SPECSYS[data['system']]
+            if data['system'] in SPECSYS:
+                header[f'SPECSYS'] = SPECSYS[data['system']]
         elif coord_type == 'linear':
             indices = worldmap[index] + 1
             for idx1 in range(len(indices)):

--- a/spectral_cube/io/class_lmv.py
+++ b/spectral_cube/io/class_lmv.py
@@ -259,11 +259,11 @@ def read_lmv_tofits(fileobj):
     hdu = fits.PrimaryHDU(data=data, header=Header)
     return hdu
 
-def load_lmv_cube(fileobj, target_cls=None):
+def load_lmv_cube(fileobj, target_cls=None, use_dask=None):
     hdu = read_lmv_tofits(fileobj)
     meta = {'filename':fileobj.name}
 
-    return load_fits_cube(hdu, meta=meta)
+    return load_fits_cube(hdu, meta=meta, use_dask=use_dask)
 
 def _read_byte(f):
     '''Read a single byte (from idlsave)'''

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, absolute_import, division
 
 import six
+import dask
 import warnings
 
 from astropy.io import fits
@@ -226,8 +227,9 @@ def write_fits_cube(cube, filename, overwrite=False,
         hdulist[0].header.add_history("Written by spectral_cube v{version} on "
                                       "{date}".format(version=SPECTRAL_CUBE_VERSION,
                                                       date=now))
-        with open(filename, "wb+") as fobj:
-            hdulist.writeto(fobj)
+        with dask.config.set(scheduler='synchronous'):
+            with open(filename, "wb+") as fobj:
+                hdulist.writeto(fobj)
     else:
         raise NotImplementedError()
 

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -226,10 +226,8 @@ def write_fits_cube(cube, filename, overwrite=False,
         hdulist[0].header.add_history("Written by spectral_cube v{version} on "
                                       "{date}".format(version=SPECTRAL_CUBE_VERSION,
                                                       date=now))
-        try:
-            hdulist.writeto(filename, overwrite=overwrite)
-        except TypeError:
-            hdulist.writeto(filename, clobber=overwrite)
+        with open(filename, "wb+") as fobj:
+            hdulist.writeto(fobj)
     else:
         raise NotImplementedError()
 

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -206,7 +206,6 @@ def load_fits_cube(input, hdu=0, meta=None, target_cls=None, use_dask=False, **k
                                             mask=comp_mask, meta=meta,
                                             header=header)
             else:
-                VRSC = VaryingResolutionSpectralCube
                 stokes_data[component] = VRSC(comp_data, wcs=comp_wcs,
                                               mask=comp_mask, meta=meta,
                                               header=header,

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -23,6 +23,7 @@ except ImportError:
     SPECTRAL_CUBE_VERSION = 'dev'
 
 from .. import SpectralCube, StokesSpectralCube, LazyMask, VaryingResolutionSpectralCube
+from ..dask_spectral_cube import DaskSpectralCube, DaskVaryingResolutionSpectralCube
 from ..lower_dimensional_structures import LowerDimensionalObject
 from ..spectral_cube import BaseSpectralCube
 from .. import cube_utils
@@ -134,7 +135,7 @@ def read_data_fits(input, hdu=None, mode='denywrite', **kwargs):
     return array_hdu.data, array_hdu.header, beam_table
 
 
-def load_fits_cube(input, hdu=0, meta=None, target_cls=None, **kwargs):
+def load_fits_cube(input, hdu=0, meta=None, target_cls=None, use_dask=False, **kwargs):
     """
     Read in a cube from a FITS file using astropy.
 
@@ -147,6 +148,13 @@ def load_fits_cube(input, hdu=0, meta=None, target_cls=None, **kwargs):
     meta: dict
         Metadata (can be inherited from other readers, for example)
     """
+
+    if use_dask:
+        SC = DaskSpectralCube
+        VRSC = DaskVaryingResolutionSpectralCube
+    else:
+        SC = SpectralCube
+        VRSC = VaryingResolutionSpectralCube
 
     data, header, beam_table = read_data_fits(input, hdu=hdu, **kwargs)
 
@@ -173,9 +181,9 @@ def load_fits_cube(input, hdu=0, meta=None, target_cls=None, **kwargs):
         mask = LazyMask(np.isfinite, data=data, wcs=wcs)
         assert data.shape == mask._data.shape
         if beam_table is None:
-            cube = SpectralCube(data, wcs, mask, meta=meta, header=header)
+            cube = SC(data, wcs, mask, meta=meta, header=header)
         else:
-            cube = VaryingResolutionSpectralCube(data, wcs, mask, meta=meta,
+            cube = VRSC(data, wcs, mask, meta=meta,
                                                  header=header,
                                                  beam_table=beam_table)
 
@@ -194,9 +202,9 @@ def load_fits_cube(input, hdu=0, meta=None, target_cls=None, **kwargs):
             comp_data, comp_wcs = cube_utils._orient(data[component], wcs)
             comp_mask = LazyMask(np.isfinite, data=comp_data, wcs=comp_wcs)
             if beam_table is None:
-                stokes_data[component] = SpectralCube(comp_data, wcs=comp_wcs,
-                                                      mask=comp_mask, meta=meta,
-                                                      header=header)
+                stokes_data[component] = SC(comp_data, wcs=comp_wcs,
+                                            mask=comp_mask, meta=meta,
+                                            header=header)
             else:
                 VRSC = VaryingResolutionSpectralCube
                 stokes_data[component] = VRSC(comp_data, wcs=comp_wcs,

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -235,9 +235,7 @@ def write_fits_cube(cube, filename, overwrite=False,
         hdulist[0].header.add_history("Written by spectral_cube v{version} on "
                                       "{date}".format(version=SPECTRAL_CUBE_VERSION,
                                                       date=now))
-        with dask.config.set(scheduler='synchronous'):
-            with open(filename, "wb+") as fobj:
-                hdulist.writeto(fobj)
+        hdulist.writeto(filename)
     else:
         raise NotImplementedError()
 

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -229,11 +229,12 @@ def write_fits_cube(cube, filename, overwrite=False,
 
     if isinstance(cube, BaseSpectralCube):
         hdulist = cube.hdulist
-        now = datetime.datetime.strftime(datetime.datetime.now(),
-                                         "%Y/%m/%d-%H:%M:%S")
-        hdulist[0].header.add_history("Written by spectral_cube v{version} on "
-                                      "{date}".format(version=SPECTRAL_CUBE_VERSION,
-                                                      date=now))
+        if include_origin_notes:
+            now = datetime.datetime.strftime(datetime.datetime.now(),
+                                            "%Y/%m/%d-%H:%M:%S")
+            hdulist[0].header.add_history("Written by spectral_cube v{version} on "
+                                        "{date}".format(version=SPECTRAL_CUBE_VERSION,
+                                                        date=now))
         hdulist.writeto(filename)
     else:
         raise NotImplementedError()

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -4,6 +4,7 @@ import warnings
 
 import numpy as np
 from numpy.ma.core import nomask
+import dask.array as da
 
 from astropy import convolution
 from astropy import units as u
@@ -826,6 +827,8 @@ class BaseOneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
             if self._mask is not nomask:
                 # Kind of a hack; this is probably inefficient
                 bad = self._mask.exclude()[key]
+                if isinstance(bad, da.Array):
+                    bad = bad.compute()
                 new_qty[bad] = np.nan
             return new_qty
 

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -184,7 +184,13 @@ class MaskBase(object):
         -----
         This is an internal method used by :class:`SpectralCube`.
         """
-        return data[view][self.include(data=data, wcs=wcs, view=view)]
+
+        mask = self.include(data=data, wcs=wcs, view=view)
+
+        if isinstance(data, da.Array) and not isinstance(mask, da.Array):
+            mask = da.asarray(mask)
+
+        return data[view][mask]
 
     def _filled(self, data, wcs=None, fill=np.nan, view=(), use_memmap=False,
                 **kwargs):

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -117,7 +117,10 @@ class MaskBase(object):
         kwargs are passed to _validate_wcs
         """
         self._validate_wcs(data, wcs, **kwargs)
-        return self._include(data=data, wcs=wcs, view=view)
+        inc = self._include(data=data, wcs=wcs, view=view)
+        if isinstance(inc, da.Array):
+            inc = inc.compute()
+        return inc
 
     # Commented out, but left as a possibility, because including this didn't fix any
     # of the problems we encountered with matplotlib plotting

--- a/spectral_cube/np_compat.py
+++ b/spectral_cube/np_compat.py
@@ -9,15 +9,21 @@ def allbadtonan(function):
     results.  For >=1.9, any axes with all-nan values will have all-nan outputs
     in the collapsed version
     """
-    def f(data, axis=None):
-        result = function(data, axis=axis)
+    def f(data, axis=None, keepdims=None):
+        if keepdims is None:
+            result = function(data, axis=axis)
+        else:
+            result = function(data, axis=axis, keepdims=keepdims)
         if LooseVersion(np.__version__) >= LooseVersion('1.9.0') and hasattr(result, '__len__'):
             if axis is None:
                 if np.all(np.isnan(data)):
                     return np.nan
                 else:
                     return result
-            nans = np.all(np.isnan(data), axis=axis)
+            if keepdims is None:
+                nans = np.all(np.isnan(data), axis=axis)
+            else:
+                nans = np.all(np.isnan(data), axis=axis, keepdims=keepdims)
             result[nans] = np.nan
         return result
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2189,7 +2189,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             data = self._get_filled_data(fill=0.)
 
             if isinstance(data, da.Array):
-                data = data.compute()
+                # Note that >f8 can cause issues with yt, and for visualization
+                # we don't really need the full 64-bit of floating point
+                # precision, so we cast to float32.
+                data = data.astype(np.float32).compute()
 
             hdu = PrimaryHDU(data, header=self.wcs.to_header())
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -3484,6 +3484,13 @@ class VaryingResolutionSpectralCube(BaseSpectralCube, MultiBeamMixinClass):
 
     _oned_spectrum = VaryingResolutionOneDSpectrum
 
+    def __new__(cls, *args, **kwargs):
+        if kwargs.pop('use_dask', False):
+            from .dask_spectral_cube import DaskVaryingResolutionSpectralCube
+            return super().__new__(DaskVaryingResolutionSpectralCube)
+        else:
+            return super().__new__(cls)
+
     def __init__(self, *args, **kwargs):
         """
         Create a SpectralCube with an associated beam table.  The new

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -3406,9 +3406,16 @@ class SpectralCube(BaseSpectralCube, BeamMixinClass):
 
     _oned_spectrum = OneDSpectrum
 
+    def __new__(cls, *args, **kwargs):
+        if kwargs.pop('use_dask', False):
+            from .dask_spectral_cube import DaskSpectralCube
+            return super().__new__(DaskSpectralCube)
+        else:
+            return super().__new__(cls)
+
     def __init__(self, data, wcs, mask=None, meta=None, fill_value=np.nan,
                  header=None, allow_huge_operations=False, beam=None,
-                 wcs_tolerance=0.0, **kwargs):
+                 wcs_tolerance=0.0, use_dask=False, **kwargs):
 
         super(SpectralCube, self).__init__(data=data, wcs=wcs, mask=mask,
                                            meta=meta, fill_value=fill_value,

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1055,6 +1055,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             data cube
         """
         data = self._mask._flattened(data=self._data, wcs=self._wcs, view=slice)
+        if isinstance(data, da.Array):
+            # Quantity does not work well with lazily evaluated data with an
+            # unkonwn shape (which is the case when doing boolean indexing of arrays)
+            data = self._compute(data)
         if weights is not None:
             weights = self._mask._flattened(data=weights, wcs=self._wcs, view=slice)
             return u.Quantity(data * weights, self.unit, copy=False)

--- a/spectral_cube/tests/test_analysis_functions.py
+++ b/spectral_cube/tests/test_analysis_functions.py
@@ -44,7 +44,7 @@ def test_shift():
                                rtol=1e-4)
 
 
-def test_stacking():
+def test_stacking(use_dask):
     '''
     Use a set of identical Gaussian profiles randomly offset to ensure the
     shifted spectrum has the correct properties.
@@ -58,7 +58,7 @@ def test_stacking():
 
     test_cube, test_vels = \
         generate_gaussian_cube(amp=amp, sigma=sigma, noise=noise,
-                               shape=shape)
+                               shape=shape, use_dask=use_dask)
 
     true_spectrum = gaussian(test_cube.spectral_axis.value,
                              amp, v0.value, sigma)
@@ -86,7 +86,7 @@ def test_stacking():
                                test_cube.spectral_axis.value)
 
 
-def test_stacking_badvels():
+def test_stacking_badvels(use_dask):
     '''
     Regression test for #493: don't include bad velocities when stacking
     '''
@@ -99,7 +99,7 @@ def test_stacking_badvels():
 
     test_cube, test_vels = \
         generate_gaussian_cube(amp=amp, sigma=sigma, noise=noise,
-                               shape=shape)
+                               shape=shape, use_dask=use_dask)
 
     true_spectrum = gaussian(test_cube.spectral_axis.value,
                              amp, v0.value, sigma)
@@ -121,7 +121,7 @@ def test_stacking_badvels():
     assert np.std(resid) <= 1e-3
 
 
-def test_stacking_reversed_specaxis():
+def test_stacking_reversed_specaxis(use_dask):
     '''
     Use a set of identical Gaussian profiles randomly offset to ensure the
     shifted spectrum has the correct properties.
@@ -135,7 +135,7 @@ def test_stacking_reversed_specaxis():
 
     test_cube, test_vels = \
         generate_gaussian_cube(amp=amp, sigma=sigma, noise=noise,
-                               shape=shape, spec_scale=-1. * u.km / u.s)
+                               shape=shape, spec_scale=-1. * u.km / u.s, use_dask=use_dask)
 
     true_spectrum = gaussian(test_cube.spectral_axis.value,
                              amp, v0.value, sigma)
@@ -157,7 +157,7 @@ def test_stacking_reversed_specaxis():
                                test_cube.spectral_axis.value)
 
 
-def test_stacking_wpadding():
+def test_stacking_wpadding(use_dask):
     '''
     Use a set of identical Gaussian profiles randomly offset to ensure the
     shifted spectrum has the correct properties.
@@ -170,7 +170,7 @@ def test_stacking_wpadding():
     shape = (100, 25, 25)
 
     test_cube, test_vels = \
-        generate_gaussian_cube(shape=shape, amp=amp, sigma=sigma, noise=noise)
+        generate_gaussian_cube(shape=shape, amp=amp, sigma=sigma, noise=noise, use_dask=use_dask)
 
     # Stack the spectra in the cube
     stacked = \
@@ -200,7 +200,7 @@ def test_stacking_wpadding():
         or (stacked.size == stack_shape + 1)
 
 
-def test_padding_direction():
+def test_padding_direction(use_dask):
 
     amp = 1.
     sigma = 8.
@@ -212,7 +212,7 @@ def test_padding_direction():
 
     test_cube, test_vels = \
         generate_gaussian_cube(shape=shape, amp=amp, sigma=sigma, noise=noise,
-                               vel_surface=vel_surface)
+                               vel_surface=vel_surface, use_dask=use_dask)
 
     # Stack the spectra in the cube
     stacked = \
@@ -235,7 +235,7 @@ def test_padding_direction():
     assert np.std(resid) <= 1e-3
 
 
-def test_stacking_woffset():
+def test_stacking_woffset(use_dask):
     '''
     Use a set of identical Gaussian profiles randomly offset to ensure the
     shifted spectrum has the correct properties.
@@ -252,7 +252,7 @@ def test_stacking_woffset():
 
     test_cube, test_vels = \
         generate_gaussian_cube(shape=shape, amp=amp, sigma=sigma, noise=noise,
-                               v0=v0.value)
+                               v0=v0.value, use_dask=use_dask)
 
     # Stack the spectra in the cube
     stacked = \
@@ -276,7 +276,7 @@ def test_stacking_woffset():
         or (stacked.size == stack_shape + 1)
 
 
-def test_stacking_shape_failure():
+def test_stacking_shape_failure(use_dask):
     """
     Regression test for #466
     """
@@ -288,7 +288,7 @@ def test_stacking_shape_failure():
 
     test_cube, test_vels = \
         generate_gaussian_cube(amp=amp, sigma=sigma, noise=noise,
-                               shape=shape)
+                               shape=shape, use_dask=use_dask)
 
     # make the test_vels array the wrong shape
     test_vels = test_vels[:-1, :-1]
@@ -315,7 +315,7 @@ def test_stacking_shape_failure():
     assert "velocity_surface contains no finite values" in exc.value.args[0]
 
 
-def test_stacking_noisy():
+def test_stacking_noisy(use_dask):
 
     # Test stack w/ S/N of 0.2
     # This is cheating b/c we know the correct peak velocities, but serves as
@@ -329,7 +329,7 @@ def test_stacking_noisy():
 
     test_cube, test_vels = \
         generate_gaussian_cube(amp=amp, sigma=sigma, noise=noise,
-                               shape=shape)
+                               shape=shape, use_dask=use_dask)
 
     # Stack the spectra in the cube
     stacked = \

--- a/spectral_cube/tests/test_casafuncs.py
+++ b/spectral_cube/tests/test_casafuncs.py
@@ -13,7 +13,9 @@ from astropy import units as u
 
 from ..io.casa_masks import make_casa_mask
 from ..io.casa_wcs import wcs_casa2astropy
-from .. import SpectralCube, StokesSpectralCube, BooleanArrayMask, VaryingResolutionSpectralCube
+from .. import StokesSpectralCube, BooleanArrayMask
+
+from .. import SpectralCube, VaryingResolutionSpectralCube
 
 try:
     import casatools
@@ -99,6 +101,15 @@ def test_casa_read_basic(memmap, bigendian):
     assert_quantity_allclose(cube.unmasked_data[0, 0, :],
                              [1, 1, 1, 1, 1] * u.Jy / u.beam)
     assert_quantity_allclose(cube.unmasked_data[0, 1, 2], 1 * u.Jy / u.beam)
+
+
+def test_casa_read_basic_nodask():
+
+    # For CASA datasets, the default when reading cubes is use_dask=True.
+    # Here we check that setting use_dask=False explicitly raises an error.
+
+    with pytest.raises(ValueError, match='Loading CASA datasets is not possible with use_dask=False'):
+        SpectralCube.read(os.path.join(DATA, 'basic.image'), use_dask=False)
 
 
 def test_casa_read_basic_nomask():

--- a/spectral_cube/tests/test_cube_utils.py
+++ b/spectral_cube/tests/test_cube_utils.py
@@ -7,27 +7,27 @@ from .test_spectral_cube import cube_and_raw, path
 from ..cube_utils import largest_beam, smallest_beam, beams_to_bintable
 
 
-def test_largest_beam(data_522_delta_beams):
+def test_largest_beam(data_522_delta_beams, use_dask):
 
-    cube, data = cube_and_raw(data_522_delta_beams)
+    cube, data = cube_and_raw(data_522_delta_beams, use_dask=use_dask)
 
     large_beam = largest_beam(cube.beams)
 
     assert large_beam == cube.beams[2]
 
 
-def test_smallest_beam(data_522_delta_beams):
+def test_smallest_beam(data_522_delta_beams, use_dask):
 
-    cube, data = cube_and_raw(data_522_delta_beams)
+    cube, data = cube_and_raw(data_522_delta_beams, use_dask=use_dask)
 
     small_beam = smallest_beam(cube.beams)
 
     assert small_beam == cube.beams[0]
 
 
-def test_beams_to_bintable_cube(data_522_delta_beams):
+def test_beams_to_bintable_cube(data_522_delta_beams, use_dask):
 
-    cube, data = cube_and_raw(data_522_delta_beams)
+    cube, data = cube_and_raw(data_522_delta_beams, use_dask=use_dask)
 
     hdul = fits.open(data_522_delta_beams)
     beamtable = hdul[1]
@@ -40,6 +40,7 @@ def test_beams_to_bintable_cube(data_522_delta_beams):
     assert bms.header['NCHAN'] == 5
 
     hdul.close()
+
 
 def test_beams_to_bintable():
     """ Check that NPOL is set """

--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -31,3 +31,10 @@ def test_scheduler(data_adv):
     cube.use_dask_scheduler('threads')
     cube._compute(fake_array)
     assert fake_array.kwargs == {'scheduler': 'threads'}
+
+    with cube.use_dask_scheduler('processes', num_workers=4):
+        cube._compute(fake_array)
+        assert fake_array.kwargs == {'scheduler': 'processes', 'num_workers': 4}
+
+    cube._compute(fake_array)
+    assert fake_array.kwargs == {'scheduler': 'threads'}

--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -1,0 +1,33 @@
+# Tests specific to the dask classe
+
+from spectral_cube import DaskSpectralCube
+
+
+class Array:
+
+    args = None
+    kwargs = None
+
+    def compute(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+def test_scheduler(data_adv):
+
+    cube = DaskSpectralCube.read(data_adv)
+    fake_array = Array()
+
+    cube._compute(fake_array)
+    assert fake_array.kwargs == {'scheduler': 'synchronous'}
+
+    with cube.use_dask_scheduler('threads'):
+        cube._compute(fake_array)
+        assert fake_array.kwargs == {'scheduler': 'threads'}
+
+    cube._compute(fake_array)
+    assert fake_array.kwargs == {'scheduler': 'synchronous'}
+
+    cube.use_dask_scheduler('threads')
+    cube._compute(fake_array)
+    assert fake_array.kwargs == {'scheduler': 'threads'}

--- a/spectral_cube/tests/test_io.py
+++ b/spectral_cube/tests/test_io.py
@@ -3,12 +3,17 @@ from __future__ import print_function, absolute_import, division
 import numpy as np
 from astropy.io import fits as pyfits
 from astropy import units as u
-from .. import SpectralCube, StokesSpectralCube
+from .. import StokesSpectralCube
 from ..lower_dimensional_structures import (OneDSpectrum,
                                             VaryingResolutionOneDSpectrum)
 from . import path
 
 from radio_beam import Beam
+
+
+from .. import SpectralCube, VaryingResolutionSpectralCube
+from ..dask_spectral_cube import DaskSpectralCube
+
 
 def test_lmv_fits():
     c1 = SpectralCube.read(path('example_cube.fits'))
@@ -23,54 +28,59 @@ def test_lmv_fits():
     #assert c1.wcs==c2.wcs
 
 
-def test_3d_4d_stokes(data_adv, data_advs):
+def test_3d_4d_stokes(data_adv, data_advs, use_dask):
     f3 = pyfits.open(data_adv)
     f4 = pyfits.open(data_advs)
     f3b = pyfits.PrimaryHDU(data=f3[0].data, header=f4[0].header)
 
-    c1 = SpectralCube.read(f3)
-    c2 = SpectralCube.read(f4)
-    c3 = SpectralCube.read(f3b)
+    c1 = SpectralCube.read(f3, use_dask=use_dask)
+    c2 = SpectralCube.read(f4, use_dask=use_dask)
+    c3 = SpectralCube.read(f3b, use_dask=use_dask)
 
     assert c1.shape == c3.shape
     # c2 has a different shape on disk...
     f3.close()
     f4.close()
 
-def test_4d_stokes(data_advs):
+
+def test_4d_stokes(data_advs, use_dask):
     f = pyfits.open(data_advs)
-    c = StokesSpectralCube.read(f)
+    c = StokesSpectralCube.read(f, use_dask=use_dask)
     assert isinstance(c, StokesSpectralCube)
+    if use_dask:
+        assert isinstance(c.I, DaskSpectralCube)
+    else:
+        assert isinstance(c.I, SpectralCube)
     f.close()
 
 
-def test_4d_stokes_read_3d(data_adv):
+def test_4d_stokes_read_3d(data_adv, use_dask):
     # Regression test for a bug that caused StokesSpectralCube.read to not work
     # correctly when reading in a 3D FITS file.
     f = pyfits.open(data_adv)
-    c = StokesSpectralCube.read(f)
+    c = StokesSpectralCube.read(f, use_dask=use_dask)
     assert isinstance(c, StokesSpectralCube)
     f.close()
 
 
-def test_3d_beams(data_vda_beams):
-    c = SpectralCube.read(data_vda_beams)
+def test_3d_beams(data_vda_beams, use_dask):
+    c = SpectralCube.read(data_vda_beams, use_dask=use_dask)
     np.testing.assert_almost_equal(c.beams[0].major.value, 0.4)
     np.testing.assert_almost_equal(c.beams[0].minor.value, 0.1)
 
 
-def test_4d_beams(data_sdav_beams):
-    c = SpectralCube.read(data_sdav_beams)
+def test_4d_beams(data_sdav_beams, use_dask):
+    c = SpectralCube.read(data_sdav_beams, use_dask=use_dask)
     np.testing.assert_almost_equal(c.beams[0].major.value, 0.4)
     np.testing.assert_almost_equal(c.beams[0].minor.value, 0.1)
 
 
-def test_3d_beams_roundtrip(tmpdir, data_vda_beams):
-    c = SpectralCube.read(data_vda_beams)
+def test_3d_beams_roundtrip(tmpdir, data_vda_beams, use_dask):
+    c = SpectralCube.read(data_vda_beams, use_dask=use_dask)
     np.testing.assert_almost_equal(c.beams[0].major.value, 0.4)
     np.testing.assert_almost_equal(c.beams[0].minor.value, 0.1)
     c.write(tmpdir.join('vda_beams_out.fits').strpath)
-    c2 = SpectralCube.read(tmpdir.join('vda_beams_out.fits').strpath)
+    c2 = SpectralCube.read(tmpdir.join('vda_beams_out.fits').strpath, use_dask=use_dask)
 
     # assert c==c2 # this is not implemented?
     assert np.all(c.filled_data[:] == c2.filled_data[:])
@@ -80,13 +90,13 @@ def test_3d_beams_roundtrip(tmpdir, data_vda_beams):
     np.testing.assert_almost_equal(c2.beams[0].minor.value, 0.1)
 
 
-def test_4d_beams_roundtrip(tmpdir, data_sdav_beams):
+def test_4d_beams_roundtrip(tmpdir, data_sdav_beams, use_dask):
     # not sure if 4d can round-trip...
-    c = SpectralCube.read(data_sdav_beams)
+    c = SpectralCube.read(data_sdav_beams, use_dask=use_dask)
     np.testing.assert_almost_equal(c.beams[0].major.value, 0.4)
     np.testing.assert_almost_equal(c.beams[0].minor.value, 0.1)
     c.write(tmpdir.join('sdav_beams_out.fits').strpath)
-    c2 = SpectralCube.read(tmpdir.join('sdav_beams_out.fits').strpath)
+    c2 = SpectralCube.read(tmpdir.join('sdav_beams_out.fits').strpath, use_dask=use_dask)
 
     # assert c==c2 # this is not implemented?
     assert np.all(c.filled_data[:] == c2.filled_data[:])
@@ -103,7 +113,7 @@ def test_1d(data_5_spectral):
     np.testing.assert_almost_equal(spec, np.arange(5, dtype='float'))
     hdul.close()
 
-def test_1d_beams(data_5_spectral_beams):
+def test_1d_beams(data_5_spectral_beams, use_dask):
     hdu = pyfits.open(data_5_spectral_beams)
     spec = OneDSpectrum.from_hdu(hdu)
 

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -10,7 +10,7 @@ from astropy.wcs import WCS
 from astropy import units as u
 
 from .test_spectral_cube import cube_and_raw
-from .. import (BooleanArrayMask, SpectralCube, LazyMask, LazyComparisonMask,
+from .. import (BooleanArrayMask, LazyMask, LazyComparisonMask,
                 FunctionMask, CompositeMask)
 from ..masks import is_broadcastable_and_smaller, dims_to_skip, view_of_subset
 
@@ -36,6 +36,7 @@ def test_spectral_cube_mask():
     assert_allclose(m.exclude(data, wcs, view=(0, 0, slice(1, 4))), [0, 0, 1])
     assert_allclose(m._filled(data, wcs, view=(0, 0, slice(1, 4))), [1, 2, np.nan])
     assert_allclose(m._flattened(data, wcs, view=(0, 0, slice(1, 4))), [1, 2])
+
 
 def test_lazy_mask():
 
@@ -68,6 +69,7 @@ def test_lazy_mask():
     assert_allclose(m.exclude(data, wcs, view=(0, 0, slice(1, 4))), [1, 1, 0])
     assert_allclose(m._filled(data, wcs, view=(0, 0, slice(1, 4))), [np.nan, np.nan, 0])
     assert_allclose(m._flattened(data, wcs, view=(0, 0, slice(1, 4))), [0])
+
 
 def test_lazy_comparison_mask():
 
@@ -252,8 +254,8 @@ def test_mask_spectral_unit(filename):
                     outcv.to(u.Hz).value)
 
 
-def test_wcs_validity_check(data_adv):
-    cube, data = cube_and_raw(data_adv)
+def test_wcs_validity_check(data_adv, use_dask):
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
     mask = BooleanArrayMask(data > 0, cube._wcs)
     cube = cube.with_mask(mask)
     s2 = cube.spectral_slab(-2 * u.km / u.s, 2 * u.km / u.s)
@@ -261,8 +263,9 @@ def test_wcs_validity_check(data_adv):
     # just checking that this works, not that it does anything in particular
     moment_map = s3.moment(order=1)
 
-def test_wcs_validity_check_failure(data_adv):
-    cube, data = cube_and_raw(data_adv)
+
+def test_wcs_validity_check_failure(data_adv, use_dask):
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     assert cube.wcs.wcs.crval[2] == -3.21214698632E+05
 
@@ -294,8 +297,8 @@ def test_wcs_validity_check_failure(data_adv):
     moment_map = s3.moment(order=1)
 
 
-def test_mask_spectral_unit_functions(data_adv):
-    cube, data = cube_and_raw(data_adv)
+def test_mask_spectral_unit_functions(data_adv, use_dask):
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     # function mask should do nothing
     mask1 = FunctionMask(lambda x: x>0)
@@ -352,9 +355,11 @@ shapes = ([1,5,5], [1,5,1], [5,5,1], [5,5], [5,5,2],
           [2,3,4], [4,3,2], [4,2,3], [2,4,3])
 shape_combos = list(itertools.combinations(shapes,2))
 
+
 @pytest.mark.parametrize(('shp1','shp2'),shape_combos)
 def test_is_broadcastable(shp1, shp2):
     assert is_broadcastable_and_smaller(shp1,shp2) == is_broadcastable_try(shp1,shp2)
+
 
 @pytest.mark.parametrize(('shp1','shp2','dim'),
                          (([5,5],[2,5,5],[0]),
@@ -363,6 +368,7 @@ def test_is_broadcastable(shp1, shp2):
 def test_dims_to_skip(shp1, shp2, dim):
     assert dims_to_skip(shp1, shp2) == dim
 
+
 @pytest.mark.parametrize(('shp1','shp2', 'inview', 'outview'),
                          (([5,5],[2,5,5],  (slice(0,1), slice(1,3), slice(2,4),), (slice(1,3), slice(2,4))),
                           # not a valid broadcast ([5,5],[5,5,2],  [slice(1,3), slice(2,4), slice(0,1),], [slice(1,3), slice(2,4)]),
@@ -370,8 +376,9 @@ def test_dims_to_skip(shp1, shp2, dim):
 def test_view_of_subset(shp1, shp2, inview, outview):
     assert view_of_subset(shp1,shp2,inview) == outview
 
-def test_flat_mask(data_adv):
-    cube, data = cube_and_raw(data_adv)
+
+def test_flat_mask(data_adv, use_dask):
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     mask_array = np.array([[True,False],[False,False],[True,True]])
     bool_mask_array = BooleanArrayMask(mask=mask_array, wcs=cube._wcs,
@@ -384,10 +391,11 @@ def test_flat_mask(data_adv):
     assert np.all(cube.sum(axis=0)[mask_array] == mcube.sum(axis=0)[mask_array])
     assert np.all(np.isnan(mcube.sum(axis=0)[~mask_array]))
 
+
 @pytest.mark.skipif(LooseVersion(np.__version__) < LooseVersion('1.7'),
                     reason='Numpy <1.7 does not support multi-slice indexing.')
-def test_flat_mask_spectral(data_adv):
-    cube, data = cube_and_raw(data_adv)
+def test_flat_mask_spectral(data_adv, use_dask):
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     mask_array = np.array([[True,False],[False,False],[True,True]])
     bool_mask_array = BooleanArrayMask(mask=mask_array, wcs=cube._wcs,
@@ -400,8 +408,9 @@ def test_flat_mask_spectral(data_adv):
     assert np.all((data*cubemask).sum(axis=(1,2)) ==
                   mcube.sum(axis=(1,2)).value)
 
-def test_include(data_adv):
-    cube, data = cube_and_raw(data_adv)
+
+def test_include(data_adv, use_dask):
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     mask_array = np.array([[True,False],[False,False],[True,True]])
     bool_mask_array = BooleanArrayMask(mask=mask_array, wcs=cube._wcs,
@@ -409,12 +418,13 @@ def test_include(data_adv):
 
     assert np.all(bool_mask_array.include() == mask_array)
 
-def test_1d_mask(data_adv):
+
+def test_1d_mask(data_adv, use_dask):
     # regression test for issue revealed in #183
     # In principle, this is also a regression test for #298, except this always
     # passed where #298 failed, which I don't understand.
 
-    cube, data = cube_and_raw(data_adv)
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
     mask = np.array([True, False, True, False])
 
     sum0 = cube.with_mask(mask[:,None,None]).sum(axis=0)
@@ -422,8 +432,9 @@ def test_1d_mask(data_adv):
 
     np.testing.assert_almost_equal(sum0.value, sum0d)
 
-def test_1d_mask_amp(data_adv):
-    cube, data = cube_and_raw(data_adv)
+
+def test_1d_mask_amp(data_adv, use_dask):
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
     mask = np.array([True, False, True, False])
 
     Mask = BooleanArrayMask(mask[:,None,None],
@@ -435,8 +446,9 @@ def test_1d_mask_amp(data_adv):
 
     ampd.include()
 
-def test_2dcomparison_mask_1d_index(data_adv):
-    cube, data = cube_and_raw(data_adv)
+
+def test_2dcomparison_mask_1d_index(data_adv, use_dask):
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     med = cube.median(axis=0)
     mask = cube > med
@@ -469,8 +481,9 @@ def test_2dcomparison_mask_1d_index(data_adv):
 
     assert isinstance(spec[0], u.Quantity)
 
-def test_1dcomparison_mask_1d_index(data_adv):
-    cube, data = cube_and_raw(data_adv)
+
+def test_1dcomparison_mask_1d_index(data_adv, use_dask):
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     med = cube.median()
     mask = cube > med
@@ -491,8 +504,9 @@ def test_1dcomparison_mask_1d_index(data_adv):
 
     assert isinstance(spec[0], u.Quantity)
 
-def test_1dmask_indexing(data_adv):
-    cube, data = cube_and_raw(data_adv)
+
+def test_1dmask_indexing(data_adv, use_dask):
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     med = cube.median()
     mask = cube > med
@@ -508,12 +522,13 @@ def test_1dmask_indexing(data_adv):
     assert np.all(np.isnan(spec[badvals]))
     assert not np.any(np.isnan(spec[~badvals]))
 
-def test_numpy_ma_tools(data_adv):
+
+def test_numpy_ma_tools(data_adv, use_dask):
     """
     check that np.ma.core.is_masked works
     """
 
-    cube, data = cube_and_raw(data_adv)
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     med = cube.median()
     mask = cube > med
@@ -525,12 +540,13 @@ def test_numpy_ma_tools(data_adv):
     assert np.ma.core.is_masked(mcube[:,0,0])
     assert np.ma.core.getmask(mcube[:,0,0]) is not None
 
+
 @pytest.mark.xfail
-def test_numpy_ma_tools_2d(data_adv):
+def test_numpy_ma_tools_2d(data_adv, use_dask):
     """ This depends on 2D objects keeping masks, which depends on #395.
     so, TODO: un-xfail this """
 
-    cube, data = cube_and_raw(data_adv)
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     med = cube.median()
     mask = cube > med
@@ -541,10 +557,10 @@ def test_numpy_ma_tools_2d(data_adv):
     assert np.ma.core.getmask(mcube[0,:,:]) is not None
 
 
-def test_filled(data_adv):
+def test_filled(data_adv, use_dask):
     """ test that 'filled' works """
 
-    cube, data = cube_and_raw(data_adv)
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     med = cube.median()
     mask = cube > med
@@ -558,9 +574,10 @@ def test_filled(data_adv):
 
     assert (np.isnan(filled) == mcube.mask.exclude()).all()
 
-def test_boolean_array_composite_mask(data_adv):
 
-    cube, data = cube_and_raw(data_adv)
+def test_boolean_array_composite_mask(data_adv, use_dask):
+
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     med = cube.median()
     mask = cube > med

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -238,8 +238,8 @@ def filename(request):
                           ('data_vad'),
                           ('data_adv'),
                           ), indirect=['filename'])
-def test_mask_spectral_unit(filename):
-    cube, data = cube_and_raw(filename)
+def test_mask_spectral_unit(filename, use_dask):
+    cube, data = cube_and_raw(filename, use_dask=use_dask)
     mask = BooleanArrayMask(data, cube._wcs)
     mask_freq = mask.with_spectral_unit(u.Hz)
 

--- a/spectral_cube/tests/test_moments.py
+++ b/spectral_cube/tests/test_moments.py
@@ -89,9 +89,9 @@ else:
 
 
 @axis_order
-def test_strategies_consistent(axis, order):
+def test_strategies_consistent(axis, order, use_dask):
     mc_hdu = moment_cube()
-    sc = SpectralCube.read(mc_hdu)
+    sc = SpectralCube.read(mc_hdu, use_dask=use_dask)
 
     cwise = sc.moment(axis=axis, order=order, how='cube')
     swise = sc.moment(axis=axis, order=order, how='slice')
@@ -105,17 +105,17 @@ def test_strategies_consistent(axis, order):
                           for o in [0, 1, 2]
                           for a in [0, 1, 2]
                           for h in ['cube', 'slice', 'auto', 'ray']])
-def test_reference(order, axis, how):
+def test_reference(order, axis, how, use_dask):
     mc_hdu = moment_cube()
-    sc = SpectralCube.read(mc_hdu)
+    sc = SpectralCube.read(mc_hdu, use_dask=use_dask)
     mom_sc = sc.moment(order=order, axis=axis, how=how)
     assert_allclose(mom_sc, MOMENTS[order][axis])
 
 
 @axis_order
-def test_consistent_mask_handling(axis, order):
+def test_consistent_mask_handling(axis, order, use_dask):
     mc_hdu = moment_cube()
-    sc = SpectralCube.read(mc_hdu)
+    sc = SpectralCube.read(mc_hdu, use_dask=use_dask)
     sc._mask = sc > 4*u.K
 
     cwise = sc.moment(axis=axis, order=order, how='cube')
@@ -125,18 +125,18 @@ def test_consistent_mask_handling(axis, order):
     assert_allclose(cwise, rwise, rtol=rtol, atol=atol)
 
 
-def test_convenience_methods():
+def test_convenience_methods(use_dask):
     mc_hdu = moment_cube()
-    sc = SpectralCube.read(mc_hdu)
+    sc = SpectralCube.read(mc_hdu, use_dask=use_dask)
 
     assert_allclose(sc.moment0(axis=0), MOMENTS[0][0])
     assert_allclose(sc.moment1(axis=2), MOMENTS[1][2])
     assert_allclose(sc.moment2(axis=1), MOMENTS[2][1])
 
 
-def test_linewidth():
+def test_linewidth(use_dask):
     mc_hdu = moment_cube()
-    sc = SpectralCube.read(mc_hdu)
+    sc = SpectralCube.read(mc_hdu, use_dask=use_dask)
 
     with warnings.catch_warnings(record=True) as w:
         assert_allclose(sc.moment2(), MOMENTS[2][0])
@@ -155,9 +155,9 @@ def test_linewidth():
     assert len(w) == 0
 
 
-def test_preserve_unit():
+def test_preserve_unit(use_dask):
     mc_hdu = moment_cube()
-    sc = SpectralCube.read(mc_hdu)
+    sc = SpectralCube.read(mc_hdu, use_dask=use_dask)
     sc_kms = sc.with_spectral_unit(u.km/u.s)
     m0 = sc_kms.moment0(axis=0)
     m1 = sc_kms.moment1(axis=0)
@@ -165,12 +165,13 @@ def test_preserve_unit():
     assert_allclose(m0, MOMENTS[0][0].to(u.K*u.km/u.s))
     assert_allclose(m1, MOMENTS[1][0].to(u.km/u.s))
 
-def test_with_flux_unit():
+
+def test_with_flux_unit(use_dask):
     """
     As of Issue 184, redundant with test_reference
     """
     mc_hdu = moment_cube()
-    sc = SpectralCube.read(mc_hdu)
+    sc = SpectralCube.read(mc_hdu, use_dask=use_dask)
     sc._unit = u.K
     sc_kms = sc.with_spectral_unit(u.km/u.s)
     m0 = sc_kms.moment0(axis=0)
@@ -182,19 +183,20 @@ def test_with_flux_unit():
     assert_allclose(m0, MOMENTS[0][0].to(u.K*u.km/u.s))
     assert_allclose(m1, MOMENTS[1][0].to(u.km/u.s))
 
+
 @pytest.mark.parametrize(('order', 'axis', 'how'),
                          [(o, a, h)
                           for o in [0, 1, 2]
                           for a in [0, 1, 2]
                           for h in ['cube', 'slice', 'auto', 'ray']])
-def test_how_withfluxunit(order, axis, how):
+def test_how_withfluxunit(order, axis, how, use_dask):
     """
     Regression test for issue 180
     As of issue 184, this is mostly redundant with test_reference except that
     it (kind of) checks that units are set
     """
     mc_hdu = moment_cube()
-    sc = SpectralCube.read(mc_hdu)
+    sc = SpectralCube.read(mc_hdu, use_dask=use_dask)
     sc._unit = u.K
     mom_sc = sc.moment(order=order, axis=axis, how=how)
 

--- a/spectral_cube/tests/test_performance.py
+++ b/spectral_cube/tests/test_performance.py
@@ -134,7 +134,7 @@ def test_parallel_performance_smoothing():
             print(rslt)
 
 # python 2.7 doesn't have tracemalloc
-@pytest.mark.skipif('True or not tracemallocOK or (sys.version_info.major==3 and sys.version_info.minor<6) or not NPY_VERSION_CHECK or WINDOWS')
+@pytest.mark.skipif('not tracemallocOK or (sys.version_info.major==3 and sys.version_info.minor<6) or not NPY_VERSION_CHECK or WINDOWS')
 def test_memory_usage():
     """
     Make sure that using memmaps happens where expected, for the most part, and

--- a/spectral_cube/tests/test_performance.py
+++ b/spectral_cube/tests/test_performance.py
@@ -1,5 +1,7 @@
 """
-Performance-related tests to make sure we don't use more memory than we should
+Performance-related tests to make sure we don't use more memory than we should.
+
+For now this is just for SpectralCube, not DaskSpectralCube.
 """
 
 from __future__ import print_function, absolute_import, division
@@ -38,6 +40,7 @@ def find_base_nbytes(obj):
         return find_base_nbytes(obj.base)
     return obj.nbytes
 
+
 def test_pix_size():
     mc_hdu = moment_cube()
     sc = SpectralCube.read(mc_hdu)
@@ -51,6 +54,7 @@ def test_pix_size():
     assert find_base_nbytes(y) == sc.shape[1]*sc.shape[2]*bytes_per_pix
     assert find_base_nbytes(x) == sc.shape[1]*sc.shape[2]*bytes_per_pix
 
+
 def test_compare_pix_size_approaches():
     mc_hdu = moment_cube()
     sc = SpectralCube.read(mc_hdu)
@@ -61,6 +65,7 @@ def test_compare_pix_size_approaches():
     assert_allclose(sa, s)
     assert_allclose(ya, y)
     assert_allclose(xa, x)
+
 
 def test_pix_cen():
     mc_hdu = moment_cube()
@@ -74,6 +79,7 @@ def test_pix_cen():
     assert find_base_nbytes(s) == sc.shape[0]*bytes_per_pix
     assert find_base_nbytes(y) == sc.shape[1]*sc.shape[2]*bytes_per_pix
     assert find_base_nbytes(x) == sc.shape[1]*sc.shape[2]*bytes_per_pix
+
 
 @pytest.mark.skipif('True')
 def test_parallel_performance_smoothing():
@@ -128,7 +134,7 @@ def test_parallel_performance_smoothing():
             print(rslt)
 
 # python 2.7 doesn't have tracemalloc
-@pytest.mark.skipif('not tracemallocOK or (sys.version_info.major==3 and sys.version_info.minor<6) or not NPY_VERSION_CHECK or WINDOWS')
+@pytest.mark.skipif('True or not tracemallocOK or (sys.version_info.major==3 and sys.version_info.minor<6) or not NPY_VERSION_CHECK or WINDOWS')
 def test_memory_usage():
     """
     Make sure that using memmaps happens where expected, for the most part, and
@@ -160,6 +166,7 @@ def test_memory_usage():
 
     # writing the cube should not occupy any more memory
     snap3 = tracemalloc.take_snapshot()
+
     diff = snap3.compare_to(snap2, 'lineno')
     assert sum([dd.size_diff for dd in diff])*u.B < 100*u.kB
 

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -301,6 +301,7 @@ def test_slice_tricks():
     assert new.ndim == 3
     assert len(w) == 0
 
+
 def test_array_property():
     test_wcs_1 = WCS(naxis=1)
     spec = OneDSpectrum(twelve_qty_1d, wcs=test_wcs_1)
@@ -312,6 +313,7 @@ def test_array_property():
 
     assert isinstance(arr, np.ndarray)
     assert not isinstance(arr, u.Quantity)
+
 
 def test_quantity_property():
     test_wcs_1 = WCS(naxis=1)
@@ -467,9 +469,9 @@ def test_projection_subimage(data_55):
     assert np.all(proj5.value == proj.value)
 
 
-def test_projection_subimage_nocelestial_fail(data_255_delta):
+def test_projection_subimage_nocelestial_fail(data_255_delta, use_dask):
 
-    cube, data = cube_and_raw(data_255_delta)
+    cube, data = cube_and_raw(data_255_delta, use_dask=use_dask)
 
     proj = cube.moment0(axis=1)
 
@@ -523,6 +525,7 @@ def test_mask_convolve():
     from astropy.convolution import convolve,Box1DKernel
     convolve(spec, Box1DKernel(3))
 
+
 def test_convolve():
     test_wcs_1 = WCS(naxis=1)
     spec = OneDSpectrum(twelve_qty_1d, wcs=test_wcs_1)
@@ -531,6 +534,7 @@ def test_convolve():
     specsmooth = spec.spectral_smooth(Box1DKernel(1))
 
     np.testing.assert_allclose(spec, specsmooth)
+
 
 def test_spectral_interpolate():
     test_wcs_1 = WCS(naxis=1)
@@ -543,14 +547,14 @@ def test_spectral_interpolate():
     np.testing.assert_allclose(new_spec, np.linspace(0,11,23)*u.Jy)
 
 
-def test_spectral_interpolate_with_mask(data_522_delta):
+def test_spectral_interpolate_with_mask(data_522_delta, use_dask):
 
     hdu = fits.open(data_522_delta)[0]
 
     # Swap the velocity axis so indiff < 0 in spectral_interpolate
     hdu.header["CDELT3"] = - hdu.header["CDELT3"]
 
-    cube = SpectralCube.read(hdu)
+    cube = SpectralCube.read(hdu, use_dask=use_dask)
 
     mask = np.ones(cube.shape, dtype=bool)
     mask[:2] = False
@@ -569,9 +573,10 @@ def test_spectral_interpolate_with_mask(data_522_delta):
     np.testing.assert_almost_equal(result.filled_data[:].value,
                                    [0.0, 0.5, np.NaN, np.NaN])
 
-def test_spectral_interpolate_reversed(data_522_delta):
 
-    cube, data = cube_and_raw(data_522_delta)
+def test_spectral_interpolate_reversed(data_522_delta, use_dask):
+
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
 
     # Reverse spectral axis
     sg = cube.spectral_axis[::-1]
@@ -582,9 +587,10 @@ def test_spectral_interpolate_reversed(data_522_delta):
 
     np.testing.assert_almost_equal(sg.value, result.spectral_axis.value)
 
-def test_spectral_interpolate_with_fillvalue(data_522_delta):
 
-    cube, data = cube_and_raw(data_522_delta)
+def test_spectral_interpolate_with_fillvalue(data_522_delta, use_dask):
+
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
 
     # Step one channel out of bounds.
     sg = ((cube.spectral_axis[0]) -
@@ -599,10 +605,10 @@ def test_spectral_interpolate_with_fillvalue(data_522_delta):
                                    np.ones(4)*42)
 
 
-def test_spectral_units(data_255_delta):
+def test_spectral_units(data_255_delta, use_dask):
     # regression test for issue 391
 
-    cube, data = cube_and_raw(data_255_delta)
+    cube, data = cube_and_raw(data_255_delta, use_dask=use_dask)
 
     sp = cube[:,0,0]
 
@@ -615,9 +621,9 @@ def test_spectral_units(data_255_delta):
     assert sp.header['CUNIT1'] in ('m s-1', 'm/s')
 
 
-def test_repr_1d(data_255_delta):
+def test_repr_1d(data_255_delta, use_dask):
 
-    cube, data = cube_and_raw(data_255_delta)
+    cube, data = cube_and_raw(data_255_delta, use_dask=use_dask)
 
     sp = cube[:,0,0]
 
@@ -628,9 +634,9 @@ def test_repr_1d(data_255_delta):
     assert 'OneDSpectrum' in sp[1:-1].__repr__()
 
 
-def test_1d_slices(data_255_delta):
+def test_1d_slices(data_255_delta, use_dask):
 
-    cube, data = cube_and_raw(data_255_delta)
+    cube, data = cube_and_raw(data_255_delta, use_dask=use_dask)
 
     sp = cube[:,0,0]
 
@@ -647,9 +653,9 @@ def test_1d_slices(data_255_delta):
                          ('min', 'max', 'std', 'mean', 'sum', 'cumsum',
                           'nansum', 'ptp', 'var'),
                         )
-def test_1d_slice_reductions(method, data_255_delta):
+def test_1d_slice_reductions(method, data_255_delta, use_dask):
 
-    cube, data = cube_and_raw(data_255_delta)
+    cube, data = cube_and_raw(data_255_delta, use_dask=use_dask)
 
     sp = cube[:,0,0]
 
@@ -664,8 +670,8 @@ def test_1d_slice_reductions(method, data_255_delta):
     assert 'OneDSpectrum' in sp[1:-1].__repr__()
 
 
-def test_1d_slice_round(data_255_delta):
-    cube, data = cube_and_raw(data_255_delta)
+def test_1d_slice_round(data_255_delta, use_dask):
+    cube, data = cube_and_raw(data_255_delta, use_dask=use_dask)
 
     sp = cube[:,0,0]
 
@@ -678,8 +684,8 @@ def test_1d_slice_round(data_255_delta):
     assert 'OneDSpectrum' in sp[1:-1].round().__repr__()
 
 
-def test_LDO_arithmetic(data_vda):
-    cube, data = cube_and_raw(data_vda)
+def test_LDO_arithmetic(data_vda, use_dask):
+    cube, data = cube_and_raw(data_vda, use_dask=use_dask)
 
     sp = cube[:,0,0]
 
@@ -688,9 +694,9 @@ def test_LDO_arithmetic(data_vda):
     assert np.all(spx2.filled_data[:].value == sp.value*2)
 
 
-def test_beam_jtok_2D(data_advs):
+def test_beam_jtok_2D(data_advs, use_dask):
 
-    cube, data = cube_and_raw(data_advs)
+    cube, data = cube_and_raw(data_advs, use_dask=use_dask)
     cube._meta['BUNIT'] = 'Jy / beam'
     cube._unit = u.Jy / u.beam
 
@@ -711,8 +717,8 @@ def test_beam_jtok_2D(data_advs):
                                    (plane.value * jtok).value)
 
 
-def test_basic_arrayness(data_adv):
-    cube, data = cube_and_raw(data_adv)
+def test_basic_arrayness(data_adv, use_dask):
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     assert cube.shape == data.shape
 
@@ -737,11 +743,11 @@ def test_basic_arrayness(data_adv):
     # assert np.all(np.ma.array(slc) == data[0,:,:])
 
 
-def test_spatial_world_extrema_2D(data_522_delta):
+def test_spatial_world_extrema_2D(data_522_delta, use_dask):
 
     hdu = fits.open(data_522_delta)[0]
 
-    cube = SpectralCube.read(hdu)
+    cube = SpectralCube.read(hdu, use_dask=use_dask)
 
     plane = cube[0]
 
@@ -753,13 +759,13 @@ def test_spatial_world_extrema_2D(data_522_delta):
 @pytest.mark.parametrize('view', (np.s_[:, :],
                                   np.s_[::2, :],
                                   np.s_[0]))
-def test_spatial_world(view, data_adv):
+def test_spatial_world(view, data_adv, use_dask):
     p = path(data_adv)
     # d = fits.getdata(p)
     # wcs = WCS(p)
     # c = SpectralCube(d, wcs)
 
-    c = SpectralCube.read(p)
+    c = SpectralCube.read(p, use_dask=use_dask)
 
     plane = c[0]
 

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -152,11 +152,11 @@ def test_catch_kernel_with_units(data_522_delta, use_dask):
 
 
 @pytest.mark.skipif('WINDOWS')
-def test_spectral_smooth_4cores(data_522_delta, use_dask):
+def test_spectral_smooth_4cores(data_522_delta):
 
     pytest.importorskip('joblib')
 
-    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
+    cube, data = cube_and_raw(data_522_delta, use_dask=False)
 
     result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4, use_memmap=True)
 

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -32,8 +32,8 @@ from . import path, utilities
 WINDOWS = sys.platform == "win32"
 
 
-def test_convolution(data_255_delta):
-    cube, data = cube_and_raw(data_255_delta)
+def test_convolution(data_255_delta, use_dask):
+    cube, data = cube_and_raw(data_255_delta, use_dask=use_dask)
 
     # 1" convolved with 1.5" -> 1.8027....
     target_beam = Beam(1.802775637731995*u.arcsec, 1.802775637731995*u.arcsec,
@@ -56,8 +56,8 @@ def test_convolution(data_255_delta):
     assert np.all(conv_cube.filled_data[1,:,:] == 0.0)
 
 
-def test_beams_convolution(data_455_delta_beams):
-    cube, data = cube_and_raw(data_455_delta_beams)
+def test_beams_convolution(data_455_delta_beams, use_dask):
+    cube, data = cube_and_raw(data_455_delta_beams, use_dask=use_dask)
 
     # 1" convolved with 1.5" -> 1.8027....
     target_beam = Beam(1.802775637731995*u.arcsec, 1.802775637731995*u.arcsec,
@@ -76,8 +76,8 @@ def test_beams_convolution(data_455_delta_beams):
                                        conv_cube.filled_data[ii,:,:].value)
 
 
-def test_beams_convolution_equal(data_522_delta_beams):
-    cube, data = cube_and_raw(data_522_delta_beams)
+def test_beams_convolution_equal(data_522_delta_beams, use_dask):
+    cube, data = cube_and_raw(data_522_delta_beams, use_dask=use_dask)
 
     # Only checking that the equal beam case is handled correctly.
     # Fake the beam in the first channel. Then ensure that the first channel
@@ -94,11 +94,11 @@ def test_beams_convolution_equal(data_522_delta_beams):
 
 
 @pytest.mark.parametrize('use_memmap', (True, False))
-def test_reproject(use_memmap, data_adv):
+def test_reproject(use_memmap, data_adv, use_dask):
 
     pytest.importorskip('reproject')
 
-    cube, data = cube_and_raw(data_adv)
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     wcs_in = WCS(cube.header)
     wcs_out = wcs_in.deepcopy()
@@ -122,9 +122,9 @@ def test_reproject(use_memmap, data_adv):
     assert result_wcs_from_header.wcs.compare(wcs_out.wcs)
 
 
-def test_spectral_smooth(data_522_delta):
+def test_spectral_smooth(data_522_delta, use_dask):
 
-    cube, data = cube_and_raw(data_522_delta)
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
 
     result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), use_memmap=False)
 
@@ -140,10 +140,10 @@ def test_spectral_smooth(data_522_delta):
                                                                 x_size=5).array,
                                    4)
 
-def test_catch_kernel_with_units(data_522_delta):
+def test_catch_kernel_with_units(data_522_delta, use_dask):
     # Passing a kernel with a unit should raise a u.UnitsError
 
-    cube, data = cube_and_raw(data_522_delta)
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
 
     with pytest.raises(u.UnitsError,
                        match="The convolution kernel should be defined without a unit."):
@@ -152,11 +152,11 @@ def test_catch_kernel_with_units(data_522_delta):
 
 
 @pytest.mark.skipif('WINDOWS')
-def test_spectral_smooth_4cores(data_522_delta):
+def test_spectral_smooth_4cores(data_522_delta, use_dask):
 
     pytest.importorskip('joblib')
 
-    cube, data = cube_and_raw(data_522_delta)
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
 
     result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4, use_memmap=True)
 
@@ -189,9 +189,9 @@ def test_spectral_smooth_4cores(data_522_delta):
                                    4)
 
 
-def test_spectral_smooth_fail(data_522_delta_beams):
+def test_spectral_smooth_fail(data_522_delta_beams, use_dask):
 
-    cube, data = cube_and_raw(data_522_delta_beams)
+    cube, data = cube_and_raw(data_522_delta_beams, use_dask=use_dask)
 
     with pytest.raises(AttributeError,
                        match=("VaryingResolutionSpectralCubes can't be "
@@ -201,9 +201,9 @@ def test_spectral_smooth_fail(data_522_delta_beams):
         cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0))
 
 
-def test_spectral_interpolate(data_522_delta):
+def test_spectral_interpolate(data_522_delta, use_dask):
 
-    cube, data = cube_and_raw(data_522_delta)
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
 
     orig_wcs = cube.wcs.deepcopy()
 
@@ -218,9 +218,9 @@ def test_spectral_interpolate(data_522_delta):
     assert cube.wcs.wcs.compare(orig_wcs.wcs)
 
 
-def test_spectral_interpolate_with_fillvalue(data_522_delta):
+def test_spectral_interpolate_with_fillvalue(data_522_delta, use_dask):
 
-    cube, data = cube_and_raw(data_522_delta)
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
 
     # Step one channel out of bounds.
     sg = ((cube.spectral_axis[0]) -
@@ -232,9 +232,9 @@ def test_spectral_interpolate_with_fillvalue(data_522_delta):
                                    np.ones(4)*42)
 
 
-def test_spectral_interpolate_fail(data_522_delta_beams):
+def test_spectral_interpolate_fail(data_522_delta_beams, use_dask):
 
-    cube, data = cube_and_raw(data_522_delta_beams)
+    cube, data = cube_and_raw(data_522_delta_beams, use_dask=use_dask)
 
     with pytest.raises(AttributeError,
                        match=("VaryingResolutionSpectralCubes can't be "
@@ -244,7 +244,7 @@ def test_spectral_interpolate_fail(data_522_delta_beams):
         cube.spectral_interpolate(5)
 
 
-def test_spectral_interpolate_with_mask(data_522_delta):
+def test_spectral_interpolate_with_mask(data_522_delta, use_dask):
 
     hdul = fits.open(data_522_delta)
     hdu = hdul[0]
@@ -252,7 +252,7 @@ def test_spectral_interpolate_with_mask(data_522_delta):
     # Swap the velocity axis so indiff < 0 in spectral_interpolate
     hdu.header["CDELT3"] = - hdu.header["CDELT3"]
 
-    cube = SpectralCube.read(hdu)
+    cube = SpectralCube.read(hdu, use_dask=use_dask)
 
     mask = np.ones(cube.shape, dtype=bool)
     mask[:2] = False
@@ -276,9 +276,9 @@ def test_spectral_interpolate_with_mask(data_522_delta):
     hdul.close()
 
 
-def test_spectral_interpolate_reversed(data_522_delta):
+def test_spectral_interpolate_reversed(data_522_delta, use_dask):
 
-    cube, data = cube_and_raw(data_522_delta)
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
 
     orig_wcs = cube.wcs.deepcopy()
 
@@ -313,9 +313,9 @@ def test_convolution_2D(data_55_delta):
 
 
 
-def test_nocelestial_convolution_2D_fail(data_255_delta):
+def test_nocelestial_convolution_2D_fail(data_255_delta, use_dask):
 
-    cube, data = cube_and_raw(data_255_delta)
+    cube, data = cube_and_raw(data_255_delta, use_dask=use_dask)
 
     proj = cube.moment0(axis=1)
 
@@ -355,11 +355,11 @@ def test_reproject_2D(data_55):
     assert result_wcs_from_header.wcs.compare(wcs_out.wcs)
 
 
-def test_nocelestial_reproject_2D_fail(data_255_delta):
+def test_nocelestial_reproject_2D_fail(data_255_delta, use_dask):
 
     pytest.importorskip('reproject')
 
-    cube, data = cube_and_raw(data_255_delta)
+    cube, data = cube_and_raw(data_255_delta, use_dask=use_dask)
 
     proj = cube.moment0(axis=1)
 
@@ -370,7 +370,11 @@ def test_nocelestial_reproject_2D_fail(data_255_delta):
 
 @pytest.mark.parametrize('use_memmap', (True,False))
 def test_downsample(use_memmap, data_255):
-    cube, data = cube_and_raw(data_255)
+
+    # FIXME: this test should be updated to use the use_dask fixture once
+    # DaskSpectralCube.downsample_axis is fixed.
+
+    cube, data = cube_and_raw(data_255, use_dask=False)
 
     dscube = cube.downsample_axis(factor=2, axis=0, use_memmap=use_memmap)
 
@@ -385,6 +389,7 @@ def test_downsample(use_memmap, data_255):
                          data[:,2:4,:].mean(axis=1),
                          data[:,4:,:].mean(axis=1), # just data[:,4,:]
                         ]).swapaxes(0,1)
+
     assert expected.shape == (2,3,5)
     assert dscube.shape == (2,3,5)
 
@@ -402,10 +407,13 @@ def test_downsample(use_memmap, data_255):
                                    dscube.filled_data[:].value)
 
 
-
 @pytest.mark.parametrize('use_memmap', (True,False))
 def test_downsample_wcs(use_memmap, data_255):
-    cube, data = cube_and_raw(data_255)
+
+    # FIXME: this test should be updated to use the use_dask fixture once
+    # DaskSpectralCube.downsample_axis is fixed.
+
+    cube, data = cube_and_raw(data_255, use_dask=False)
 
     dscube = (cube
               .downsample_axis(factor=2, axis=1, use_memmap=use_memmap)
@@ -424,6 +432,7 @@ def test_downsample_wcs(use_memmap, data_255):
     xpixnew_ypixnew = np.array(dscube.wcs.celestial.wcs_world2pix(lonold, latold, 1))
 
     np.testing.assert_almost_equal(xpixnew_ypixnew, (0.75, 0.75))
+
 
 @pytest.mark.skipif('not tracemallocOK or (sys.version_info.major==3 and sys.version_info.minor<6) or not NPY_VERSION_CHECK')
 def test_reproject_3D_memory():

--- a/spectral_cube/tests/test_spectral_axis.py
+++ b/spectral_cube/tests/test_spectral_axis.py
@@ -5,8 +5,6 @@ from astropy.io import fits
 from astropy import units as u
 from astropy import constants
 from astropy.tests.helper import pytest, assert_quantity_allclose
-import warnings
-import os
 import numpy as np
 
 from .helpers import assert_allclose
@@ -16,6 +14,7 @@ from ..spectral_axis import (convert_spectral_axis, determine_ctype_from_vconv,
                              get_rest_value_from_wcs, air_to_vac,
                              air_to_vac_deriv, vac_to_air, doppler_z,
                              doppler_gamma, doppler_beta)
+
 
 def test_cube_wcs_freqtovel():
     header = fits.Header.fromtextfile(data_path('cubewcs1.hdr'))
@@ -34,6 +33,7 @@ def test_cube_wcs_freqtovel():
     assert newwcs.wcs.crval[2] == 305.2461585938794
     assert newwcs.wcs.cunit[2] == u.Unit('km/s')
 
+
 def test_cube_wcs_freqtovopt():
     header = fits.Header.fromtextfile(data_path('cubewcs1.hdr'))
     w1 = wcs.WCS(header)
@@ -50,6 +50,7 @@ def test_cube_wcs_freqtovopt():
         convert_spectral_axis(w1, 'km/s', 'VOPT')
 
     assert exc.value.args[0] == 'If converting from wavelength/frequency to speed, a reference wavelength/frequency is required.'
+
 
 @pytest.mark.parametrize('wcstype',('Z','W','R','V'))
 def test_greisen2006(wcstype):
@@ -102,6 +103,7 @@ def test_greisen2006(wcstype):
                                    rtol=1.e-3)
     assert wcs3.wcs.ctype[wcs3.wcs.spec] == wcs0.wcs.ctype[wcs0.wcs.spec]
     assert wcs3.wcs.cunit[wcs3.wcs.spec] == wcs0.wcs.cunit[wcs0.wcs.spec]
+
 
 def test_byhand_f2v():
     # VELO-F2V
@@ -160,6 +162,7 @@ def test_byhand_f2v():
     # this should be EXACT
     assert cdeltf_computed == cdeltf_computed_byfunction
 
+
 def test_byhand_vrad():
     # VRAD
     CRVAL3F = 1.37847121643E+09
@@ -199,6 +202,7 @@ def test_byhand_vrad():
     # (<Quantity -20609.645482954576 m / s>, <Quantity -20609.645482954576 m / s>, <Quantity 94888.9338036023 Hz>, <Quantity 94888.9338036023 Hz>)
     # (Pdb) myunit,lin_cunit,out_lin_cunit,outunit
     # WRONG (Unit("m / s"), Unit("m / s"), Unit("Hz"), Unit("Hz"))
+
 
 def test_byhand_vopt():
     # VOPT: case "Z"
@@ -305,6 +309,7 @@ def test_byhand_f2w():
     assert_allclose(crvalf_computed, crvalf, rtol=0.1)
     assert_allclose(cdeltf_computed, cdeltf, rtol=0.1)
 
+
 @pytest.mark.parametrize(('ctype','unit','velocity_convention','result'),
                          (('VELO-F2V', "Hz", None, 'FREQ'),
                           ('VELO-F2V', "m", None, 'WAVE-F2W'),
@@ -329,6 +334,7 @@ def test_ctype_determinator(ctype,unit,velocity_convention,result):
         outctype = determine_ctype_from_vconv(ctype, unit,
                                               velocity_convention=velocity_convention)
         assert outctype == result
+
 
 @pytest.mark.parametrize(('ctype','vconv'),
                          (('VELO-F2W', u.doppler_optical),
@@ -446,6 +452,7 @@ def test_air_to_vac(air, vac):
     assert np.abs((vac_to_air(air_to_vac(air))-air))/air < 1e-8
     assert np.abs((air_to_vac(vac_to_air(vac))-vac))/vac < 1e-8
 
+
 def test_byhand_awav2vel():
     # AWAV
     CRVAL3A = (6560*u.AA).to(u.m).value
@@ -497,6 +504,7 @@ def test_byhand_awav2vel():
 
     np.testing.assert_almost_equal(pix_line_output, pix_line_input, decimal=4)
 
+
 def test_byhand_awav2wav():
     # AWAV
     CRVAL3A = (6560*u.AA).to(u.m).value
@@ -526,7 +534,9 @@ def test_byhand_awav2wav():
     assert not (mywcs.wcs.crval[0] == newwcs.wcs.crval[0]
                 and mywcs.wcs.crpix[0] == newwcs.wcs.crpix[0])
 
+
 class test_nir_sinfoni_base(object):
+
     def setup_method(self, method):
         CD3_3   = 0.000245000002905726 # CD rotation matrix
         CTYPE3  = 'WAVE    '           # wavelength axis in microns

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2334,6 +2334,9 @@ def test_mask_channels_preserve_mask(filename, use_dask):
 
 def test_minimal_subcube(use_dask):
 
+    if not use_dask:
+        pytest.importorskip('scipy')
+
     data = np.arange(210, dtype=float).reshape((5, 6, 7))
     data[0] = np.nan
     data[2] = np.nan

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -901,7 +901,7 @@ def test_with_mask(use_dask):
 
 def test_with_mask_with_boolean_array(use_dask):
     cube = _dummy_cube(use_dask)
-    mask = cube._data > 2
+    mask = np.random.random(cube.shape) > 0.5
     cube2 = cube.with_mask(mask, inherit_mask=False)
     assert isinstance(cube2._mask, BooleanArrayMask)
     assert cube2._mask._wcs is cube._wcs

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -107,10 +107,8 @@ def test_arithmetic_warning(data_vda_jybeam_lower, recwarn):
     assert not cube._is_huge
 
     # make sure the small cube raises a warning about loading into memory
+    with pytest.warns(UserWarning, match='requires loading the entire'):
     cube + 5*cube.unit
-    w = recwarn.list[-1]
-
-    assert 'requires loading the entire cube into' in str(w.message)
 
 
 def test_huge_disallowed(data_vda_jybeam_lower):
@@ -433,12 +431,8 @@ class TestArithmetic(object):
     # gets done first. This is an issue that should be resolved in pytest-openfiles.
 
     @pytest.fixture(autouse=True)
-    def setup_method_fixture(self, request, data_adv):
-        self.c1, self.d1 = cube_and_raw(data_adv)
-
-        # make nice easy-to-test numbers
-        self.d1.flat[:] = np.arange(self.d1.size)
-        self.c1._data.flat[:] = np.arange(self.d1.size)
+    def setup_method_fixture(self, request, data_adv_simple):
+        self.c1, self.d1 = cube_and_raw(data_adv_simple)
 
     @pytest.mark.parametrize(('value'),(1,1.0,2,2.0))
     def test_add(self,value):

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2330,3 +2330,25 @@ def test_mask_channels_preserve_mask(filename, use_dask):
     expected_mask = mask.copy()
     expected_mask[::2] = False
     np.testing.assert_equal(cube.mask.include(), expected_mask)
+
+
+def test_minimal_subcube(use_dask):
+
+    data = np.arange(210, dtype=float).reshape((5, 6, 7))
+    data[0] = np.nan
+    data[2] = np.nan
+    data[4] = np.nan
+    data[:,0] = np.nan
+    data[:,3:4] = np.nan
+    data[:, :, 0:2] = np.nan
+    data[:, :, 4:7] = np.nan
+
+    wcs = WCS(naxis=3)
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN', 'VELO-HEL']
+
+    cube = SpectralCube(data * u.Jy / u.beam, wcs=wcs, use_dask=use_dask)
+    cube = cube.with_mask(np.isfinite(data))
+
+    subcube = cube.minimal_subcube()
+
+    assert subcube.shape == (3, 5, 2)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -611,6 +611,7 @@ class TestNumpyMethods(BaseTest):
                 m[y, x] = np.median(ray)
         if use_dask:
             if iterate_rays:
+                self.c = self.d = None
                 pytest.skip()
             else:
                 scmed = self.c.median(axis=0)
@@ -656,6 +657,7 @@ class TestNumpyMethods(BaseTest):
 
         if use_dask:
             if iterate_rays:
+                self.c = self.d = None
                 pytest.skip()
             else:
                 scmed = self.c.median(axis=0)
@@ -685,6 +687,7 @@ class TestNumpyMethods(BaseTest):
 
         if use_dask:
             if iterate_rays:
+                self.c = self.d = None
                 pytest.skip()
             else:
                 scpct = self.c.percentile(pct, axis=0)
@@ -791,8 +794,11 @@ class TestYt():
 
     @pytest.fixture(autouse=True)
     def setup_method_fixture(self, request, data_adv, use_dask):
+        print("HERE")
         self.cube = SpectralCube.read(data_adv, use_dask=use_dask)
         # Without any special arguments
+        print(self.cube)
+        print(self.cube.to_yt)
         self.ytc1 = self.cube.to_yt()
         # With spectral factor = 0.5
         self.spectral_factor = 0.5
@@ -800,6 +806,7 @@ class TestYt():
         # With nprocs = 4
         self.nprocs = 4
         self.ytc3 = self.cube.to_yt(nprocs=self.nprocs)
+        print("DONE")
 
     def test_yt(self):
         # The following assertions just make sure everything is

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -265,6 +265,8 @@ class TestSpectralCube(object):
     def test_with_spectral_unit(self, filename, masktype, unit, suffix, use_dask):
 
         if suffix == '.image':
+            if not use_dask:
+                pytest.skip()
             import casatasks
             filename = str(filename)
             casatasks.importfits(filename, filename.replace('.fits', '.image'))
@@ -2090,7 +2092,7 @@ def test_smooth_update_function_parallel(capsys, data_adv):
     pytest.importorskip('joblib')
     pytest.importorskip('scipy.ndimage')
 
-    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
+    cube, data = cube_and_raw(data_adv, use_dask=False)
 
     # this is potentially a major disaster: if update_function can't be
     # pickled, it won't work, which is why update_function is (very badly)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -134,8 +134,12 @@ def test_huge_disallowed(data_vda_jybeam_lower, use_dask):
         with pytest.raises(ValueError, match='entire cube into memory'):
             cube + 5*cube.unit
 
-        with pytest.raises(ValueError, match='entire cube into memory'):
-            cube.max(how='cube')
+        if use_dask:
+            with pytest.raises(ValueError, match='entire cube into memory'):
+                cube.mad_std()
+        else:
+            with pytest.raises(ValueError, match='entire cube into memory'):
+                cube.max(how='cube')
 
         cube.allow_huge_operations = True
 

--- a/spectral_cube/tests/test_stokes_spectral_cube.py
+++ b/spectral_cube/tests/test_stokes_spectral_cube.py
@@ -20,14 +20,14 @@ class TestStokesSpectralCube():
         self.wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN', 'FREQ']
         self.data = np.arange(4)[:, None, None, None] * np.ones((5, 20, 30))
 
-    def test_direct_init(self):
-        stokes_data = dict(I=SpectralCube(self.data[0], wcs=self.wcs),
-                           Q=SpectralCube(self.data[1], wcs=self.wcs),
-                           U=SpectralCube(self.data[2], wcs=self.wcs),
-                           V=SpectralCube(self.data[3], wcs=self.wcs))
+    def test_direct_init(self, use_dask):
+        stokes_data = dict(I=SpectralCube(self.data[0], wcs=self.wcs, use_dask=use_dask),
+                           Q=SpectralCube(self.data[1], wcs=self.wcs, use_dask=use_dask),
+                           U=SpectralCube(self.data[2], wcs=self.wcs, use_dask=use_dask),
+                           V=SpectralCube(self.data[3], wcs=self.wcs, use_dask=use_dask))
         cube = StokesSpectralCube(stokes_data)
 
-    def test_direct_init_invalid_type(self):
+    def test_direct_init_invalid_type(self, use_dask):
         stokes_data = dict(I=self.data[0],
                            Q=self.data[1],
                            U=self.data[2],
@@ -36,43 +36,43 @@ class TestStokesSpectralCube():
             cube = StokesSpectralCube(stokes_data)
         assert exc.value.args[0] == "stokes_data should be a dictionary of SpectralCube objects"
 
-    def test_direct_init_invalid_shape(self):
-        stokes_data = dict(I=SpectralCube(np.ones((6, 2, 30)), wcs=self.wcs),
-                           Q=SpectralCube(self.data[1], wcs=self.wcs),
-                           U=SpectralCube(self.data[2], wcs=self.wcs),
-                           V=SpectralCube(self.data[3], wcs=self.wcs))
+    def test_direct_init_invalid_shape(self, use_dask):
+        stokes_data = dict(I=SpectralCube(np.ones((6, 2, 30)), wcs=self.wcs, use_dask=use_dask),
+                           Q=SpectralCube(self.data[1], wcs=self.wcs, use_dask=use_dask),
+                           U=SpectralCube(self.data[2], wcs=self.wcs, use_dask=use_dask),
+                           V=SpectralCube(self.data[3], wcs=self.wcs, use_dask=use_dask))
         with pytest.raises(ValueError) as exc:
             cube = StokesSpectralCube(stokes_data)
         assert exc.value.args[0] == "All spectral cubes should have the same shape"
 
     @pytest.mark.parametrize('component', ('I', 'Q', 'U', 'V', 'RR', 'RL', 'LR', 'LL'))
-    def test_valid_component_name(self, component):
-        stokes_data = {component: SpectralCube(self.data[0], wcs=self.wcs)}
+    def test_valid_component_name(self, component, use_dask):
+        stokes_data = {component: SpectralCube(self.data[0], wcs=self.wcs, use_dask=use_dask)}
         cube = StokesSpectralCube(stokes_data)
         assert cube.components == [component]
 
     @pytest.mark.parametrize('component', ('A', 'B', 'IQUV'))
-    def test_invalid_component_name(self, component):
-        stokes_data = {component: SpectralCube(self.data[0], wcs=self.wcs)}
+    def test_invalid_component_name(self, component, use_dask):
+        stokes_data = {component: SpectralCube(self.data[0], wcs=self.wcs, use_dask=use_dask)}
         with pytest.raises(ValueError) as exc:
             cube = StokesSpectralCube(stokes_data)
         assert exc.value.args[0] == "Invalid Stokes component: {0} - should be one of I, Q, U, V, RR, LL, RL, LR".format(component)
 
-    def test_invalid_wcs(self):
+    def test_invalid_wcs(self, use_dask):
         wcs2 = WCS(naxis=3)
         wcs2.wcs.ctype = ['GLON-CAR', 'GLAT-CAR', 'FREQ']
-        stokes_data = dict(I=SpectralCube(self.data[0], wcs=self.wcs),
+        stokes_data = dict(I=SpectralCube(self.data[0], wcs=self.wcs, use_dask=use_dask),
                            Q=SpectralCube(self.data[1], wcs2))
         with pytest.raises(ValueError) as exc:
             cube = StokesSpectralCube(stokes_data)
         assert exc.value.args[0] == "All spectral cubes in stokes_data should have the same WCS"
 
-    def test_attributes(self):
+    def test_attributes(self, use_dask):
         stokes_data = OrderedDict()
-        stokes_data['I'] = SpectralCube(self.data[0], wcs=self.wcs)
-        stokes_data['Q'] = SpectralCube(self.data[1], wcs=self.wcs)
-        stokes_data['U'] = SpectralCube(self.data[2], wcs=self.wcs)
-        stokes_data['V'] = SpectralCube(self.data[3], wcs=self.wcs)
+        stokes_data['I'] = SpectralCube(self.data[0], wcs=self.wcs, use_dask=use_dask)
+        stokes_data['Q'] = SpectralCube(self.data[1], wcs=self.wcs, use_dask=use_dask)
+        stokes_data['U'] = SpectralCube(self.data[2], wcs=self.wcs, use_dask=use_dask)
+        stokes_data['V'] = SpectralCube(self.data[3], wcs=self.wcs, use_dask=use_dask)
         cube = StokesSpectralCube(stokes_data)
         assert_allclose(cube.I.unmasked_data[...], 0)
         assert_allclose(cube.Q.unmasked_data[...], 1)
@@ -80,10 +80,10 @@ class TestStokesSpectralCube():
         assert_allclose(cube.V.unmasked_data[...], 3)
         assert cube.components == ['I', 'Q', 'U', 'V']
 
-    def test_dir(self):
-        stokes_data = dict(I=SpectralCube(self.data[0], wcs=self.wcs),
-                           Q=SpectralCube(self.data[1], wcs=self.wcs),
-                           U=SpectralCube(self.data[2], wcs=self.wcs))
+    def test_dir(self, use_dask):
+        stokes_data = dict(I=SpectralCube(self.data[0], wcs=self.wcs, use_dask=use_dask),
+                           Q=SpectralCube(self.data[1], wcs=self.wcs, use_dask=use_dask),
+                           U=SpectralCube(self.data[2], wcs=self.wcs, use_dask=use_dask))
         cube = StokesSpectralCube(stokes_data)
 
         attributes = dir(cube)
@@ -95,49 +95,49 @@ class TestStokesSpectralCube():
         assert 'wcs' in attributes
         assert 'shape' in attributes
 
-    def test_mask(self):
+    def test_mask(self, use_dask):
 
         with NumpyRNGContext(12345):
             mask1 = BooleanArrayMask(np.random.random((5, 20, 30)) > 0.2, wcs=self.wcs)
             # Deliberately don't use a BooleanArrayMask to check auto-conversion
             mask2 = np.random.random((5, 20, 30)) > 0.4
 
-        stokes_data = dict(I=SpectralCube(self.data[0], wcs=self.wcs),
-                           Q=SpectralCube(self.data[1], wcs=self.wcs),
-                           U=SpectralCube(self.data[2], wcs=self.wcs),
-                           V=SpectralCube(self.data[3], wcs=self.wcs))
+        stokes_data = dict(I=SpectralCube(self.data[0], wcs=self.wcs, use_dask=use_dask),
+                           Q=SpectralCube(self.data[1], wcs=self.wcs, use_dask=use_dask),
+                           U=SpectralCube(self.data[2], wcs=self.wcs, use_dask=use_dask),
+                           V=SpectralCube(self.data[3], wcs=self.wcs, use_dask=use_dask))
         cube1 = StokesSpectralCube(stokes_data, mask=mask1)
 
         cube2 = cube1.with_mask(mask2)
         assert_equal(cube2.mask.include(), (mask1).include() & mask2)
 
-    def test_mask_invalid_component_name(self):
-        stokes_data = {'BANANA': SpectralCube(self.data[0], wcs=self.wcs)}
+    def test_mask_invalid_component_name(self, use_dask):
+        stokes_data = {'BANANA': SpectralCube(self.data[0], wcs=self.wcs, use_dask=use_dask)}
         with pytest.raises(ValueError) as exc:
             cube = StokesSpectralCube(stokes_data)
         assert exc.value.args[0] == "Invalid Stokes component: BANANA - should be one of I, Q, U, V, RR, LL, RL, LR"
 
-    def test_mask_invalid_shape(self):
-        stokes_data = dict(I=SpectralCube(self.data[0], wcs=self.wcs),
-                           Q=SpectralCube(self.data[1], wcs=self.wcs),
-                           U=SpectralCube(self.data[2], wcs=self.wcs),
-                           V=SpectralCube(self.data[3], wcs=self.wcs))
+    def test_mask_invalid_shape(self, use_dask):
+        stokes_data = dict(I=SpectralCube(self.data[0], wcs=self.wcs, use_dask=use_dask),
+                           Q=SpectralCube(self.data[1], wcs=self.wcs, use_dask=use_dask),
+                           U=SpectralCube(self.data[2], wcs=self.wcs, use_dask=use_dask),
+                           V=SpectralCube(self.data[3], wcs=self.wcs, use_dask=use_dask))
         mask1 = BooleanArrayMask(np.random.random((5, 20, 15)) > 0.2, wcs=self.wcs)
         with pytest.raises(ValueError) as exc:
             cube1 = StokesSpectralCube(stokes_data, mask=mask1)
         assert exc.value.args[0] == "Mask shape is not broadcastable to data shape: (5, 20, 15) vs (5, 20, 30)"
 
-    def test_separate_mask(self):
+    def test_separate_mask(self, use_dask):
 
         with NumpyRNGContext(12345):
             mask1 = BooleanArrayMask(np.random.random((5, 20, 30)) > 0.2, wcs=self.wcs)
             mask2 = [BooleanArrayMask(np.random.random((5, 20, 30)) > 0.4, wcs=self.wcs) for i in range(4)]
             mask3 = BooleanArrayMask(np.random.random((5, 20, 30)) > 0.2, wcs=self.wcs)
 
-        stokes_data = dict(I=SpectralCube(self.data[0], wcs=self.wcs, mask=mask2[0]),
-                           Q=SpectralCube(self.data[1], wcs=self.wcs, mask=mask2[1]),
-                           U=SpectralCube(self.data[2], wcs=self.wcs, mask=mask2[2]),
-                           V=SpectralCube(self.data[3], wcs=self.wcs, mask=mask2[3]))
+        stokes_data = dict(I=SpectralCube(self.data[0], wcs=self.wcs, mask=mask2[0], use_dask=use_dask),
+                           Q=SpectralCube(self.data[1], wcs=self.wcs, mask=mask2[1], use_dask=use_dask),
+                           U=SpectralCube(self.data[2], wcs=self.wcs, mask=mask2[2], use_dask=use_dask),
+                           V=SpectralCube(self.data[3], wcs=self.wcs, mask=mask2[3], use_dask=use_dask))
 
         cube1 = StokesSpectralCube(stokes_data, mask=mask1)
 

--- a/spectral_cube/tests/test_subcubes.py
+++ b/spectral_cube/tests/test_subcubes.py
@@ -26,9 +26,9 @@ except ImportError:
     scipyOK = False
 
 
-def test_subcube(data_advs):
+def test_subcube(data_advs, use_dask):
 
-    cube, data = cube_and_raw(data_advs)
+    cube, data = cube_and_raw(data_advs, use_dask=use_dask)
 
     sc1 = cube.subcube(xlo=1, xhi=3)
     sc2 = cube.subcube(xlo=24.06269*u.deg, xhi=24.06206*u.deg)
@@ -61,9 +61,9 @@ def test_subcube(data_advs):
 @pytest.mark.parametrize('regfile',
                          ('255-fk5.reg', '255-pixel.reg'),
                         )
-def test_ds9region_255(regfile, data_255):
+def test_ds9region_255(regfile, data_255, use_dask):
     # specific test for correctness
-    cube, data = cube_and_raw(data_255)
+    cube, data = cube_and_raw(data_255, use_dask=use_dask)
 
     shapelist = regions.read_ds9(path(regfile))
 
@@ -85,8 +85,8 @@ def test_ds9region_255(regfile, data_255):
                               ('partial_overlap_fk5.reg', (slice(None), 1, 1)),
                               ('no_overlap_fk5.reg', ValueError),
                               ))
-def test_ds9region_new(regfile, result, data_adv):
-    cube, data = cube_and_raw(data_adv)
+def test_ds9region_new(regfile, result, data_adv, use_dask):
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
     regionlist = regions.read_ds9(path(regfile))
 
@@ -112,8 +112,8 @@ def test_ds9region_new(regfile, result, data_adv):
 @pytest.mark.skipif('not scipyOK', reason='Could not import scipy')
 @pytest.mark.skipif('not regionsOK', reason='Could not import regions')
 @pytest.mark.skipif('not REGIONS_GT_03', reason='regions version should be >= 0.3')
-def test_regions_spectral(data_adv):
-    cube, data = cube_and_raw(data_adv)
+def test_regions_spectral(data_adv, use_dask):
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
     rf_cube = get_rest_value_from_wcs(cube.wcs).to("GHz",
                                                          equivalencies=u.spectral())
 

--- a/spectral_cube/tests/test_visualization.py
+++ b/spectral_cube/tests/test_visualization.py
@@ -7,16 +7,16 @@ from .test_spectral_cube import cube_and_raw
 
 
 @pytest.mark.openfiles_ignore
-def test_projvis(data_vda_jybeam_lower):
+def test_projvis(data_vda_jybeam_lower, use_dask):
     pytest.importorskip('matplotlib')
-    cube, data = cube_and_raw(data_vda_jybeam_lower)
+    cube, data = cube_and_raw(data_vda_jybeam_lower, use_dask=use_dask)
     mom0 = cube.moment0()
     mom0.quicklook(use_aplpy=False)
 
 
-def test_proj_imshow(data_vda_jybeam_lower):
+def test_proj_imshow(data_vda_jybeam_lower, use_dask):
     plt = pytest.importorskip('matplotlib.pyplot')
-    cube, data = cube_and_raw(data_vda_jybeam_lower)
+    cube, data = cube_and_raw(data_vda_jybeam_lower, use_dask=use_dask)
     mom0 = cube.moment0()
     if LooseVersion(plt.matplotlib.__version__) < LooseVersion('2.1'):
         # imshow is now only compatible with more recent versions of matplotlib
@@ -27,28 +27,28 @@ def test_proj_imshow(data_vda_jybeam_lower):
 
 
 @pytest.mark.openfiles_ignore
-def test_projvis_aplpy(tmp_path, data_vda_jybeam_lower):
+def test_projvis_aplpy(tmp_path, data_vda_jybeam_lower, use_dask):
     pytest.importorskip('aplpy')
-    cube, data = cube_and_raw(data_vda_jybeam_lower)
+    cube, data = cube_and_raw(data_vda_jybeam_lower, use_dask=use_dask)
     mom0 = cube.moment0()
     mom0.quicklook(use_aplpy=True, filename=tmp_path / 'test.png')
 
 
-def test_mask_quicklook(data_vda_jybeam_lower):
+def test_mask_quicklook(data_vda_jybeam_lower, use_dask):
     pytest.importorskip('aplpy')
-    cube, data = cube_and_raw(data_vda_jybeam_lower)
+    cube, data = cube_and_raw(data_vda_jybeam_lower, use_dask=use_dask)
     cube.mask.quicklook(view=(0, slice(None), slice(None)), use_aplpy=True)
 
 
 @pytest.mark.openfiles_ignore
-def test_to_glue(data_vda_jybeam_lower):
+def test_to_glue(data_vda_jybeam_lower, use_dask):
     pytest.importorskip('glue')
-    cube, data = cube_and_raw(data_vda_jybeam_lower)
+    cube, data = cube_and_raw(data_vda_jybeam_lower, use_dask=use_dask)
     cube.to_glue(start_gui=False)
 
 
 @pytest.mark.openfiles_ignore
-def test_to_pvextractor(data_vda_jybeam_lower):
+def test_to_pvextractor(data_vda_jybeam_lower, use_dask):
     pytest.importorskip('pvextractor')
-    cube, data = cube_and_raw(data_vda_jybeam_lower)
+    cube, data = cube_and_raw(data_vda_jybeam_lower, use_dask=use_dask)
     cube.to_pvextractor()

--- a/spectral_cube/tests/utilities.py
+++ b/spectral_cube/tests/utilities.py
@@ -58,7 +58,8 @@ def generate_gaussian_cube(shape=(100, 25, 25), sigma=8., amp=1.,
                            beamfwhm=3 * u.arcsec,
                            v0=None,
                            vel_surface=None,
-                           seed=247825498):
+                           seed=247825498,
+                           use_dask=None):
     '''
     Generate a SpectralCube with Gaussian profiles.
 
@@ -106,7 +107,7 @@ def generate_gaussian_cube(shape=(100, 25, 25), sigma=8., amp=1.,
     test_hdu = generate_hdu(test_cube, pixel_scale, spec_scale, beamfwhm,
                             spec_inds[0] + v0)
 
-    spec_cube = SpectralCube.read(test_hdu)
+    spec_cube = SpectralCube.read(test_hdu, use_dask=use_dask)
 
     mean_positions = mean_positions * spec_scale.unit
 


### PR DESCRIPTION
I started working on https://github.com/radio-astro-tools/spectral-cube/pull/567 but I found that we can probably implement dask support in a simpler way that is not mixed in with the joblib-related code, so I decided to start a new PR and go through and systematically implement all methods/properties.

Here are all the methods/properties that exist on ``SpectralCube``, and I'll check them if they are done or score them out if they don't need to be overridden:

<details>

* [x] apply_function
* [x] apply_function_parallel_spatial
* [x] apply_function_parallel_spectral
* [x] apply_numpy_function
* [x] argmax
* [x] argmin
* [x] <s>base</s> (not needed, only existed for joblib)
* [x] <s>beam</s> (unrelated to data array)
* [x] <s>chunked</s> (``NotImplemented`` for SpectralCube)
* [x] <s>closest_spectral_channel</s> (unrelated to data array)
* [x] convolve_to
* [x] downsample_axis
* [x] <s>fill_value</s> (unrelated to data array)
* [ ] filled
* [x] filled_data
* [x] <s>find_lines</s> (unrelated to data array)
* [x] flattened
* [x] <s>flattened_world</s> (wrapper around ``world``)
* [x] get_mask_array
* [x] hdu
* [x] <s>hdulist</s> (thin wrapper around ``hdu``)
* [x] <s>header</s>
* [x] <s>latitude_extrema</s> (wrapper around ``world_extrema``)
* [x] <s>linewidth_fwhm</s> (wrapper around ``linewidth_sigma``)
* [x] <s>linewidth_sigma</s> (wrapper around ``moment2``)
* [x] <s>longitude_extrema</s> (wrapper around ``world_extrema``)
* [x] mad_std
* [x] <s>mask</s> (unrelated to data array)
* [x] <s>mask_channels</s> (wrapper around ``with_mask``)
* [x] max
* [x] mean
* [x] median
* [x] <s>meta</s> (unrelated to data array)
* [x] min
* [x] <s>minimal_subcube</s> (wrapper around ``subcube_slices_from_mask`` and ``__getitem__``)
* [x] moment
* [x] <s>moment0</s> (wrapper around ``moment``)
* [x] <s>moment1</s> (wrapper around ``moment``)
* [x] <s>moment2</s> (wrapper around ``moment``)
* [x] <s>ndim</s> (works because dask array exposes this too)
* [x] percentile
* [x] <s>pixels_per_beam</s> (unrelated to data array)
* [x] plot_channel_maps
* [x] read
* [ ] reproject
* [x] <s>shape</s> (works because dask array exposes this too)
* [x] sigma_clip_spectrally
* [x] <s>size</s> (works because dask array exposes this too)
* [x] <s>spatial_coordinate_map</s> (wrapper around ``world``)
* [x] spatial_smooth
* [x] spatial_smooth_median
* [x] <s>spectral_axis</s> (wrapper around ``world``)
* [x] <s>spectral_extrema</s> (wrapper around ``spectral_axis``)
* [x] spectral_interpolate
* [x] <s>spectral_slab</s> (only uses slicing which should work with dask)
* [x] spectral_smooth
* [x] spectral_smooth_median
* [x] std
* [x] <s>subcube</s> (wrapper around ``__getitem__``)
* [x] subcube_from_crtfregion
* [x] subcube_from_ds9region
* [x] <s>subcube_from_mask</s> (wrapper around ``subcube_slices_from_mask``)
* [x] subcube_from_regions
* [x] subcube_slices_from_mask
* [x] sum
* [x] <s>to</s> (wrapper around ``_new_cube_with``)
* [ ] to_ds9
* [x] <s>to_glue</s> (works as-is)
* [x] <s>to_pvextractor</s> (works as-is)
* [ ] to_yt
* [x] <s>unit</s> (unrelated to data array)
* [x] <s>unitless</s> (wrapper around ``_new_cube_with``)
* [x] unitless_filled_data
* [x] unmasked_copy
* [x] unmasked_data
* [x] <s>velocity_convention</s> (unrelated to data array)
* [x] <s>wcs</s> (unrelated to data array)
* [x] <s>with_beam</s> (keeps data as-is)
* [x] <s>with_fill_value</s> (keeps data as-is)
* [x] <s>with_mask</s> (keeps data as-is)
* [x] <s>with_spectral_unit</s> (keeps data as-is)
* [x] world
* [x] <s>world_extrema</s> (wrapper around ``shape`` and ``wcs``)
* [x] world_spines (``NotImplemented`` for SpectralCube)
* [x] write

</details>

In addition to this, I will need to:

* [x] Make sure ``DaskSpectralCube.read/write`` work as expected
* [x] Determine how to deal with the varying beam spectral cube class
* [x] Update tests to try both the plain and the dask class
* [x] Do systematic benchmarking of performance
* [x] Make sure parallel versions are efficient