### PR TITLE
Update package name to 'spectral-cube' in template

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,7 @@ version = release = get_distribution(setup_cfg['name']).version
 
 
 html_theme_options = {
-    'logotext1': 'packagename',  # white,  semi-bold
+    'logotext1': 'spectral-cube',  # white,  semi-bold
     'logotext2': '',  # orange, light
     'logotext3': ':docs'   # white,  light
     }


### PR DESCRIPTION
Currently for the docs hosted online it says `packagename` in the top nav bar where it should be `spectral-cube`, or something similar. 