### PR TITLE
Handling larger range for BUNIT conversions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ packages = find:
 install_requires =
     astropy
     numpy>=1.8.0
-    radio_beam
+    radio_beam>=0.3.3
     six
     dask[array]
     joblib

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -480,6 +480,15 @@ class MultiBeamMixinClass(object):
         self._beams = obj
 
     @property
+    @cached
+    def pixels_per_beam(self):
+        pixels_per_beam = [(beam.sr /
+                (astropy.wcs.utils.proj_plane_pixel_area(self.wcs) *
+                 u.deg**2)).to(u.one).value for beam in self.beams]
+
+        return pixels_per_beam
+
+    @property
     def unmasked_beams(self):
         return self._beams
 

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -544,9 +544,21 @@ def bunit_converters(obj, unit, equivalencies=(), freq=None):
 
         Parameters
         ----------
+        obj : {SpectralCube, LowerDimensionalObject}
+            A spectral cube or any other lower dimensional object.
+        unit : `~astropy.units.Unit`
+            Unit to convert `obj` to.
+        equivalencies : tuple, optional
+            Initial list of equivalencies.
+        freq `~astropy.unit.Quantity`, optional
+            Frequency to use for spectral conversions. If the spectral axis is available, the
+            frequencies will already be defined.
 
         Outputs
         -------
