### PR TITLE
Mask behavior fix

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -1834,8 +1834,11 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         spatial_only: bool
             Only compute the minimal subcube in the spatial dimensions
         """
-        return self[self.subcube_slices_from_mask(self._mask,
-                                                  spatial_only=spatial_only)]
+        if self._mask is not None:
+            return self[self.subcube_slices_from_mask(self._mask,
+                                                      spatial_only=spatial_only)]
+        else:
+            return self[:]
 
     def subcube_from_mask(self, region_mask):
         """

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2474,3 +2474,25 @@ def test_minimal_subcube(use_dask):
     subcube = cube.minimal_subcube()
 
     assert subcube.shape == (3, 5, 2)
+
+
+def test_minimal_subcube_nomask(use_dask):
+
+    if not use_dask:
+        pytest.importorskip('scipy')
+
+    data = np.arange(210, dtype=float).reshape((5, 6, 7))
+
+    wcs = WCS(naxis=3)
+    wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN', 'VELO-HEL']
+
+    cube = SpectralCube(data * u.Jy / u.beam, wcs=wcs, use_dask=use_dask)
+
+    # verify that there is no mask
+    assert cube._mask is None
+
+    # this should not raise an Exception
+    subcube = cube.minimal_subcube()
+
+    # shape is unchanged
+    assert subcube.shape == (5, 6, 7)


### PR DESCRIPTION
Bugfix: if a cube has no mask and you use `minimal_subcube`, it can result in an AttributeError:

```python
DaskVaryingResolutionSpectralCube with shape=(1941, 1120, 1536) and unit=Jy / beam and chunk size (36, 224, 1536):
 n_x:   1536  type_x: RA---SIN  unit_x: deg    range:   245.492478 deg:  245.585582 deg
 n_y:   1120  type_y: DEC--SIN  unit_y: deg    range:   -50.121553 deg:  -50.078036 deg
 n_s:   1941  type_s: FREQ      unit_s: Hz     range: 231520543428.154 Hz:233414894425.702 Hz
Traceback (most recent call last):
  File "/orange/adamginsburg/ALMA_IMF/reduction/analysis/statcont_cubes.py", line 99, in <module>
    cube = cube.minimal_subcube()
  File "/orange/adamginsburg/repos/spectral-cube/spectral_cube/spectral_cube.py", line 1838, in minimal_subcube
    spatial_only=spatial_only)]
  File "/orange/adamginsburg/repos/spectral-cube/spectral_cube/dask_spectral_cube.py", line 1066, in subcube_slices_from_mask
    include = region_mask.include(self._data, self._wcs,
AttributeError: 'NoneType' object has no attribute 'include'
```