### PR TITLE
Make DOI badge render properly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,5 +36,5 @@ Build and coverage status
    :target: https://travis-ci.org/radio-astro-tools/spectral-cube
 .. |Coverage Status| image:: https://coveralls.io/repos/radio-astro-tools/spectral-cube/badge.svg?branch=master
    :target: https://coveralls.io/r/radio-astro-tools/spectral-cube?branch=master
-.. |DOI| image:: https://zenodo.org/badge/doi/10.5281/zenodo.11485.png
+.. |DOI| image:: https://zenodo.org/badge/doi/10.5281/zenodo.11485.svg
    :target: http://dx.doi.org/10.5281/zenodo.11485


### PR DESCRIPTION
Currently the DOI badge has a white background and white text and is very difficult to see. This change fixes that. 
![2020-09-23 14-46-57](https://user-images.githubusercontent.com/22137276/94055978-a6545100-fdab-11ea-9d6e-ab24f652e14a.png)
![2020-09-23 14-47-22](https://user-images.githubusercontent.com/22137276/94056010-b4a26d00-fdab-11ea-9805-338c3fb8962d.png)

