### PR TITLE
Improve performance of CASA reading by combining chunks on-the-fly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ docs/api
 # Other generated stuff
 */version.py
 */cython_version.py
+.coverage*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools",
             "setuptools_scm",
+            "oldest-supported-numpy",
             "wheel"]
 build-backend = 'setuptools.build_meta'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,11 @@
 
 import os
 import sys
+
+import numpy
+
 from setuptools import setup
+from setuptools.extension import Extension
 
 TEST_HELP = """
 Note: running tests is no longer done using 'python setup.py test'. Instead
@@ -48,4 +52,7 @@ if 'build_docs' in sys.argv or 'build_sphinx' in sys.argv:
     print(DOCS_HELP)
     sys.exit(1)
 
-setup(use_scm_version={'write_to': os.path.join('spectral_cube', 'version.py')})
+setup(use_scm_version={'write_to': os.path.join('spectral_cube', 'version.py')},
+      ext_modules=[Extension("spectral_cube.io._casa_chunking",
+                             [os.path.join('spectral_cube', 'io', '_casa_chunking.c')],
+                             include_dirs=[numpy.get_include()])])

--- a/spectral_cube/io/_casa_chunking.c
+++ b/spectral_cube/io/_casa_chunking.c
@@ -1,0 +1,218 @@
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+#include <Python.h>
+#include <numpy/arrayobject.h>
+#include <numpy/npy_math.h>
+
+/* Define docstrings */
+static char module_docstring[] = "Fast histogram functioins";
+static char _combine_chunks_docstring[] = "Compute a 1D histogram";
+
+/* Declare the C functions here. */
+static PyObject *_combine_chunks(PyObject *self, PyObject *args);
+
+/* Define the methods that will be available on the module. */
+static PyMethodDef module_methods[] = {
+    {"_combine_chunks", _combine_chunks, METH_VARARGS, _combine_chunks_docstring},
+    {NULL, NULL, 0, NULL}};
+
+/* This is the function that is called on import. */
+
+#if PY_MAJOR_VERSION >= 3
+#define MOD_ERROR_VAL NULL
+#define MOD_SUCCESS_VAL(val) val
+#define MOD_INIT(name) PyMODINIT_FUNC PyInit_##name(void)
+#define MOD_DEF(ob, name, doc, methods)     \
+    static struct PyModuleDef moduledef = { \
+        PyModuleDef_HEAD_INIT,              \
+        name,                               \
+        doc,                                \
+        -1,                                 \
+        methods,                            \
+    };                                      \
+    ob = PyModule_Create(&moduledef);
+#else
+#define MOD_ERROR_VAL
+#define MOD_SUCCESS_VAL(val)
+#define MOD_INIT(name) void init##name(void)
+#define MOD_DEF(ob, name, doc, methods) \
+    ob = Py_InitModule3(name, methods, doc);
+#endif
+
+MOD_INIT(_casa_chunking)
+{
+    PyObject *m;
+    MOD_DEF(m, "_casa_chunking", module_docstring, module_methods);
+    if (m == NULL)
+        return MOD_ERROR_VAL;
+    import_array();
+    return MOD_SUCCESS_VAL(m);
+}
+
+static PyObject *_combine_chunks(PyObject *self, PyObject *args)
+{
+
+    long n;
+    double xmin, xmax, tx, fnx, normx;
+    PyObject *input_obj, *output_obj;
+    PyArrayObject *input_array, *output_array;
+    int ox, oy, oz, ow, nx, ny, nz, nw, nsx, nsy, nsz, nsw;
+    npy_intp dims[1];
+    double *output;
+    NpyIter *iter;
+    NpyIter_IterNextFunc *iternext;
+    char **dataptr;
+    npy_intp *strideptr, *innersizeptr, index;
+    PyArray_Descr *dtype;
+    int bx, by, bz, bw, i, j, k, l, i_o, j_o, k_o, l_o, i_f, j_f, k_f, l_f;
+
+    // NOTE: this function is written in a way to work with 4-d data as it can
+    // then easily be called with 3-d data and have a dimension removed.
+
+    /* Parse the input tuple */
+    if (!PyArg_ParseTuple(args, "Oiiiiiiii", &input_obj, &nx, &ny, &nz, &nw, &ox, &oy, &oz, &ow))
+    {
+        PyErr_SetString(PyExc_TypeError, "Error parsing input");
+        return NULL;
+    }
+
+    /* Interpret the input objects as `numpy` arrays. */
+    input_array = (PyArrayObject *)PyArray_FROM_O(input_obj);
+
+    /* If that didn't work, throw an `Exception`. */
+    if (input_array == NULL)
+    {
+        PyErr_SetString(PyExc_TypeError, "Couldn't parse the input array.");
+        Py_XDECREF(input_array);
+        return NULL;
+    }
+
+    /* How many data points are there? */
+    n = (long)PyArray_DIM(input_array, 0);
+
+    /* Build the output array */
+    dims[0] = n;
+    output_obj = PyArray_SimpleNew(1, dims, NPY_DOUBLE);
+    if (output_obj == NULL)
+    {
+        PyErr_SetString(PyExc_RuntimeError, "Couldn't build output array");
+        Py_DECREF(input_array);
+        Py_XDECREF(output_obj);
+        return NULL;
+    }
+
+    output_array = (PyArrayObject *)output_obj;
+
+    //  TODO: the following is probably unecessary
+    PyArray_FILLWBYTE(output_array, 0);
+
+    if (n == 0)
+    {
+        Py_DECREF(input_array);
+        return output_obj;
+    }
+
+    // TODO: can probaby assume data is contiguous and might be able to
+    // therefore simplify some of the folloing
+    dtype = PyArray_DescrFromType(NPY_DOUBLE);
+    iter = NpyIter_New(input_array,
+                       NPY_ITER_READONLY | NPY_ITER_EXTERNAL_LOOP | NPY_ITER_BUFFERED,
+                       NPY_KEEPORDER, NPY_SAFE_CASTING, dtype);
+    if (iter == NULL)
+    {
+        PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator");
+        Py_DECREF(input_array);
+        Py_DECREF(output_obj);
+        Py_DECREF(output_array);
+        return NULL;
+    }
+
+    /*
+   * The iternext function gets stored in a local variable
+   * so it can be called repeatedly in an efficient manner.
+   */
+    iternext = NpyIter_GetIterNext(iter, NULL);
+    if (iternext == NULL)
+    {
+        PyErr_SetString(PyExc_RuntimeError, "Couldn't set up iterator");
+        NpyIter_Deallocate(iter);
+        Py_DECREF(input_array);
+        Py_DECREF(output_obj);
+        Py_DECREF(output_array);
+        return NULL;
+    }
+
+    /* The location of the data pointer which the iterator may update */
+    dataptr = NpyIter_GetDataPtrArray(iter);
+
+    /* The location of the stride which the iterator may update */
+    strideptr = NpyIter_GetInnerStrideArray(iter);
+
+    /* The location of the inner loop size which the iterator may update */
+    innersizeptr = NpyIter_GetInnerLoopSizePtr(iter);
+
+    /* Get C array for output array */
+    output = (double *)PyArray_DATA(output_array);
+
+    Py_BEGIN_ALLOW_THREADS
+
+    npy_intp stride = *strideptr;
+    npy_intp size = *innersizeptr;
+
+    for (bw = 0; bw < ow; ++bw)
+    {
+        l_o = bw * nw;
+        for (bz = 0; bz < oz; ++bz)
+        {
+            k_o = bz * nz;
+            for (by = 0; by < oy; ++by)
+            {
+                j_o = by * ny;
+                for (bx = 0; bx < ox; ++bx)
+                {
+                    i_o = bx * nx;
+                    for (l = 0; l < nw; ++l)
+                    {
+                        for (k = 0; k < nz; ++k)
+                        {
+                            for (j = 0; j < ny; ++j)
+                            {
+                                for (i = 0; i < nx; ++i)
+                                {
+
+                                    if (size == 0)
+                                    {
+                                        iternext(iter);
+                                        stride = *strideptr;
+                                        size = *innersizeptr;
+                                    }
+
+                                    i_f = i_o + i;
+                                    j_f = j_o + j;
+                                    k_f = k_o + k;
+                                    l_f = l_o + l;
+
+                                    index = i_f + j_f * (nx * ox) + k_f * (nx * ox * ny * oy) + l_f * (nx * ox * ny * oy * nz * oz);
+
+                                    output[index] = *(double *)dataptr[0];
+                                    dataptr[0] += stride;
+
+                                    size--;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Py_END_ALLOW_THREADS
+
+    NpyIter_Deallocate(iter);
+
+    /* Clean up. */
+    Py_DECREF(input_array);
+
+    return output_obj;
+}

--- a/spectral_cube/io/_casa_chunking.c
+++ b/spectral_cube/io/_casa_chunking.c
@@ -145,6 +145,13 @@ static PyObject *_combine_chunks(PyObject *self, PyObject *args)
                             }
                         }
                     }
+
+                    if (itemsize == 1) {
+                        while(index_in % 8 != 0) {
+                            index_in++;
+                        }
+                    }
+
                 }
             }
         }

--- a/spectral_cube/io/_casa_chunking.c
+++ b/spectral_cube/io/_casa_chunking.c
@@ -49,12 +49,9 @@ static PyObject *_combine_chunks(PyObject *self, PyObject *args)
     PyArrayObject *input_array, *output_array;
     int ox, oy, oz, ow, nx, ny, nz, nw;
     npy_intp dims[1];
-    double *output;
-    NpyIter *iter;
-    NpyIter_IterNextFunc *iternext;
-    char **dataptr;
-    npy_intp *strideptr, *innersizeptr, index_in, index_out;
-    PyArray_Descr *dtype;
+    uint8_t *input, *output;
+    int index_in, index_out;
+    int itempos;
     int bx, by, bz, bw, i, j, k, l, i_o, j_o, k_o, l_o, i_f, j_f, k_f, l_f, itemsize;
 
     // NOTE: this function is written in a way to work with 4-d data as it can
@@ -154,8 +151,6 @@ static PyObject *_combine_chunks(PyObject *self, PyObject *args)
     }
 
     Py_END_ALLOW_THREADS
-
-    NpyIter_Deallocate(iter);
 
     /* Clean up. */
     Py_DECREF(input_array);

--- a/spectral_cube/io/casa_dask.py
+++ b/spectral_cube/io/casa_dask.py
@@ -260,7 +260,7 @@ def casa_image_dask_reader(imagename, memmap=True, mask=False, target_chunksize=
     # chunkshape = determine_optimal_chunkshape(totalshape, chunkshape)
 
     if target_chunksize is None:
-        target_chunksize = 1000000
+        target_chunksize = 10000000
 
     if chunksize < target_chunksize:
 

--- a/spectral_cube/io/casa_dask.py
+++ b/spectral_cube/io/casa_dask.py
@@ -121,10 +121,10 @@ class CASAArrayWrapper:
                 array_uint8 = np.fromfile(self._filename, dtype=np.uint8,
                                           offset=start, count=end - start)
                 array_bits = np.unpackbits(array_uint8, bitorder='little')
-                array_bits = combine_chunks_c(array_bits, 1,
+                chunk = array_bits[offset - start * 8:offset + self._chunksize - start * 8]
+                chunk = combine_chunks_c(chunk, 1,
                                               shape=self._chunkshape,
                                               oversample=self._chunkoversample)
-                chunk = array_bits[offset - start * 8:offset + self._chunksize - start * 8]
                 return chunk.reshape(self._chunkshape[::-1], order='F').T[item_in_chunk].astype(np.bool_)
             else:
                 ceil_chunksize = int(ceil(self._chunksize / 8)) * 8

--- a/spectral_cube/io/casa_dask.py
+++ b/spectral_cube/io/casa_dask.py
@@ -51,7 +51,6 @@ def combine_chunks_c(array_1d, itemsize, shape, oversample):
     if len(oversample) == 3:
         oversample = tuple(oversample) + (1,)
     native_shape = [s // o for (s, o) in zip(shape, oversample)]
-    print(array_1d.dtype)
     return _combine_chunks(array_1d, itemsize, *native_shape[::-1], *oversample[::-1])
 
 
@@ -293,9 +292,7 @@ def casa_image_dask_reader(imagename, memmap=True, mask=False, target_chunksize=
             if finished:
                 break
 
-    print('Original chunk shape: {0}'.format(chunkshape))
     chunkshape = [c * o for (c, o) in zip(chunkshape, chunkoversample)]
-    print('New chunk shape: {0}'.format(chunkshape))
 
     # Create a wrapper that takes slices and returns the appropriate CASA data
     wrapper = CASAArrayWrapper(img_fn, totalshape, chunkshape, chunkoversample=chunkoversample, dtype=dtype, itemsize=itemsize, memmap=memmap)

--- a/spectral_cube/io/casa_dask.py
+++ b/spectral_cube/io/casa_dask.py
@@ -10,8 +10,46 @@ import numpy as np
 import dask.array
 
 from .casa_low_level_io import getdminfo
+from ._casa_chunking import _combine_chunks
 
 __all__ = ['casa_image_dask_reader']
+
+
+def combine_chunks(array_1d, shape, oversample):
+    """
+    Given a 1d array of values from a CASA file, which contains ``oversample``
+    chunks (which is a list/tuple of three elements) return a 1d array that
+    would have been returned if there was just one chunk.
+
+    For now, assume that oversample is a tuple of elements in opposite of Numpy
+    order for axes.
+    """
+
+    # NOTE: if this ends up being a bottleneck, it could also be written as a
+    # C/Cython function.
+
+    size = int(np.product(shape))
+    native_shape = [s // o for (s, o) in zip(shape, oversample)]
+    native_size = int(np.product(native_shape))
+
+    # Split 1-d array into native chunks and add to final array
+    result = np.zeros(shape)
+    for i in range(oversample[0]):
+        for j in range(oversample[1]):
+            for k in range(oversample[2]):
+                array_current, array_1d = array_1d[:native_size], array_1d[native_size:]
+                result[i * native_shape[0]:(i+1) * native_shape[0],
+                       j * native_shape[1]:(j+1) * native_shape[1],
+                       k * native_shape[2]:(k+1) * native_shape[2]] = array_current.reshape(native_shape, order='F')
+
+    return result.reshape((size,), order='F')
+
+
+def combine_chunks_c(array_1d, shape, oversample):
+    size = int(np.product(shape))
+    native_shape = [s // o for (s, o) in zip(shape, oversample)]
+    result = _combine_chunks(array_1d, *native_shape[::-1], *oversample[::-1])
+    return result.reshape((size,), order='F')
 
 
 class CASAArrayWrapper:
@@ -26,10 +64,11 @@ class CASAArrayWrapper:
     down.
     """
 
