### PR TITLE
Change to setup_python.sh for windows builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ install:
     # we need to use ci-helpers to set up Python.
     - if [[ $TRAVIS_OS_NAME == osx || $TRAVIS_OS_NAME == windows ]]; then
         git clone git://github.com/astropy/ci-helpers.git;
-        source ci-helpers/travis/setup_conda.sh;
+        source ci-helpers/travis/setup_python.sh;
       fi
 
 


### PR DESCRIPTION
Following astropy, change to setup_python.sh for windows builds: https://github.com/astropy/astropy/blob/master/.travis.yml#L250