### PR TITLE
bugfix: writeto function with overwrite does not work

### DIFF
--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -235,7 +235,7 @@ def write_fits_cube(cube, filename, overwrite=False,
             hdulist[0].header.add_history("Written by spectral_cube v{version} on "
                                         "{date}".format(version=SPECTRAL_CUBE_VERSION,
                                                         date=now))
-        hdulist.writeto(filename)
+        hdulist.writeto(filename, overwrite=overwrite)
     else:
         raise NotImplementedError()
 


### PR DESCRIPTION
Dear developers, 
The current version of spectral_cube seems could not overwrite fits cubes when calling the writeto function with overwrite=True. The issue is because in "spectral_cube/io/fits.py", inside `def write_fits_cube`, the `overwrite` argument is not passed to the called function `hdulist.writeto`. A simple fix is done within this pull request. 
Thanks for having a look. 