+        equivalencies : tuple
+            Output tuple of unit conversion equivalencies.
+
         '''
 
         # Add a simple check it the new unit is already equivalent, and so we don't need

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -568,7 +568,7 @@ def bunit_converters(obj, unit, equivalencies=(), freq=None):
         if obj.unit.is_equivalent(unit):
             # return equivalencies
             factor = obj.unit.to(unit, equivalencies=equivalencies)
-            return [factor]
+            return np.array([factor])
 
         has_btemp = obj.unit.is_equivalent(u.K) or unit.is_equivalent(u.K)
         has_perbeam = obj.unit.is_equivalent(u.Jy/u.beam) or unit.is_equivalent(u.Jy/u.beam)

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -652,7 +652,8 @@ def bunit_converters(obj, unit, equivalencies=(), freq=None):
                 # create a beam equivalency for brightness temperature
                 bmequiv = beam.jtok_equiv(thisfreq)
 
-                # TODO: Remove check once `beamarea_equiv` is in a radio-beam release.
+                # NOTE: `beamarea_equiv` was included in the radio-beam v0.3.3 release
+                # The if/else here handles potential cases where earlier releases are installed.
                 if hasattr(beam, 'beamarea_equiv'):
                     bmarea_equiv = beam.beamarea_equiv
                 else:

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -618,6 +618,10 @@ def bunit_converters(obj, unit, equivalencies=(), freq=None):
 
         if has_perpix:
 
+            if not obj.wcs.has_celestial:
+                raise ValueError("Spatial WCS information is required for unit conversions"
+                                 " involving spatial areas (e.g., Jy/pix, Jy/sr)")
+
             pix_area = (proj_plane_pixel_area(obj.wcs.celestial) * u.deg**2).to(u.sr)
 
             pix_area_equiv = [(u.Jy / u.pix, u.Jy / u.sr,

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -670,9 +670,6 @@ def bunit_converters(obj, unit, equivalencies=(), freq=None):
                         raise ValueError("Conversions between K and Jy/beam or Jy/pix"
                                         "requires the cube to have a beam defined.")
 
-                    # if has_beams:
-                    #     jtok_factor = obj.jtok_factors(equivalencies=equivalencies) / (u.Jy / u.beam)
-                    # else:
                     jtok_factor = beam.jtok(thisfreq) / (u.Jy / u.beam)
 
                     # We're going to do this piecemeal because it's easier to conceptualize

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -623,14 +623,14 @@ def bunit_converters(obj, unit, equivalencies=(), freq=None):
         factors = []
 
         # Iterate through spectral channels.
-        for i in iter:
+        for ii in iter:
 
-            beam = beams[i]
+            beam = beams[ii]
 
             # Use the range of frequencies when the beam does not change. Otherwise, select the
             # frequency corresponding to this beam.
             if has_beams:
-                thisfreq = freq[i]
+                thisfreq = freq[ii]
             else:
                 thisfreq = freq
 
@@ -720,4 +720,3 @@ def bunit_converters(obj, unit, equivalencies=(), freq=None):
         else:
             # Slice along first axis to return a 1D array.
             return factors[0]
-

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -161,56 +161,15 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass, HeaderMixinClass):
             # No copying
             return self
 
+        if hasattr(self, 'with_spectral_unit'):
+            freq = self.with_spectral_unit(u.Hz).spectral_axis
+
         if freq is None and 'RESTFRQ' in self.header:
             freq = self.header['RESTFRQ'] * u.Hz
 
         # Create the tuple of unit conversions needed.
         factor = cube_utils.bunit_converters(self, unit, equivalencies=equivalencies,
                                              freq=freq)
-
-        # if ((self.unit.is_equivalent(u.Jy / u.beam) and
-        #      not any({u.Jy/u.beam, u.K}.issubset(set(eq)) for eq in equivalencies))):
-        #     # the 'not any' above checks that there is not already a defined
-        #     # Jy<->K equivalency.  If there is, the code below is redundant
-        #     # and will cause problems.
-
-        #     if hasattr(self, 'beams'):
-        #         factor = (self.jtok_factors(equivalencies=equivalencies) *
-        #                   (self.unit*u.beam).to(u.Jy))
-        #     else:
-        #         # replace "beam" with the actual beam
-        #         if not hasattr(self, 'beam'):
-        #             raise ValueError("To convert objects with Jy/beam units, "
-        #                              "the object needs to have a beam defined.")
-        #         brightness_unit = self.unit * u.beam
-
-        #         # create a beam equivalency for brightness temperature
-        #         if freq is None:
-        #             try:
-        #                 freq = self.with_spectral_unit(u.Hz).spectral_axis
-        #             except AttributeError:
-        #                 raise TypeError("Object of type {0} has no spectral "
-        #                                 "information. `freq` must be provided for"
-        #                                 " unit conversion from Jy/beam"
-        #                                 .format(type(self)))
-        #         else:
-        #             if not freq.unit.is_equivalent(u.Hz):
-        #                 raise u.UnitsError("freq must be given in equivalent "
-        #                                    "frequency units.")
-
-        #         bmequiv = self.beam.jtok_equiv(freq)
-        #         # backport to handle astropy < 3: the beam equivalency was only
-        #         # modified to handle jy/beam in astropy 3
-        #         if bmequiv[0] == u.Jy:
-        #             bmequiv.append([u.Jy/u.beam, u.K, bmequiv[2], bmequiv[3]])
-
-        #         factor = brightness_unit.to(unit,
-        #                                     equivalencies=bmequiv + list(equivalencies))
-
-        # else:
-
-        # scaling factor
-        # factor = self.unit.to(unit, equivalencies=equivalencies)
 
         converted_array = (self.quantity * factor).value
 

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -17,7 +17,7 @@ from astropy.io.registry import UnifiedReadWriteMethod
 from . import spectral_axis
 from .io.core import LowerDimensionalObjectWrite
 from .utils import SliceWarning, BeamWarning, SmoothingWarning, FITSWarning
-from .cube_utils import convert_bunit
+from . import cube_utils
 from . import wcs_utils
 from .masks import BooleanArrayMask, MaskBase
 
@@ -26,7 +26,6 @@ from .base_class import (BaseNDClass, SpectralAxisMixinClass,
                          MultiBeamMixinClass, BeamMixinClass,
                          HeaderMixinClass
                         )
-from . import cube_utils
 
 __all__ = ['LowerDimensionalObject', 'Projection', 'Slice', 'OneDSpectrum']
 class LowerDimensionalObject(u.Quantity, BaseNDClass, HeaderMixinClass):
@@ -162,48 +161,56 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass, HeaderMixinClass):
             # No copying
             return self
 
-        if ((self.unit.is_equivalent(u.Jy / u.beam) and
-             not any({u.Jy/u.beam, u.K}.issubset(set(eq)) for eq in equivalencies))):
-            # the 'not any' above checks that there is not already a defined
-            # Jy<->K equivalency.  If there is, the code below is redundant
-            # and will cause problems.
+        if freq is None and 'RESTFRQ' in self.header:
+            freq = self.header['RESTFRQ'] * u.Hz
 
-            if hasattr(self, 'beams'):
-                factor = (self.jtok_factors(equivalencies=equivalencies) *
-                          (self.unit*u.beam).to(u.Jy))
-            else:
-                # replace "beam" with the actual beam
-                if not hasattr(self, 'beam'):
-                    raise ValueError("To convert objects with Jy/beam units, "
-                                     "the object needs to have a beam defined.")
-                brightness_unit = self.unit * u.beam
+        # Create the tuple of unit conversions needed.
+        equivalencies = cube_utils.bunit_converters(self, unit, equivalencies=equivalencies,
+                                                    freq=freq)
 
-                # create a beam equivalency for brightness temperature
-                if freq is None:
-                    try:
-                        freq = self.with_spectral_unit(u.Hz).spectral_axis
-                    except AttributeError:
-                        raise TypeError("Object of type {0} has no spectral "
-                                        "information. `freq` must be provided for"
-                                        " unit conversion from Jy/beam"
-                                        .format(type(self)))
-                else:
-                    if not freq.unit.is_equivalent(u.Hz):
-                        raise u.UnitsError("freq must be given in equivalent "
-                                           "frequency units.")
+        # if ((self.unit.is_equivalent(u.Jy / u.beam) and
+        #      not any({u.Jy/u.beam, u.K}.issubset(set(eq)) for eq in equivalencies))):
+        #     # the 'not any' above checks that there is not already a defined
+        #     # Jy<->K equivalency.  If there is, the code below is redundant
+        #     # and will cause problems.
 
-                bmequiv = self.beam.jtok_equiv(freq)
-                # backport to handle astropy < 3: the beam equivalency was only
-                # modified to handle jy/beam in astropy 3
-                if bmequiv[0] == u.Jy:
-                    bmequiv.append([u.Jy/u.beam, u.K, bmequiv[2], bmequiv[3]])
+        #     if hasattr(self, 'beams'):
+        #         factor = (self.jtok_factors(equivalencies=equivalencies) *
+        #                   (self.unit*u.beam).to(u.Jy))
+        #     else:
+        #         # replace "beam" with the actual beam
+        #         if not hasattr(self, 'beam'):
+        #             raise ValueError("To convert objects with Jy/beam units, "
+        #                              "the object needs to have a beam defined.")
+        #         brightness_unit = self.unit * u.beam
 
-                factor = brightness_unit.to(unit,
-                                            equivalencies=bmequiv + list(equivalencies))
+        #         # create a beam equivalency for brightness temperature
+        #         if freq is None:
+        #             try:
+        #                 freq = self.with_spectral_unit(u.Hz).spectral_axis
+        #             except AttributeError:
+        #                 raise TypeError("Object of type {0} has no spectral "
+        #                                 "information. `freq` must be provided for"
+        #                                 " unit conversion from Jy/beam"
+        #                                 .format(type(self)))
+        #         else:
+        #             if not freq.unit.is_equivalent(u.Hz):
+        #                 raise u.UnitsError("freq must be given in equivalent "
+        #                                    "frequency units.")
 
-        else:
-            # scaling factor
-            factor = self.unit.to(unit, equivalencies=equivalencies)
+        #         bmequiv = self.beam.jtok_equiv(freq)
+        #         # backport to handle astropy < 3: the beam equivalency was only
+        #         # modified to handle jy/beam in astropy 3
+        #         if bmequiv[0] == u.Jy:
+        #             bmequiv.append([u.Jy/u.beam, u.K, bmequiv[2], bmequiv[3]])
+
+        #         factor = brightness_unit.to(unit,
+        #                                     equivalencies=bmequiv + list(equivalencies))
+
+        # else:
+
+        # scaling factor
+        factor = self.unit.to(unit, equivalencies=equivalencies)
 
         converted_array = (self.quantity * factor).value
 
@@ -412,7 +419,7 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass,
         mywcs = wcs.WCS(hdu.header)
 
         if "BUNIT" in hdu.header:
-            unit = convert_bunit(hdu.header["BUNIT"])
+            unit = cube_utils.convert_bunit(hdu.header["BUNIT"])
             meta["BUNIT"] = hdu.header["BUNIT"]
         else:
             unit = None
@@ -673,7 +680,7 @@ class BaseOneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
         mywcs = wcs.WCS(hdu.header)
 
         if "BUNIT" in hdu.header:
-            unit = convert_bunit(hdu.header["BUNIT"])
+            unit = cube_utils.convert_bunit(hdu.header["BUNIT"])
             meta["BUNIT"] = hdu.header["BUNIT"]
         else:
             unit = None

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -165,8 +165,8 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass, HeaderMixinClass):
             freq = self.header['RESTFRQ'] * u.Hz
 
         # Create the tuple of unit conversions needed.
-        equivalencies = cube_utils.bunit_converters(self, unit, equivalencies=equivalencies,
-                                                    freq=freq)
+        factor = cube_utils.bunit_converters(self, unit, equivalencies=equivalencies,
+                                             freq=freq)
 
         # if ((self.unit.is_equivalent(u.Jy / u.beam) and
         #      not any({u.Jy/u.beam, u.K}.issubset(set(eq)) for eq in equivalencies))):
@@ -210,7 +210,7 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass, HeaderMixinClass):
         # else:
 
         # scaling factor
-        factor = self.unit.to(unit, equivalencies=equivalencies)
+        # factor = self.unit.to(unit, equivalencies=equivalencies)
 
         converted_array = (self.quantity * factor).value
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2480,80 +2480,8 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             # No copying
             return self
 
-        has_btemp = self.unit.is_equivalent(u.K) or unit.is_equivalent(u.K)
-        has_perbeam = self.unit.is_equivalent(u.Jy/u.beam) or unit.is_equivalent(u.Jy/u.beam)
-        has_perangarea = self.unit.is_equivalent(u.Jy/u.sr) or unit.is_equivalent(u.Jy/u.sr)
-        has_perpix = self.unit.is_equivalent(u.Jy/u.pix) or unit.is_equivalent(u.Jy/u.pix)
-
-        has_beam = hasattr(self, 'beam') or self._beam is None
-
-        if has_perangarea:
-            bmequiv_angarea = u.brightness_temperature(self.with_spectral_unit(u.Hz).spectral_axis)
-
-            equivalencies = list(equivalencies) + bmequiv_angarea
-
-        if has_perbeam or has_perangarea:
-            if not has_beam:
-                raise ValueError("To convert cubes with Jy/beam units, "
-                                 "the cube needs to have a beam defined.")
-
-            # create a beam equivalency for brightness temperature
-            bmequiv = self.beam.jtok_equiv(self.with_spectral_unit(u.Hz).spectral_axis)
-
-            # TODO: Remove check once `beamarea_equiv` is in a radio-beam release.
-            if hasattr(self.beam, 'beamarea_equiv'):
-                bmarea_equiv = self.beam.beamarea_equiv
-            else:
-                bmarea_equiv = u.beam_angular_area(self.beam.sr)
-
-            equivalencies = list(equivalencies) + bmequiv + bmarea_equiv
-
-        if has_perpix:
-
-            pix_area = (wcs.utils.proj_plane_pixel_area(self.wcs.celestial) * u.deg**2).to(u.sr)
-
-            pix_area_equiv = [(u.Jy / u.pix, u.Jy / u.sr,
-                              lambda x: x / pix_area.value,
-                              lambda x: x * pix_area.value)]
-
-            equivalencies = list(equivalencies) + pix_area_equiv
-
-            # Define full from brightness temp to Jy / pix.
-            # Otherwise isn't working in 1 step
-            if has_btemp:
-                if not has_beam:
-                    raise ValueError("Conversions between K and Jy/beam or Jy/pix"
-                                    "requires the cube to have a beam defined.")
-
-                jtok_factor = self.beam.jtok(self.with_spectral_unit(u.Hz).spectral_axis) / (u.Jy / u.beam)
-
-                # We're going to do this piecemeal because it's easier to conceptualize
-                # We specifically anchor these conversions based on the beam area. So from
-                # beam to pix, this is beam -> angular area -> area per pixel
-                # Altogether:
-                # K ->  Jy/beam -> Jy /sr - > Jy / pix
-                forward_factor = 1 / (jtok_factor * (self.beam.sr / u.beam) / (pix_area / u.pix))
-                reverse_factor = jtok_factor * (self.beam.sr / u.beam) / (pix_area / u.pix)
-
-                pix_area_btemp_equiv = [(u.K, u.Jy / u.pix,
-                                        lambda x: x * forward_factor.value,
-                                        lambda x: x * reverse_factor.value)]
-
-                equivalencies = list(equivalencies) + pix_area_btemp_equiv
-
-            if has_perbeam:
-                if not has_beam:
-                    raise ValueError("Conversions between Jy/beam or Jy/pix"
-                                    "requires the cube to have a beam defined.")
-
-                beam_area = self.beam.sr
-
-                pix_area_btemp_equiv = [(u.Jy / u.pix, u.Jy / u.beam,
-                                        lambda x: x * (beam_area / pix_area).value,
-                                        lambda x: x * (pix_area / beam_area).value)]
-
-                equivalencies = list(equivalencies) + pix_area_btemp_equiv
-
+        # Create the tuple of unit conversions needed.
+        equivalencies = cube_utils.bunit_converters(self, unit, equivalencies=equivalencies)
 
         factor = self.unit.to(unit, equivalencies=equivalencies)
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -4051,19 +4051,8 @@ class VaryingResolutionSpectralCube(BaseSpectralCube, MultiBeamMixinClass):
             return self
 
         # Create the tuple of unit conversions needed.
-        equivalencies = cube_utils.bunit_converters(self, unit, equivalencies=equivalencies)
-
-        # TODO: YYY
-
-        if self.unit.is_equivalent(u.Jy/u.beam) and unit.is_equivalent(u.K):
-            # replace "beam" with the actual beam
-            if not hasattr(self, 'beams'):
-                raise ValueError("To convert cubes with Jy/beam units, "
-                                 "the cube needs to have beams defined.")
-            factor = self.jtok_factors(equivalencies=equivalencies) * (self.unit*u.beam).to(u.Jy)
-        else:
-            # scaling factor
-            factor = self.unit.to(unit, equivalencies=equivalencies)
+        factor = cube_utils.bunit_converters(self, unit, equivalencies=equivalencies)
+        factor = np.array(factor)
 
         # special case: array in equivalencies
         # (I don't think this should have to be special cased, but I don't know

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2481,9 +2481,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             return self
 
         # Create the tuple of unit conversions needed.
-        equivalencies = cube_utils.bunit_converters(self, unit, equivalencies=equivalencies)
-
-        factor = self.unit.to(unit, equivalencies=equivalencies)
+        factor = cube_utils.bunit_converters(self, unit, equivalencies=equivalencies)
 
         # special case: array in equivalencies
         # (I don't think this should have to be special cased, but I don't know
@@ -4051,6 +4049,11 @@ class VaryingResolutionSpectralCube(BaseSpectralCube, MultiBeamMixinClass):
         if unit == self.unit:
             # No copying
             return self
+
+        # Create the tuple of unit conversions needed.
+        equivalencies = cube_utils.bunit_converters(self, unit, equivalencies=equivalencies)
+
+        # TODO: YYY
 
         if self.unit.is_equivalent(u.Jy/u.beam) and unit.is_equivalent(u.K):
             # replace "beam" with the actual beam

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2480,20 +2480,18 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             # No copying
             return self
 
-        if self.unit.is_equivalent(u.Jy/u.beam):
+        if self.unit.is_equivalent(u.Jy/u.beam) or unit.is_equivalent(u.Jy/u.beam):
             # replace "beam" with the actual beam
             if not hasattr(self, 'beam') or self._beam is None:
                 raise ValueError("To convert cubes with Jy/beam units, "
                                  "the cube needs to have a beam defined.")
-            brightness_unit = self.unit * u.beam
 
             # create a beam equivalency for brightness temperature
             bmequiv = self.beam.jtok_equiv(self.with_spectral_unit(u.Hz).spectral_axis)
-            factor = brightness_unit.to(unit,
-                                        equivalencies=bmequiv+list(equivalencies))
-        else:
-            # scaling factor
-            factor = self.unit.to(unit, equivalencies=equivalencies)
+
+            equivalencies = list(equivalencies) + bmequiv
+
+        factor = self.unit.to(unit, equivalencies=equivalencies)
 
         # special case: array in equivalencies
         # (I don't think this should have to be special cased, but I don't know

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -797,6 +797,28 @@ def test_unit_conversions_general_1D(data_advs, use_dask, init_unit):
             np.testing.assert_almost_equal(roundtrip_spec.value,
                                            spec.value)
 
+@pytest.mark.parametrize(('init_unit'), bunits_list_1D)
+def test_multibeams_unit_conversions_general_1D(data_vda_beams, use_dask, init_unit):
+
+    cube, data = cube_and_raw(data_vda_beams, use_dask=use_dask)
+    cube._meta['BUNIT'] = init_unit.to_string()
+    cube._unit = init_unit
+
+    spec = cube[:, 0, 0]
+
+    # Check all unit conversion combos:
+    for targ_unit in bunits_list_1D:
+        newspec = spec.to(targ_unit)
+
+        if init_unit == targ_unit:
+            np.testing.assert_almost_equal(newspec.value,
+                                           spec.value)
+
+        else:
+            roundtrip_spec = newspec.to(init_unit)
+            np.testing.assert_almost_equal(roundtrip_spec.value,
+                                           spec.value)
+
 
 def test_basic_arrayness(data_adv, use_dask):
     cube, data = cube_and_raw(data_adv, use_dask=use_dask)

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -744,6 +744,59 @@ def test_beam_jtok_2D(data_advs, use_dask):
     np.testing.assert_almost_equal(Kplane.value,
                                    (plane.value * jtok).value)
 
+bunits_list = [u.Jy / u.beam, u.K, u.Jy / u.sr, u.Jy / u.pix, u.Jy / u.arcsec**2,
+               u.mJy / u.beam, u.mK]
+
+@pytest.mark.parametrize(('init_unit'), bunits_list)
+def test_unit_conversions_general_2D(data_advs, use_dask, init_unit):
+
+    cube, data = cube_and_raw(data_advs, use_dask=use_dask)
+    cube._meta['BUNIT'] = init_unit.to_string()
+    cube._unit = init_unit
+
+    plane = cube[0]
+
+    # Check all unit conversion combos:
+    for targ_unit in bunits_list:
+        newplane = plane.to(targ_unit)
+
+        if init_unit == targ_unit:
+            np.testing.assert_almost_equal(newplane.value,
+                                           plane.value)
+
+        else:
+            roundtrip_plane = newplane.to(init_unit)
+            np.testing.assert_almost_equal(roundtrip_plane.value,
+                                           plane.value)
+
+# TODO: Our 1D object do NOT retain spatial info that is needed for other BUNIT conversion
+# e.g., Jy/sr, Jy/pix. So we're limited to Jy/beam -> K conversion for now
+# See: https://github.com/radio-astro-tools/spectral-cube/pull/395
+bunits_list_1D = [u.Jy / u.beam, u.K,
+                  u.mJy / u.beam, u.mK]
+
+@pytest.mark.parametrize(('init_unit'), bunits_list_1D)
+def test_unit_conversions_general_1D(data_advs, use_dask, init_unit):
+
+    cube, data = cube_and_raw(data_advs, use_dask=use_dask)
+    cube._meta['BUNIT'] = init_unit.to_string()
+    cube._unit = init_unit
+
+    spec = cube[:, 0, 0]
+
+    # Check all unit conversion combos:
+    for targ_unit in bunits_list_1D:
+        newspec = spec.to(targ_unit)
+
+        if init_unit == targ_unit:
+            np.testing.assert_almost_equal(newspec.value,
+                                           spec.value)
+
+        else:
+            roundtrip_spec = newspec.to(init_unit)
+            np.testing.assert_almost_equal(roundtrip_spec.value,
+                                           spec.value)
+
 
 def test_basic_arrayness(data_adv, use_dask):
     cube, data = cube_and_raw(data_adv, use_dask=use_dask)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1757,13 +1757,7 @@ def test_beam_jtok_array(data_advs, use_dask):
     cube._meta['BUNIT'] = 'Jy / beam'
     cube._unit = u.Jy/u.beam
 
-    equiv = cube.beam.jtok_equiv(cube.with_spectral_unit(u.GHz).spectral_axis)
     jtok = cube.beam.jtok(cube.with_spectral_unit(u.GHz).spectral_axis)
-
-    Kcube = cube.to(u.K, equivalencies=equiv)
-    np.testing.assert_almost_equal(Kcube.filled_data[:].value,
-                                   (cube.filled_data[:].value *
-                                    jtok[:,None,None]).value)
 
     # test that the beam equivalencies are correctly automatically defined
     Kcube = cube.to(u.K)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1692,7 +1692,7 @@ def test_basic_unit_conversion_beams(data_vda_beams, use_dask):
                                     1e3))
 
 
-bunits_list = [u.Jy / u.beam, u.K, u.Jy / u.sr, u.Jy / u.pix]
+bunits_list = [u.Jy / u.beam, u.K, u.Jy / u.sr, u.Jy / u.pix, u.Jy / u.arcsec**2]
 
 @pytest.mark.parametrize(('init_unit'), bunits_list)
 def test_unit_conversions_general(data_advs, use_dask, init_unit):
@@ -1716,12 +1716,15 @@ def test_unit_conversions_general(data_advs, use_dask, init_unit):
 
 
 def test_beam_jpix_checks_array(data_advs, use_dask):
+    '''
+    Ensure round-trip consistency in our defined K -> Jy/pix conversions.
+
+    '''
 
     cube, data = cube_and_raw(data_advs, use_dask=use_dask)
     cube._meta['BUNIT'] = 'Jy / beam'
     cube._unit = u.Jy/u.beam
 
-    equiv = cube.beam.jtok_equiv(cube.with_spectral_unit(u.GHz).spectral_axis)
     jtok = cube.beam.jtok(cube.with_spectral_unit(u.GHz).spectral_axis)
 
     pixperbeam = cube.pixels_per_beam * u.pix
@@ -1731,7 +1734,7 @@ def test_beam_jpix_checks_array(data_advs, use_dask):
                                    (cube.filled_data[:].value /
                                     pixperbeam).value)
 
-    Kcube = cube.to(u.K, equivalencies=equiv)
+    Kcube = cube.to(u.K)
     np.testing.assert_almost_equal(Kcube.filled_data[:].value,
                                    (cube_jypix.filled_data[:].value *
                                     jtok[:,None,None] * pixperbeam).value)
@@ -1742,8 +1745,10 @@ def test_beam_jpix_checks_array(data_advs, use_dask):
                                    roundtrip_cube.filled_data[:].value)
 
     Kcube_from_jypix = cube_jypix.to(u.K)
+
     np.testing.assert_almost_equal(Kcube.filled_data[:].value,
                                    Kcube_from_jypix.filled_data[:].value)
+
 
 def test_beam_jtok_array(data_advs, use_dask):
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1692,8 +1692,24 @@ def test_basic_unit_conversion_beams(data_vda_beams, use_dask):
                                     1e3))
 
 
+bunits_list = [u.Jy / u.beam, u.K, u.Jy / u.sr, u.Jy / u.pix]
 
-def test_beam_jtok_array(data_advs, use_dask):
+@pytest.mark.parametrize(('init_unit'), bunits_list)
+def test_unit_conversions_general(data_advs, use_dask, init_unit):
+
+    cube, data = cube_and_raw(data_advs, use_dask=use_dask)
+    cube._meta['BUNIT'] = init_unit.to_string()
+    cube._unit = init_unit
+
+    # Check all unit conversion combos:
+    for targ_unit in bunits_list:
+        newcube = cube.to(targ_unit)
+
+        if init_unit == targ_unit:
+            np.testing.assert_almost_equal(newcube.filled_data[:].value,
+                                            cube.filled_data[:].value)
+
+def test_beam_jtok_array(data_advs, use_dask, init_unit):
 
     cube, data = cube_and_raw(data_advs, use_dask=use_dask)
     cube._meta['BUNIT'] = 'Jy / beam'
@@ -1712,7 +1728,6 @@ def test_beam_jtok_array(data_advs, use_dask):
     np.testing.assert_almost_equal(Kcube.filled_data[:].value,
                                    (cube.filled_data[:].value *
                                     jtok[:,None,None]).value)
-
 
 def test_multibeam_jtok_array(data_vda_beams, use_dask):
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1715,6 +1715,26 @@ def test_unit_conversions_general(data_advs, use_dask, init_unit):
             np.testing.assert_almost_equal(roundtrip_cube.filled_data[:].value,
                                            cube.filled_data[:].value)
 
+@pytest.mark.parametrize(('init_unit'), bunits_list)
+def test_multibeam_unit_conversions_general(data_vda_beams, use_dask, init_unit):
+
+    cube, data = cube_and_raw(data_vda_beams, use_dask=use_dask)
+    cube._meta['BUNIT'] = init_unit.to_string()
+    cube._unit = init_unit
+
+    # Check all unit conversion combos:
+    for targ_unit in bunits_list:
+        newcube = cube.to(targ_unit)
+
+        if init_unit == targ_unit:
+            np.testing.assert_almost_equal(newcube.filled_data[:].value,
+                                           cube.filled_data[:].value)
+
+        else:
+            roundtrip_cube = newcube.to(init_unit)
+            np.testing.assert_almost_equal(roundtrip_cube.filled_data[:].value,
+                                           cube.filled_data[:].value)
+
 
 def test_beam_jpix_checks_array(data_advs, use_dask):
     '''

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1709,7 +1709,7 @@ def test_unit_conversions_general(data_advs, use_dask, init_unit):
             np.testing.assert_almost_equal(newcube.filled_data[:].value,
                                             cube.filled_data[:].value)
 