-    def __init__(self, filename, totalshape, chunkshape, dtype=None, itemsize=None, memmap=False):
+    def __init__(self, filename, totalshape, chunkshape, chunkoversample=None, dtype=None, itemsize=None, memmap=False):
         self._filename = filename
         self._totalshape = totalshape[::-1]
         self._chunkshape = chunkshape[::-1]
+        self._chunkoversample = chunkoversample[::-1]
         self.shape = totalshape[::-1]
         self.dtype = dtype
         self.ndim = len(self.shape)
@@ -84,14 +123,16 @@ class CASAArrayWrapper:
             else:
                 ceil_chunksize = int(ceil(self._chunksize / 8)) * 8
                 return (self._array[chunk_number*ceil_chunksize:(chunk_number+1)*ceil_chunksize][:self._chunksize]
-                             .reshape(self._chunkshape[::-1], order='F').T[item_in_chunk])
+                            .reshape(self._chunkshape[::-1], order='F').T[item_in_chunk])
 
         else:
 
             if self._memmap:
-                return np.fromfile(self._filename, dtype=self.dtype,
-                                   offset=offset,
-                                   count=self._chunksize).reshape(self._chunkshape[::-1], order='F').T[item_in_chunk]
+                return (combine_chunks_c(np.fromfile(self._filename, dtype=self.dtype,
+                                       offset=offset,
+                                       count=self._chunksize), shape=self._chunkshape,
+                                       oversample=self._chunkoversample)
+                                       .reshape(self._chunkshape[::-1], order='F').T[item_in_chunk])
             else:
                 return (self._array[chunk_number*self._chunksize:(chunk_number+1)*self._chunksize]
                             .reshape(self._chunkshape[::-1], order='F').T[item_in_chunk])
