### PR TITLE
Added initial implementation of global 'single-pass' statistics

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@
 - Add new dask-friendly classes ``DaskSpectralCube`` and
   ``DaskVaryingResolutionSpectralCube`` which use dask to efficiently
   carry out calculations. #618
+- Add new ``statistics`` method on ``DaskSpectralCube`` which allows
+  several global statistics to be computed by loading each cube chunk
+  only once. #663
 
 0.4.5 (unreleased)
 ------------------

--- a/docs/dask.rst
+++ b/docs/dask.rst
@@ -238,3 +238,25 @@ needs to include ``axis=0`` in the call to :func:`~astropy.stats.sigma_clip` as 
     [########################################] | 100% Completed | 56.8s
 
 This leads to an improvement in performance of 1.8x in this case.
+
+Efficient global statistics
+---------------------------
+
+If you are interested in computing a number of global statistics (e.g. min, max, mean)
+for a whole cube, and want to avoid separate calls which would lead to the data being
+read each time, it is also possible to compute these statistics in a way that each
+chunk is accessed only once - this is done via the
+:meth:`~spectral_cube.DaskSpectralCube.statistics` method which returns a dictionary
+of statistics, which are named using the same convention as CASA's
+`ia.statistics <https://casa.nrao.edu/Release4.1.0/doc/CasaRef/image.statistics.html>`_::
+
+    >>> stats = cube.statistics()  # doctest: +IGNORE_OUTPUT
+    >>> sorted(stats)
+    ['max', 'mean', 'min', 'npts', 'rms', 'sigma', 'sum', 'sumsq']
+    >>> stats['min']
+    <Quantity -0.01408793 Jy / beam>
+    >>> stats['mean']
+    <Quantity 0.00338361 Jy / beam>
+
+This method should respect the current scheduler, so you may be able to get better performance
+with a multi-threaded scheduler.

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -719,11 +719,16 @@ class DaskSpectralCubeMixin:
 
         data = self._get_filled_data(fill=np.nan)
 
+        try:
+            from bottleneck import nanmin, nanmax, nansum
+        except ImportError:
+            from numpy import nanmin, nanmax, nansum
+
         def compute_stats(chunk, *args):
-            return np.array([np.nanmin(chunk),
-                             np.nanmax(chunk),
-                             np.nansum(chunk),
-                             np.nansum(chunk * chunk)])
+            return np.array([nanmin(chunk),
+                             nanmax(chunk),
+                             nansum(chunk),
+                             nansum(chunk * chunk)])
 
         results = da.map_blocks(compute_stats, data).compute()
 

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -730,7 +730,8 @@ class DaskSpectralCubeMixin:
                              nansum(chunk),
                              nansum(chunk * chunk)])
 
-        results = da.map_blocks(compute_stats, data).compute()
+        with dask.config.set(**self._scheduler_kwargs):
+            results = da.map_blocks(compute_stats, data).compute()
 
         min_values, max_values, sum_values, ssum_values = results.reshape((-1, 4)).T
 

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -735,7 +735,7 @@ class DaskSpectralCubeMixin:
                              nansum(chunk * chunk)])
 
         with dask.config.set(**self._scheduler_kwargs):
-            results = da.map_blocks(compute_stats, data).compute()
+            results = da.map_blocks(compute_stats, data.reshape(-1)).compute()
 
         count_values, min_values, max_values, sum_values, ssum_values = results.reshape((-1, 5)).T
 

--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -100,7 +100,7 @@ def test_statistics_consistency_casa(data_adv, tmp_path):
     make_casa_testimage(data_adv, tmp_path / 'casa.image')
 
     ia = casatools.image()
-    ia.open(str(tmp_path / 'casa.mask'))
+    ia.open(str(tmp_path / 'casa.image'))
     stats_casa = ia.statistics()
     ia.close()
 

--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -77,7 +77,7 @@ def test_rechunk(data_adv):
 
 
 def test_statistics(data_adv):
-    cube = DaskSpectralCube.read(data_adv)
+    cube = DaskSpectralCube.read(data_adv).rechunk(chunks=(1, 2, 3))
     stats = cube.statistics()
     assert_quantity_allclose(stats['npts'], 24)
     assert_quantity_allclose(stats['mean'], 0.4941651776136591 * u.K)

--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -2,10 +2,23 @@
 
 import pytest
 
+from numpy.testing import assert_allclose
 from astropy.tests.helper import assert_quantity_allclose
 from astropy import units as u
 
 from spectral_cube import DaskSpectralCube
