### PR TITLE
Avoid data copy when calling sigma_clip

### DIFF
--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -809,7 +809,7 @@ class DaskSpectralCubeMixin:
 
         def spectral_sigma_clip(array):
             return stats.sigma_clip(array, sigma=threshold, axis=0,
-                                    masked=False, copy=False, **kwargs)
+                                    masked=False, copy=True, **kwargs)
 
         return self.apply_function_parallel_spectral(spectral_sigma_clip,
                                                      accepts_chunks=True)

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -808,8 +808,8 @@ class DaskSpectralCubeMixin:
         """
 
         def spectral_sigma_clip(array):
-            result = stats.sigma_clip(array, sigma=threshold, axis=0, **kwargs)
-            return result.filled(np.nan)
+            return stats.sigma_clip(array, sigma=threshold, axis=0,
+                                    masked=False, copy=False, **kwargs)
 
         return self.apply_function_parallel_spectral(spectral_sigma_clip,
                                                      accepts_chunks=True)


### PR DESCRIPTION
This is a small optimization but every little helps! (I think it will only really make a difference with Astropy v4.3 as there was a copy-related bug in previous versions). I also opened https://github.com/astropy/astropy/pull/11692 which improves the multi-threading case.

In any case here are some interesting timings on dedicated hardware with a 12Gb cube and with this latest version:

```python
import dask
from spectral_cube import SpectralCube
cube = SpectralCube.read('BrickMaser_271_spw49.image')
sclipped = cube.sigma_clip_spectrally(threshold=1.8, maxiters=None,
                                      save_to_tmp_dir='temp.zarr')
```

runs in **4min12s**. With:

```
cube.use_dask_scheduler('threads')
```

This goes down to **54s**! Now going back to serial mode with MAD:

```
sclipped = cube.sigma_clip_spectrally(threshold=1.8, maxiters=None,
                                      save_to_tmp_dir='temp.zarr',
                                      stdfunc='mad_std')
```

this takes **4min4s** so basically the same as with regular standard deviation. In comparison if I use the old astropy sigma clipping code with the ``mad_std`` function specified manually:

```
def nan_mad_std(data, axis=None):
    return mad_std(data, axis=axis, ignore_nan=True)

sclipped = cube.sigma_clip_spectrally(threshold=1.8, maxiters=None,
                                      save_to_tmp_dir='temp.zarr',
                                      stdfunc=nan_mad_std)
```

This takes **21min41s**, so in this particular case the new mad_std implementation is 5x faster.