@@ -120,10 +161,23 @@ def from_array_fast(arrays, asarray=False, lock=False):
     return dask_arrays
 
 
-def casa_image_dask_reader(imagename, memmap=True, mask=False):
+def casa_image_dask_reader(imagename, memmap=True, mask=False, target_chunksize=None):
     """
     Read a CASA image (a folder containing a ``table.f0_TSM0`` file) into a
     numpy array.
+
+    Parameters
+    ----------
+    imagename : str
+        The filename of the CASA image directory
+    memmap : bool, optional
+        Whether to use memory mapping or load the full cube into memory
+    mask : str or bool, optional
+        If set to a string, should be the name of the mask (e.g. ``mask1``) and
+        the mask is returned instead of the data. If `True`, ``mask0`` will be used.
+    target_chunksize : int
+        The desired dask chunk size - CASA chunks are aggregated into blocks of
+        approximately this number of elements.
     """
 
     # the data is stored in the following binary file
@@ -200,8 +254,41 @@ def casa_image_dask_reader(imagename, memmap=True, mask=False):
     chunkshape = tuple(int(x) for x in chunkshape)
     totalshape = tuple(int(x) for x in totalshape)
 
+    # CASA chunks are typically too small to be efficient, so we use a larger
+    # chunk size for dask and then tell CASAArrayWrapper about both the native
+    # and target chunk size.
+    # chunkshape = determine_optimal_chunkshape(totalshape, chunkshape)
+
+    if target_chunksize is None:
+        target_chunksize = 1000000
+
+    if chunksize < target_chunksize:
+
+        # Find optimal chunk - since we want to be efficient we want the new
+        # chunks to be contiguous on disk so we first try and increase the
+        # chunk size in x, then y, etc.
+
+        chunkoversample = previous_chunkoversample = [1 for i in range(len(chunkshape))]
+
+        finished = False
+        for dim in range(4):
+            factors = [f for f in range(stacks[0] + 1) if stacks[0] % f == 0]
+            for factor in factors:
+                chunkoversample[dim] = factor
+                if np.product(chunkoversample) * chunksize > target_chunksize:
+                    chunkoversample = previous_chunkoversample
+                    finished = True
+                    break
+                previous_chunkoversample = chunkoversample
+            if finished:
+                break
+
+    print('Original chunk shape: {0}'.format(chunkshape))
+    chunkshape = [c * o for (c, o) in zip(chunkshape, chunkoversample)]
+    print('New chunk shape: {0}'.format(chunkshape))
+
     # Create a wrapper that takes slices and returns the appropriate CASA data
