### PR TITLE
Fix for issue 635: check whether `self.mask` exists before using it

### DIFF
--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -733,10 +733,7 @@ class MultiBeamMixinClass(object):
 
         use_dask = isinstance(self._data, da.Array)
         if use_dask:
-            # is this the right way?  Or should it be `BooleanArrayMask(self._mask_include) & includemask?
-            newmask = da.logical_and(BooleanArrayMask(self._mask_include,
-                                                      wcs=self._wcs,
-                                                      shape=self._data.shape),
+            newmask = da.logical_and(self._mask_include,
                                      includemask)
         elif self.mask is None:
             newmask = includemask

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -588,7 +588,8 @@ class MultiBeamMixinClass(object):
                 beam_mask = da.any(da.logical_and(self._mask_include,
                                                   self.goodbeams_mask[:, None, None]),
                                    axis=(1, 2))
-                beam_mask = self._compute(beam_mask)
+                # da.any appears to return an object dtype instead of a bool
+                beam_mask = self._compute(beam_mask).astype('bool')
             elif self.mask is not None:
                 beam_mask = np.any(np.logical_and(self.mask.include(),
                                                   self.goodbeams_mask[:, None, None]),

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -733,7 +733,10 @@ class MultiBeamMixinClass(object):
 
         use_dask = isinstance(self._data, da.Array)
         if use_dask:
-            newmask = da.logical_and(self._mask_include, includemask)
+            newmask = BooleanArrayMask(da.logical_and(self._mask_include, includemask),
+                                       wcs=self._wcs,
+                                       shape=self._data.shape
+                                      )
         elif self.mask is None:
             newmask = includemask
         else:

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -728,8 +728,9 @@ class MultiBeamMixinClass(object):
         includemask = BooleanArrayMask(goodbeams[:,None,None],
                                        self._wcs,
                                        shape=self._data.shape)
+        newmask = includemask if self.mask is None else np.bitwise_and(self.mask, includemask)
 
-        return self._new_thing_with(mask=np.bitwise_and(self.mask, includemask),
+        return self._new_thing_with(mask=newmask,
                                     beam_threshold=threshold,
                                     goodbeams_mask=np.bitwise_and(self.goodbeams_mask, goodbeams),
                                    )

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -733,10 +733,11 @@ class MultiBeamMixinClass(object):
 
         use_dask = isinstance(self._data, da.Array)
         if use_dask:
-            newmask = BooleanArrayMask(da.logical_and(self._mask_include, includemask),
+            # is this the right way?  Or should it be `BooleanArrayMask(self._mask_include) & includemask?
+            newmask = da.logical_and(BooleanArrayMask(self._mask_include,
                                        wcs=self._wcs,
                                        shape=self._data.shape
-                                      )
+                                      ), includemask)
         elif self.mask is None:
             newmask = includemask
         else:

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -735,9 +735,9 @@ class MultiBeamMixinClass(object):
         if use_dask:
             # is this the right way?  Or should it be `BooleanArrayMask(self._mask_include) & includemask?
             newmask = da.logical_and(BooleanArrayMask(self._mask_include,
-                                       wcs=self._wcs,
-                                       shape=self._data.shape
-                                      ), includemask)
+                                                      wcs=self._wcs,
+                                                      shape=self._data.shape),
+                                     includemask)
         elif self.mask is None:
             newmask = includemask
         else:

--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -299,9 +299,9 @@ def data_vda_beams_image(tmp_path):
                 outfile=tmp_path / 'vda_beams.image',
                 overwrite=True)
     for (bmaj, bmin, bpa, chan, pol) in beams.data:
