### PR TITLE
Expose more options for dask's map_blocks

### DIFF
--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -805,7 +805,6 @@ class DaskSpectralCubeMixin:
             data = data.rechunk(rechunk)
 
         if additional_arrays is None:
-            # newdata = data.map_blocks(function, dtype=data.dtype, **kwargs)
             newdata = da.map_blocks(function, data, dtype=data.dtype, **kwargs)
         else:
             additional_arrays = [array.rechunk(data.chunksize) for array in additional_arrays]


### PR DESCRIPTION
Adds two things:
* Makes returning a new cube optional for `apply_function_parallel_spectral`
* Retains passing `block_info` for functions that need to be aware of a chunk's location in the whole cube.

We need both of these for `apply_function_parallel_spectral` to be used for spectral fitting a whole cube: https://github.com/radio-astro-tools/tutorials/pull/12

TODO:
* [x] Test non-cube return
* [x] Test passing block_info to a function