-    wrapper = CASAArrayWrapper(img_fn, totalshape, chunkshape, dtype=dtype, itemsize=itemsize, memmap=memmap)
+    wrapper = CASAArrayWrapper(img_fn, totalshape, chunkshape, chunkoversample=chunkoversample, dtype=dtype, itemsize=itemsize, memmap=memmap)
 
     # Convert to a dask array
     dask_array = dask.array.from_array(wrapper, name='CASA Data ' + str(uuid.uuid4()), chunks=chunkshape[::-1])

--- a/spectral_cube/io/casa_dask.py
+++ b/spectral_cube/io/casa_dask.py
@@ -47,9 +47,9 @@ def combine_chunks(array_1d, shape, oversample):
 
 def combine_chunks_c(array_1d, itemsize, shape, oversample):
     if len(shape) == 3:
-        shape = shape + (1,)
+        shape = tuple(shape) + (1,)
     if len(oversample) == 3:
-        oversample = oversample + (1,)
+        oversample = tuple(oversample) + (1,)
     native_shape = [s // o for (s, o) in zip(shape, oversample)]
     print(array_1d.dtype)
     return _combine_chunks(array_1d, itemsize, *native_shape[::-1], *oversample[::-1])

--- a/spectral_cube/io/casa_dask.py
+++ b/spectral_cube/io/casa_dask.py
@@ -45,13 +45,14 @@ def combine_chunks(array_1d, shape, oversample):
     return result.reshape((size,), order='F')
 
 
-def combine_chunks_c(array_1d, shape, oversample):
+def combine_chunks_c(array_1d, itemsize, shape, oversample):
     if len(shape) == 3:
         shape = shape + (1,)
     if len(oversample) == 3:
         oversample = oversample + (1,)
     native_shape = [s // o for (s, o) in zip(shape, oversample)]
-    return _combine_chunks(array_1d, array_1d.dtype.itemsize, *native_shape[::-1], *oversample[::-1])
+    print(array_1d.dtype)
+    return _combine_chunks(array_1d, itemsize, *native_shape[::-1], *oversample[::-1])
 
 
 class CASAArrayWrapper:
@@ -133,11 +134,11 @@ class CASAArrayWrapper:
         else:
 
             if self._memmap:
-                data_bytes = np.fromfile(self._filename, dtype=self.uint8,
+                data_bytes = np.fromfile(self._filename, dtype=np.uint8,
                                          offset=offset,
-                                         count=self._chunksize)
+                                         count=self._chunksize * self._itemsize)
                 return (combine_chunks_c(data_bytes,
-                                         self.dtype.itemsize,
+                                         self._itemsize,
                                          shape=self._chunkshape,
                                          oversample=self._chunkoversample)
                                        .view(self.dtype)

--- a/spectral_cube/io/casa_dask.py
+++ b/spectral_cube/io/casa_dask.py
@@ -51,7 +51,7 @@ def combine_chunks_c(array_1d, itemsize, shape, oversample):
     if len(oversample) == 3:
         oversample = tuple(oversample) + (1,)
     native_shape = [s // o for (s, o) in zip(shape, oversample)]
-    return _combine_chunks(array_1d, itemsize, *native_shape[::-1], *oversample[::-1])
+    return _combine_chunks(np.ascontiguousarray(array_1d), itemsize, *native_shape[::-1], *oversample[::-1])
 
 
 class CASAArrayWrapper:

--- a/spectral_cube/io/casa_image.py
+++ b/spectral_cube/io/casa_image.py
@@ -39,7 +39,8 @@ def is_casa_image(origin, filepath, fileobj, *args, **kwargs):
 
 
 def load_casa_image(filename, skipdata=False, memmap=True,
-                    skipvalid=False, skipcs=False, target_cls=None, use_dask=None, **kwargs):
+                    skipvalid=False, skipcs=False, target_cls=None, use_dask=None,
+                    **kwargs):
     """
     Load a cube (into memory?) from a CASA image. By default it will transpose
     the cube into a 'python' order and drop degenerate axes. These options can

--- a/spectral_cube/io/casa_image.py
+++ b/spectral_cube/io/casa_image.py
@@ -40,7 +40,7 @@ def is_casa_image(origin, filepath, fileobj, *args, **kwargs):
 
 def load_casa_image(filename, skipdata=False, memmap=True,
                     skipvalid=False, skipcs=False, target_cls=None, use_dask=None,
-                    **kwargs):
+                    target_chunksize=None, **kwargs):
     """
     Load a cube (into memory?) from a CASA image. By default it will transpose
     the cube into a 'python' order and drop degenerate axes. These options can
@@ -60,14 +60,14 @@ def load_casa_image(filename, skipdata=False, memmap=True,
 
     # read in the data
     if not skipdata:
-        data = casa_image_dask_reader(filename, memmap=memmap)
+        data = casa_image_dask_reader(filename, memmap=memmap, target_chunksize=target_chunksize)
 
     # CASA stores validity of data as a mask
     if skipvalid:
         valid = None
     else:
         try:
-            valid = casa_image_dask_reader(filename, memmap=memmap, mask=True)
+            valid = casa_image_dask_reader(filename, memmap=memmap, mask=True, target_chunksize=target_chunksize)
         except FileNotFoundError:
             valid = None
 

--- a/spectral_cube/io/casa_low_level_io.py
+++ b/spectral_cube/io/casa_low_level_io.py
@@ -76,7 +76,7 @@ def read_iposition(f):
 
     nelem = read_int32(f)
 
-    return np.array([read_int32(f) for i in range(nelem)])
+    return np.array([read_int32(f) for i in range(nelem)], dtype=int)
 
 
 ARRAY_ITEM_READERS = {
@@ -84,7 +84,7 @@ ARRAY_ITEM_READERS = {
     'double': ('double', read_float64, np.float64),
     'dcomplex': ('void', read_complex128, np.complex128),
     'string': ('String', read_string, '<U16'),
-    'int': ('Int', read_int32, np.int32)
+    'int': ('Int', read_int32, int)
 }
 
 


### PR DESCRIPTION
For large cubes, the CASA dask reader becomes inefficient because a ~40Gb cube could end up having 10^6 chunks, so there is a huge overhead in dask for handling so many chunks/blocks which leads to much poorer performance compared to e.g. ``exportfits``. Ideally we should not have more than a few thousand chunks/blocks.

This PR is highly experimental - what it does is that it will combine neighboring chunks on disk in CASA files on-the-fly, so that the dask chunks are basically a multiple of CASA chunks. With this, I can get very close to ``exportfits`` in performance, and with the ``threading`` scheduler I can get better performance when exporting to FITS.

At this point it'd be great to gather some initial performance results on different systems and with different files!

**Notes:**

* The target dask chunksize can be set with:

```
cube = SpectralCube.read(..., target_chunksize=10000000)
```

That value is the maximum number of elements in a dask chunk - the largest chunk that is smaller or equal to this will be chosen.
* For now this does  not correctly reorder the bits for the masks, so masks will be wrong! I have been testing write performance without masks so this wasn't important yet and the masks are a small fraction of the runtime.
* For now this adds a C extension to do the re-ordering for maximum possible performance improvement. We should discuss once we know the performance results whether we are ok with that, whether we want to distribute that (and maybe other CASA I/O things) in a separate package, or if we want a pure-Python solution (possible but not as good performance)
* I think the C code could be simplified quite a bit - at the moment it can actually deal with arbitrarily stored Numpy arrays but in fact we know the data are contiguous