+from .test_casafuncs import make_casa_testimage
+
+try:
+    import casatools
+    from casatools import image
+    CASA_INSTALLED = True
+except ImportError:
+    try:
+        from taskinit import ia as image
+        CASA_INSTALLED = True
+    except ImportError:
+        CASA_INSTALLED = False
 
 
 class Array:
@@ -66,8 +79,30 @@ def test_rechunk(data_adv):
 def test_statistics(data_adv):
     cube = DaskSpectralCube.read(data_adv)
     stats = cube.statistics()
+    assert_quantity_allclose(stats['npts'], 24)
     assert_quantity_allclose(stats['mean'], 0.4941651776136591 * u.K)
-    assert_quantity_allclose(stats['std'], 0.3021908870982011 * u.K)
+    assert_quantity_allclose(stats['sigma'], 0.3021908870982011 * u.K)
     assert_quantity_allclose(stats['sum'], 11.85996426272782 * u.K)
+    assert_quantity_allclose(stats['sumsq'], 7.961125988022091 * u.K ** 2)
     assert_quantity_allclose(stats['min'], 0.0363300285196364 * u.K)
     assert_quantity_allclose(stats['max'], 0.9662900439556562 * u.K)
+    assert_quantity_allclose(stats['rms'], 0.5759458158839716 * u.K)
+
+
+@pytest.mark.skipif(not CASA_INSTALLED, reason='Requires CASA to be installed')
+def test_statistics_consistency_casa(data_adv, tmp_path):
+
+    # Similar to test_statistics but compares to CASA directly.
+
+    cube = DaskSpectralCube.read(data_adv)
+    stats = cube.statistics()
+
+    make_casa_testimage(data_adv, tmp_path / 'casa.image')
+
+    ia = casatools.image()
+    ia.open(str(tmp_path / 'casa.mask'))
+    stats_casa = ia.statistics()
+    ia.close()
+
+    for key in stats:
+        assert_allclose(stats[key].value, stats_casa[key])

--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+from astropy.tests.helper import assert_quantity_allclose
+from astropy import units as u
+
 from spectral_cube import DaskSpectralCube
 
 
@@ -58,3 +61,13 @@ def test_rechunk(data_adv):
     # note last element is 2 because the chunk size we asked for
     # is larger than cube - this is fine and deliberate in this test
     assert cube_new._data.chunksize == (1, 2, 2)
+
+
+def test_statistics(data_adv):
+    cube = DaskSpectralCube.read(data_adv)
+    stats = cube.statistics()
+    assert_quantity_allclose(stats['mean'], 0.4941651776136591 * u.K)
+    assert_quantity_allclose(stats['std'], 0.3021908870982011 * u.K)
+    assert_quantity_allclose(stats['sum'], 11.85996426272782 * u.K)
+    assert_quantity_allclose(stats['min'], 0.0363300285196364 * u.K)
+    assert_quantity_allclose(stats['max'], 0.9662900439556562 * u.K)

--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -105,4 +105,8 @@ def test_statistics_consistency_casa(data_adv, tmp_path):
     ia.close()
 
     for key in stats:
-        assert_allclose(stats[key].value, stats_casa[key])
+        if isinstance(stats[key], u.Quantity):
+            value = stats[key].value
+        else:
+            value = stats[key]
+        assert_allclose(value, stats_casa[key])


### PR DESCRIPTION
This is a work in progress but the idea is to address #659 by adding a ``statistics`` method which finds stats over the whole cube (so no ``axis=`` keyword) using a single pass over chunks. This means a chunk is read, and all statistics are evaluated on it before moving to the next chunk. This can mean minimizing chunk I/O.

```python
In [1]: from spectral_cube import SpectralCube                                                                                                         

In [2]: cube = SpectralCube.read('l1448_13co_small.fits', use_dask=True)                                                                               

In [3]: cube.statistics()                                                                                                                              
Out[3]: 
{'min': <Quantity -0.66045946>,
 'max': <Quantity 4.0023365>,
 'sum': <Quantity 303203.88>,
 'mean': <Quantity 0.51889595>,
 'std': <Quantity 0.57547368>}
```

This is still incomplete, in particular it needs:

* [x] Changelog entry
* [x] Tests
* [x] Other 'easy' stats, e.g. count (of non-masked items) and rms
* [x] Documention
* [ ] A more robust implementation for std
* [ ] An equivalent method on the non-dask class? (not sure about this since it wouldn't be 'efficient' in the same way as for dask)

Maybe in a separate PR we can then work on adding optional 'robust' statistics (like for CASA's ``ia.statistics``) but this requires first implementing algorithms for parallel percentiles (I have ideas about this).

In the mean time, @e-koch and @keflavich, maybe you could test this out to see if the performance is reasonable (and how it compares to CASA).