### PR TITLE
Fix indexing for propagating PV and PS cards.

### DIFF
--- a/spectral_cube/wcs_utils.py
+++ b/spectral_cube/wcs_utils.py
@@ -163,15 +163,15 @@ def reindex_wcs(wcs, inds):
     pv_cards = []
     for i, j in enumerate(inds):
         for k, m, v in wcs.wcs.get_pv():
-            if k == j:
-                pv_cards.append((i, m, v))
+            if k == (j + 1):
+                pv_cards.append((i + 1, m, v))
     outwcs.wcs.set_pv(pv_cards)
 
     ps_cards = []
     for i, j in enumerate(inds):
         for k, m, v in wcs.wcs.get_ps():
-            if k == j:
-                ps_cards.append((i, m, v))
+            if k == (j + 1):
+                ps_cards.append((i + 1, m, v))
     outwcs.wcs.set_ps(ps_cards)
 
 


### PR DESCRIPTION
`PVi_j` cards are being lost when reducing dimensions.  This appears to come from `wcs.get_pv()` returning tuples with the coordinates given in FITS 1-based axis indexing whereas the list of what axes to include (`inds`) is 0-based.  Included +1 to shift axes so they line up.