-def test_beam_jtok_array(data_advs, use_dask, init_unit):
+def test_beam_jtok_array(data_advs, use_dask):
 
     cube, data = cube_and_raw(data_advs, use_dask=use_dask)
     cube._meta['BUNIT'] = 'Jy / beam'

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1692,7 +1692,8 @@ def test_basic_unit_conversion_beams(data_vda_beams, use_dask):
                                     1e3))
 
 
-bunits_list = [u.Jy / u.beam, u.K, u.Jy / u.sr, u.Jy / u.pix, u.Jy / u.arcsec**2]
+bunits_list = [u.Jy / u.beam, u.K, u.Jy / u.sr, u.Jy / u.pix, u.Jy / u.arcsec**2,
+               u.mJy / u.beam, u.mK]
 
 @pytest.mark.parametrize(('init_unit'), bunits_list)
 def test_unit_conversions_general(data_advs, use_dask, init_unit):

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1707,7 +1707,12 @@ def test_unit_conversions_general(data_advs, use_dask, init_unit):
 
         if init_unit == targ_unit:
             np.testing.assert_almost_equal(newcube.filled_data[:].value,
-                                            cube.filled_data[:].value)
+                                           cube.filled_data[:].value)
+
+        else:
+            roundtrip_cube = newcube.to(init_unit)
+            np.testing.assert_almost_equal(roundtrip_cube.filled_data[:].value,
+                                           cube.filled_data[:].value)
 
 def test_beam_jtok_array(data_advs, use_dask):
 


