### PR TITLE
WIP: Change LDOs to use masked products by default

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -383,7 +383,7 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass,
         fill_value = self._fill_value if fill_value is None else fill_value
 
         if beam is None:
-            if hasattr(self, 'beam'):
+            if self._beam is not None:
                 beam = self.beam
 
         newproj = self.__class__(value=data, wcs=wcs, mask=mask, meta=meta,

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -790,3 +790,26 @@ def test_spatial_world(view, data_adv, use_dask):
     for result, expected in zip(w2_flat, world):
         print(result.shape, expected.flatten().shape)
         assert_allclose(result, expected.flatten())
+
+
+def test_LDO_fill_value():
+    new_quant = twelve_qty_2d.copy()
+
+    new_quant[0, :] = np.NaN
+
+    proj = Projection(new_quant)
+
+    proj_fill0 = proj.with_fill_value(0.)
+
+    assert (np.isfinite(new_quant) == np.isfinite(proj)).all()
+
+    # Try using the filled data.
+    assert proj_fill0.fill_value == 0.0
+
+    assert np.isfinite(proj._get_filled_data(fill=0.)).all()
+
+    assert np.isfinite(proj_fill0.filled_data[:]).all()
+    assert np.isfinite(proj_fill0.unitless_filled_data[:]).all()
+
+    assert np.isfinite(proj_fill0.quantity).all()
+    assert np.isfinite(proj_fill0.value).all()


### PR DESCRIPTION
This supersedes the first attempts in #540. 

Our issue stems from subclassing `u.Quantity` for all LDOs (Projection, Slice, OneDSpectrum) while trying to use the masking routines built for spectral-cube (`LDO.filled_data[:]`, `LDO._get_filled_data(np.NaN)`).

Basically `LDO.filled_data[:]` should be used by default for `LDO[slice]`, `LDO.value`, `LDO.quantity`, etc. as this matches the behaviour used for `SpectralCube`. But this interferes with how we currently have `u.Quantity` subclassed.