### PR TITLE
Copy all tests data in setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,10 @@ all =
     yt ; python_version<'3.8'
 
 [options.package_data]
-spectral_cube.tests = data/*
+spectral_cube.tests =
+       data/*
+       data/*/*
+
 spectral_cube.io.tests = data/*/*
 
 [upload_docs]


### PR DESCRIPTION
I needed this to get the tests running in the Debian package.

The files in the subdirectories of `tests/data` were missing, and the copy seems not to be recursive.