### PR DESCRIPTION
This is to address #683. There are a number of fairly common unit transitions that we've been missing. We also have some gaps for different objects that can be addressed here (e.g., 2D Projection or Slice).

`SpectralCube`
* [x] Jy/beam <-> Jy/pix
* [x] Jy/sr <-> Jy/beam
* [x] K <-> Jy/sr
* [x] K <-> Jy/pix

`VaryingResolutionSpectralCube`
* [x] K <-> Jy/beam
* [x] Jy/beam <-> Jy/pix
* [x] Jy/sr <-> Jy/beam
* [x] K <-> Jy/sr
* [x] K <-> Jy/pix

`Projection`/`Slice`
* [x] K <-> Jy/beam
* [x] Jy/beam <-> Jy/pix
* [x] Jy/sr <-> Jy/beam
* [x] K <-> Jy/sr
* [x] K <-> Jy/pix
* [ ] K km/s <-> Jy/beam (km/s) (integrated intensity)
* ~[ ] km/s <-> m/s (centroid/line width)~ (Unsure why I added this. It's a basic transform that already works.)

`OneDSpectrum`
* [x] K <-> Jy/beam
* Other unit conversions require spatial WCS info which we arent keeping in the slice for now (see #395 )

`VaryingResolutionOneDSpectrum`
* [x] K <-> Jy/beam