-        ia.setrestoringbeam(major=bmaj,
-                            minor=bmin,
-                            pa=bpa,
+        ia.setrestoringbeam(major={'unit': 'arcsec', 'value': bmaj},
+                            minor={'unit': 'arcsec', 'value': bmin},
+                            pa={'unit': 'deg', 'value': bpa},
                             channel=chan,
                             polarization=pol)
     ia.close()

--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -298,6 +298,12 @@ def data_vda_beams_image(tmp_path):
     ia.fromfits(infile=tmp_path / 'vda_beams.fits',
                 outfile=tmp_path / 'vda_beams.image',
                 overwrite=True)
+    for (bmaj, bmin, bpa, chan, pol) in beams.data:
+        ia.setrestoringbeams(major=bmaj,
+                             minor=bmin,
+                             pa=bpa,
+                             channel=chan,
+                             polarization=pol)
     ia.close()
     return tmp_path / 'vda_beams.image'
 

--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -299,11 +299,11 @@ def data_vda_beams_image(tmp_path):
                 outfile=tmp_path / 'vda_beams.image',
                 overwrite=True)
     for (bmaj, bmin, bpa, chan, pol) in beams.data:
-        ia.setrestoringbeams(major=bmaj,
-                             minor=bmin,
-                             pa=bpa,
-                             channel=chan,
-                             polarization=pol)
+        ia.setrestoringbeam(major=bmaj,
+                            minor=bmin,
+                            pa=bpa,
+                            channel=chan,
+                            polarization=pol)
     ia.close()
     return tmp_path / 'vda_beams.image'
 

--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -282,6 +282,26 @@ def data_vda_beams(tmp_path):
     return tmp_path / 'vda_beams.fits'
 
 
+@pytest.fixture
+def data_vda_beams_image(tmp_path):
+    d, h = prepare_adv_data()
+    d, h = transpose(d, h, [2, 0, 1])
+    d, h = transpose(d, h, [2, 1, 0])
+    h['BUNIT'] = ' Jy / beam '
+    del h['BMAJ'], h['BMIN'], h['BPA']
+    beams = prepare_4_beams()
+    hdul = fits.HDUList([fits.PrimaryHDU(data=d, header=h),
+                         beams])
+    hdul.writeto(tmp_path / 'vda_beams.fits')
+    from casatools import image
+    ia = image()
+    ia.fromfits(infile=tmp_path / 'vda_beams.fits',
+                outfile=tmp_path / 'vda_beams.image',
+                overwrite=True)
+    ia.close()
+    return tmp_path / 'vda_beams.image'
+
+
 def prepare_255_header():
     # make a version with spatial pixels
     h = fits.header.Header.fromtextfile(HEADER_FILENAME)

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -1511,5 +1511,8 @@ class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolution
 
     @property
     def _mask_include(self):
-        # TODO: should this return a BooleanArrayMask?
-        return da.from_array(MaskHandler(self), name='MaskHandler ' + str(uuid.uuid4()), chunks=self._data.chunksize)
+        return BooleanArrayMask(da.from_array(MaskHandler(self),
+                                              name='MaskHandler ' + str(uuid.uuid4()),
+                                              chunks=self._data.chunksize),
+                                wcs=self.wcs,
+                                shape=self.shape)

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -1511,4 +1511,5 @@ class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolution
 
     @property
     def _mask_include(self):
+        # TODO: should this return a BooleanArrayMask?
         return da.from_array(MaskHandler(self), name='MaskHandler ' + str(uuid.uuid4()), chunks=self._data.chunksize)

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -7,7 +7,6 @@ import warnings
 from astropy.io import fits
 from astropy.io import registry as io_registry
 import astropy.wcs
-from astropy import wcs
 from astropy.wcs import WCS
 from collections import OrderedDict
 from astropy.io.fits.hdu.hdulist import fitsopen as fits_open
