### PR TITLE
ONLY use the Jy<->K factors when converting to K!

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -3968,7 +3968,7 @@ class VaryingResolutionSpectralCube(BaseSpectralCube, MultiBeamMixinClass):
             # No copying
             return self
 
-        if self.unit.is_equivalent(u.Jy/u.beam):
+        if self.unit.is_equivalent(u.Jy/u.beam) and unit.is_equivalent(u.K):
             # replace "beam" with the actual beam
             if not hasattr(self, 'beams'):
                 raise ValueError("To convert cubes with Jy/beam units, "

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1729,6 +1729,21 @@ def test_varyres_moment(data_vda_beams, use_dask):
     assert_quantity_allclose(m0.meta['beam'].major, 0.35*u.arcsec)
 
 
+def test_varyres_unitconversion_roundtrip(data_vda_beams, use_dask):
+    cube, data = cube_and_raw(data_vda_beams, use_dask=use_dask)
+
+    assert isinstance(cube, VaryingResolutionSpectralCube)
+
+    assert cube.unit == u.Jy/u.beam
+    roundtrip = cube.to(u.mJy/u.beam).to(u.Jy/u.beam)
+    assert np.all(cube.filled_data[:] == roundtrip.filled_data[:])
+
+    roundtrip_K = cube.to(u.K).to(u.Jy/u.beam)
+    np.testing.assert_almost_equal(roundtrip_K.filled_data[:],
+                                   cube.filled_data[:])
+
+
+
 def test_append_beam_to_hdr(data_advs, use_dask):
 
     cube, data = cube_and_raw(data_advs, use_dask=use_dask)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1736,12 +1736,11 @@ def test_varyres_unitconversion_roundtrip(data_vda_beams, use_dask):
 
     assert cube.unit == u.Jy/u.beam
     roundtrip = cube.to(u.mJy/u.beam).to(u.Jy/u.beam)
-    assert np.all(cube.filled_data[:] == roundtrip.filled_data[:])
+    assert_quantity_allclose(cube.filled_data[:], roundtrip.filled_data[:])
 
-    roundtrip_K = cube.to(u.K).to(u.Jy/u.beam)
-    np.testing.assert_almost_equal(roundtrip_K.filled_data[:],
-                                   cube.filled_data[:])
-
+    # you can't straightforwardly roundtrip to Jy/beam yet
+    # it requires a per-beam equivalency, which is why there's
+    # a specific hack to go from Jy/beam (in each channel) -> K
 
 
 def test_append_beam_to_hdr(data_advs, use_dask):


### PR DESCRIPTION
Serious bug discovered by @djeff1887.  If you convert Jy/beam to a self-equivalent unit, like mJy/beam or Jy/sr, it will convert using the Jy<->K equivalency factors, which is not at all what is intended.