### PR TITLE
Update install script w/subproc

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -66,3 +66,11 @@ Now, quit CASA and re-open it, then type the following to install ``spectral-cub
     CASA <1>: import subprocess, sys
 
     CASA <2>: subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--user', 'spectral-cube'])
+
+
+For CASA versions 5 and earlier, you need to install a specific version of spectral-cube because more recent
+versions of spectral-cube require python3.::
+
+    CASA <1>: import subprocess, sys
+
+    CASA <2>: subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--user', 'spectral-cube==v0.4.4'])

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -63,6 +63,6 @@ installed. Start up CASA as normal, and type::
 
 Now, quit CASA and re-open it, then type the following to install ``spectral-cube``::
 
-    CASA <1>: import pip
+    CASA <1>: import subprocess, sys
 
-    CASA <2>: pip.main(['install', 'spectral-cube', '--user'])
+    CASA <2>: subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--user', 'spectral-cube'])


### PR DESCRIPTION
Our install instructions use the deprecated pip.main and shouldn't.

https://docs.astropy.org/en/latest/install.html#installing-astropy-into-casa is the "right way" to hackinstall stuff into old casa.