@@ -183,9 +182,8 @@ def load_fits_cube(input, hdu=0, meta=None, target_cls=None, use_dask=False, **k
         if beam_table is None:
             cube = SC(data, wcs, mask, meta=meta, header=header)
         else:
-            cube = VRSC(data, wcs, mask, meta=meta,
-                                                 header=header,
-                                                 beam_table=beam_table)
+            cube = VRSC(data, wcs, mask, meta=meta, header=header,
+                        beam_table=beam_table)
 
         if hasattr(cube._mask, '_data'):
             # check that the shape matches if there is a shape

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -264,6 +264,10 @@ class MaskBase(object):
     def size(self):
         return np.product(self.shape)
 
+    @property
+    def dtype(self):
+        return np.dtype('bool')
+
     def __getitem__(self):
         raise NotImplementedError("Slicing not supported by mask class {0}"
                                   .format(self.__class__.__name__))

--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -256,6 +256,14 @@ class MaskBase(object):
         raise NotImplementedError("{0} mask classes do not have shape attributes."
                                   .format(self.__class__.__name__))
 
+    @property
+    def ndim(self):
+        return len(self.shape)
+
+    @property
+    def size(self):
+        return np.product(self.shape)
+
     def __getitem__(self):
         raise NotImplementedError("Slicing not supported by mask class {0}"
                                   .format(self.__class__.__name__))

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1880,13 +1880,16 @@ def test_varyres_moment_logic_issue364(data_vda_beams, use_dask):
     assert_quantity_allclose(m0.meta['beam'].major, 0.35*u.arcsec)
 
 
-def test_mask_bad_beams(data_vda_beams, use_dask):
+@pytest.mark.parametrize('filename', ['data_vda_beams',
+                                      'data_vda_beams_image'],
+                         indirect=['filename'])
+def test_mask_bad_beams(filename, use_dask):
     """
     Prior to #543, this tested two different scenarios of beam masking.  After
     that, the tests got mucked up because we can no longer have minor>major in
     the beams.
     """
-    cube, data = cube_and_raw(data_vda_beams, use_dask=use_dask)
+    cube, data = cube_and_raw(filename, use_dask=use_dask)
 
     # make sure all of the beams are initially good (finite)
     assert np.all(cube.goodbeams_mask)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1890,6 +1890,9 @@ def test_mask_bad_beams(filename, use_dask):
     that, the tests got mucked up because we can no longer have minor>major in
     the beams.
     """
+    if 'image' in filename and not use_dask:
+        pytest.skip()
+
     cube, data = cube_and_raw(filename, use_dask=use_dask)
 
     # make sure all of the beams are initially good (finite)
@@ -2382,7 +2385,7 @@ def test_mask_none(use_dask):
 
 
 @pytest.mark.parametrize('filename', ['data_vda', 'data_vda_beams'],
-                            indirect=['filename'])
+                         indirect=['filename'])
 def test_mask_channels_preserve_mask(filename, use_dask):
 
     # Regression test for a bug that caused the mask to not be preserved.

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1895,6 +1895,8 @@ def test_mask_bad_beams(filename, use_dask):
 
     cube, data = cube_and_raw(filename, use_dask=use_dask)
 
+    assert isinstance(cube, base_class.MultiBeamMixinClass)
+
     # make sure all of the beams are initially good (finite)
     assert np.all(cube.goodbeams_mask)
     # make sure cropping the cube maintains the mask

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1890,7 +1890,7 @@ def test_mask_bad_beams(filename, use_dask):
     that, the tests got mucked up because we can no longer have minor>major in
     the beams.
     """
-    if 'image' in filename and not use_dask:
+    if 'image' in str(filename) and not use_dask:
         pytest.skip()
 
     cube, data = cube_and_raw(filename, use_dask=use_dask)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1880,6 +1880,7 @@ def test_varyres_moment_logic_issue364(data_vda_beams, use_dask):
     assert_quantity_allclose(m0.meta['beam'].major, 0.35*u.arcsec)
 
 
+@pytest.mark.skipif('not casaOK')
 @pytest.mark.parametrize('filename', ['data_vda_beams',
                                       'data_vda_beams_image'],
                          indirect=['filename'])


### PR DESCRIPTION
Corrects an error where some dask cubes can have `None` masks, causing errors.

It's unclear whether this is the right fix; a more appropriate fix might be to
systematically ensure that mask is never None