### PR TITLE
Handle Jy/beam operations where the beam is altered

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,7 @@
 0.6 (unreleased)
 ----------------
+- Fix `convolve_to` when units are in Jy/beam. Add error/warnings for operations
+  for all operations that change the spatial resolution for Jy/beam cubes.
 - Add ``argmax_world`` and ``argmin_world`` to return the argmin/max position
   in WCS coordinates. This is ONLY defined for independent WCS axes
   (e.g., spectral) #680

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -104,6 +104,22 @@ class HeaderMixinClass(object):
 
         return header
 
+    def check_jybeam_smoothing(self, raise_error_jybm=True):
+        '''
+        Runs for spatial resolution operations (e.g. `spatial_smooth`) and either an error or warning
+        when smoothing will affect brightness in Jy/beam operations.
+
+        This is also true for using the `with_beam` and `with_beams` methods, including 1D spectra with
+        Jy/beam units.
+        '''
+
+        if self.unit.is_equivalent(u.Jy / u.beam) and raise_error_jybm:
+            if raise_error_jybm:
+                raise BeamUnitsError("Attempting to change the spatial resolution of a cube with Jy/beam units."
+                                     " To ignore this error, set `raise_error_jybm=False`.")
+            else:
+                warnings.warn("Changing the spatial resolution of a cube with Jy/beam units."
+                              " The brightness units may be wrong!", BeamWarning)
 
 class SpatialCoordMixinClass(object):
 

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -782,7 +782,7 @@ class MultiBeamMixinClass(object):
         '''
 
         # Catch cases with units in Jy/beam where new beams will alter the units.
-        self.check_jybeam_smoothing(raise_error_jybm=True)
+        self.check_jybeam_smoothing(raise_error_jybm=raise_error_jybm)
 
         meta = self.meta.copy()
         meta['beams'] = beams

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -106,11 +106,20 @@ class HeaderMixinClass(object):
 
     def check_jybeam_smoothing(self, raise_error_jybm=True):
         '''
-        Runs for spatial resolution operations (e.g. `spatial_smooth`) and either an error or warning
+        This runs for spatial resolution operations (e.g. `spatial_smooth`) and either an error or warning
         when smoothing will affect brightness in Jy/beam operations.
 
         This is also true for using the `with_beam` and `with_beams` methods, including 1D spectra with
         Jy/beam units.
+
+        Parameters
+        ----------
+        raise_error_jybeam : bool, optional
+            Raises a `~spectral_cube.utils.BeamUnitsError` when True (default). When False, it triggers a
+            `~spectral_cube.utils.BeamWarning`.
+
+            .. note: This is a reminder to expose raise_error_jybm to top-level functions.
+
         '''
 
         if self.unit.is_equivalent(u.Jy / u.beam) and raise_error_jybm:

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -782,13 +782,7 @@ class MultiBeamMixinClass(object):
         '''
 
         # Catch cases with units in Jy/beam where new beams will alter the units.
-        if self.unit.is_equivalent(u.Jy/u.beam) and self.beams is not None:
-
-            if raise_error_jybm:
-                raise BeamUnitsError("Attempting to change the beams of a cube with Jy/beam units."
-                                     " To ignore this error, set `raise_error_jybm=False`.")
-            else:
-                warnings.warn("Changing the beams of a cube with Jy/beam units. The brightness units may be wrong!", BeamWarning)
+        self.check_jybeam_smoothing(raise_error_jybm=True)
 
         meta = self.meta.copy()
         meta['beams'] = beams

--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -504,6 +504,10 @@ def point_source_5_one_beam(tmp_path):
 
     beam = Beam(3 * pixel_scale)
 
+    beamprops = beam.to_header_keywords()
+    for key in beamprops:
+        h[key] = beamprops[key]
+
     for i in range(5):
         # Convolve point source to the beams.
         d[i] = convolve_fft(d[i], beam.as_kernel(pixel_scale))

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -954,14 +954,7 @@ class DaskSpectralCubeMixin:
             Passed to the convolve function
         """
 
-        if self.unit.is_equivalent(u.Jy / u.beam) and raise_error_jybm:
-            if raise_error_jybm:
-                raise BeamUnitsError("Attempting to change the spatial resolution of a cube with Jy/beam units."
-                                     " To ignore this error, set `raise_error_jybm=False`.")
-            else:
-                warnings.warn("Changing the spatial resolution of a cube with Jy/beam units."
-                              " The brightness units may be wrong!", BeamWarning)
-
+        self.check_jybeam_smoothing(raise_error_jybm=raise_error_jybm)
 
         def convolve_wrapper(data, kernel=None, **kwargs):
             return convolve(data, kernel, normalize_kernel=True, **kwargs)
@@ -987,13 +980,7 @@ class DaskSpectralCubeMixin:
         if not SCIPY_INSTALLED:
             raise ImportError("Scipy could not be imported: this function won't work.")
 
-        if self.unit.is_equivalent(u.Jy / u.beam) and raise_error_jybm:
-            if raise_error_jybm:
-                raise BeamUnitsError("Attempting to change the spatial resolution of a cube with Jy/beam units."
-                                     " To ignore this error, set `raise_error_jybm=False`.")
-            else:
-                warnings.warn("Changing the spatial resolution of a cube with Jy/beam units."
-                              " The brightness units may be wrong!", BeamWarning)
+        self.check_jybeam_smoothing(raise_error_jybm=raise_error_jybm)
 
         def median_filter_wrapper(data, ksize=None, **kwargs):
             return ndimage.median_filter(data, ksize, **kwargs)

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -1534,7 +1534,6 @@ class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolution
             if img.size > 0:
                 out = np.zeros(img.shape, dtype=img.dtype)
                 for index in range(img.shape[0]):
-                    print(beam[index, 0, 0])
                     if beam[index, 0, 0] is None:
                         out[index] = img[index]
                     else:

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -1387,7 +1387,7 @@ class DaskSpectralCube(DaskSpectralCubeMixin, SpectralCube):
 
         return self.apply_function_parallel_spatial(convfunc,
                                                     accepts_chunks=True,
-                                                    **kwargs).with_beam(beam)
+                                                    **kwargs).with_beam(beam, raise_error_jybm=False)
 
 
 class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolutionSpectralCube):

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -1512,6 +1512,11 @@ class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolution
         beams = da.from_array(np.array(beams, dtype=np.object)
                               .reshape((len(beams), 1, 1)), chunks=(-1, -1, -1))
 
+        if self.unit.is_equivalent(u.Jy / u.beam):
+            beam_ratio_factor = (beam.sr / self.beams.sr).value
+        else:
+            beam_ratio_factor = np.ones_like(beams.sr.value)
+
         # See #631: kwargs get passed within self.apply_function_parallel_spatial
         def convfunc(img, beam, **kwargs):
             if img.size > 0:
@@ -1521,7 +1526,7 @@ class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolution
                         out[index] = img[index]
                     else:
                         kernel = beam[index, 0, 0].as_kernel(pixscale)
-                        out[index] = convolve(img[index], kernel, normalize_kernel=True, **kwargs)
+                        out[index] = convolve(img[index], kernel, normalize_kernel=True, **kwargs) * beam_ratio_factor[index]
                 return out
             else:
                 return img

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -296,13 +296,7 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass,
         if not isinstance(beam, Beam):
             raise TypeError("beam must be a radio_beam.Beam object.")
 
-        if self.unit.is_equivalent(u.Jy/u.beam) and self.beam is not None:
-
-            if raise_error_jybm:
-                raise BeamUnitsError("Attempting to change the beams of a cube with Jy/beam units."
-                                     " To ignore this error, set `raise_error_jybm=False`.")
-            else:
-                warnings.warn("Changing the beams of a cube with Jy/beam units. The brightness units may be wrong!", BeamWarning)
+        self.check_jybeam_smoothing(raise_error_jybm=raise_error_jybm)
 
         meta = self.meta.copy()
         meta['beam'] = beam
@@ -1033,13 +1027,7 @@ class OneDSpectrum(BaseOneDSpectrum, BeamMixinClass):
         if not isinstance(beam, Beam):
             raise TypeError("beam must be a radio_beam.Beam object.")
 
-        if self.unit.is_equivalent(u.Jy/u.beam) and self.beam is not None:
-
-            if raise_error_jybm:
-                raise BeamUnitsError("Attempting to change the beams of a cube with Jy/beam units."
-                                     " To ignore this error, set `raise_error_jybm=False`.")
-            else:
-                warnings.warn("Changing the beams of a cube with Jy/beam units. The brightness units may be wrong!", BeamWarning)
+        self.check_jybeam_smoothing(raise_error_jybm=raise_error_jybm)
 
         meta = self.meta.copy()
         meta['beam'] = beam

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -16,7 +16,7 @@ from astropy.io.registry import UnifiedReadWriteMethod
 
 from . import spectral_axis
 from .io.core import LowerDimensionalObjectWrite
-from .utils import SliceWarning, BeamWarning, SmoothingWarning, FITSWarning
+from .utils import SliceWarning, BeamWarning, SmoothingWarning, FITSWarning, BeamUnitsError
 from . import cube_utils
 from . import wcs_utils
 from .masks import BooleanArrayMask, MaskBase
@@ -283,7 +283,7 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass,
 
         return self
 
-    def with_beam(self, beam):
+    def with_beam(self, beam, raise_error_jybm=True):
         '''
         Attach a new beam object to the Projection.
 
@@ -292,6 +292,17 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass,
         beam : `~radio_beam.Beam`
             A new beam object.
         '''
+
+        if not isinstance(beam, Beam):
+            raise TypeError("beam must be a radio_beam.Beam object.")
+
+        if self.unit.is_equivalent(u.Jy/u.beam) and self.beam is not None:
+
+            if raise_error_jybm:
+                raise BeamUnitsError("Attempting to change the beams of a cube with Jy/beam units."
+                                     " To ignore this error, set `raise_error_jybm=False`.")
+            else:
+                warnings.warn("Changing the beams of a cube with Jy/beam units. The brightness units may be wrong!", BeamWarning)
 
         meta = self.meta.copy()
         meta['beam'] = beam
@@ -1009,7 +1020,7 @@ class OneDSpectrum(BaseOneDSpectrum, BeamMixinClass):
         out = super(OneDSpectrum, self)._new_spectrum_with(beam=beam, **kwargs)
         return out
 
-    def with_beam(self, beam):
+    def with_beam(self, beam, raise_error_jybm=True):
         '''
         Attach a new beam object to the OneDSpectrum.
 
@@ -1018,6 +1029,17 @@ class OneDSpectrum(BaseOneDSpectrum, BeamMixinClass):
         beam : `~radio_beam.Beam`
             A new beam object.
         '''
+
+        if not isinstance(beam, Beam):
+            raise TypeError("beam must be a radio_beam.Beam object.")
+
+        if self.unit.is_equivalent(u.Jy/u.beam) and self.beam is not None:
+
+            if raise_error_jybm:
+                raise BeamUnitsError("Attempting to change the beams of a cube with Jy/beam units."
+                                     " To ignore this error, set `raise_error_jybm=False`.")
+            else:
+                warnings.warn("Changing the beams of a cube with Jy/beam units. The brightness units may be wrong!", BeamWarning)
 
         meta = self.meta.copy()
         meta['beam'] = beam

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -3199,6 +3199,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         newcube = self.apply_function_parallel_spatial(convfunc,
                                                        **kwargs).with_beam(beam)
 
+        # Scale Jy/beam units by the change in beam size
+        if self.unit.is_equivalent(u.Jy / u.beam):
+            newcube *= (beam.sr / self.beam.sr).value
+
         return newcube
 
     def mask_channels(self, goodchannels):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -3197,7 +3197,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                             **kwargs)
 
         newcube = self.apply_function_parallel_spatial(convfunc,
-                                                       **kwargs).with_beam(beam)
+                                                       **kwargs).with_beam(beam, raise_error_jybm=False)
 
         # Scale Jy/beam units by the change in beam size
         if self.unit.is_equivalent(u.Jy / u.beam):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2659,13 +2659,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         if not scipyOK:
             raise ImportError("Scipy could not be imported: this function won't work.")
 
-        if self.unit.is_equivalent(u.Jy / u.beam) and raise_error_jybm:
-            if raise_error_jybm:
-                raise BeamUnitsError("Attempting to change the spatial resolution of a cube with Jy/beam units."
-                                     " To ignore this error, set `raise_error_jybm=False`.")
-            else:
-                warnings.warn("Changing the spatial resolution of a cube with Jy/beam units."
-                              " The brightness units may be wrong!", BeamWarning)
+        self.check_jybeam_smoothing(raise_error_jybm=raise_error_jybm)
 
         def _msmooth_image(im, **kwargs):
             return ndimage.filters.median_filter(im, size=ksize, **kwargs)
@@ -2698,13 +2692,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             Passed to the convolve function
         """
 
-        if self.unit.is_equivalent(u.Jy / u.beam) and raise_error_jybm:
-            if raise_error_jybm:
-                raise BeamUnitsError("Attempting to change the spatial resolution of a cube with Jy/beam units."
-                                     " To ignore this error, set `raise_error_jybm=False`.")
-            else:
-                warnings.warn("Changing the spatial resolution of a cube with Jy/beam units."
-                              " The brightness units may be wrong!", BeamWarning)
+        self.check_jybeam_smoothing(raise_error_jybm=raise_error_jybm)
 
         def _gsmooth_image(img, **kwargs):
             """
@@ -3587,13 +3575,7 @@ class SpectralCube(BaseSpectralCube, BeamMixinClass):
         if not isinstance(beam, Beam):
             raise TypeError("beam must be a radio_beam.Beam object.")
 
-        if self.unit.is_equivalent(u.Jy/u.beam) and self.beam is not None:
-
-            if raise_error_jybm:
-                raise BeamUnitsError("Attempting to change the beams of a cube with Jy/beam units."
-                                     " To ignore this error, set `raise_error_jybm=False`.")
-            else:
-                warnings.warn("Changing the beams of a cube with Jy/beam units. The brightness units may be wrong!", BeamWarning)
+        self.check_jybeam_smoothing(raise_error_jybm=raise_error_jybm)
 
         meta = self._meta.copy()
         meta['beam'] = beam

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -52,7 +52,7 @@ from .utils import (cached, warn_slow, VarianceWarning, BeamWarning,
                     NotImplementedWarning, SliceWarning, SmoothingWarning,
                     StokesWarning, ExperimentalImplementationWarning,
                     BeamAverageWarning, NonFiniteBeamsWarning, BeamWarning,
-                    WCSCelestialError)
+                    WCSCelestialError, BeamUnitsError)
 from .spectral_axis import (determine_vconv_from_ctype, get_rest_value_from_wcs,
                             doppler_beta, doppler_gamma, doppler_z)
 from .io.core import SpectralCubeRead, SpectralCubeWrite
@@ -3550,7 +3550,7 @@ class SpectralCube(BaseSpectralCube, BeamMixinClass):
 
     _new_cube_with.__doc__ = BaseSpectralCube._new_cube_with.__doc__
 
-    def with_beam(self, beam):
+    def with_beam(self, beam, raise_error_jybm=True):
         '''
         Attach a beam object to the `~SpectralCube`.
 
@@ -3563,6 +3563,14 @@ class SpectralCube(BaseSpectralCube, BeamMixinClass):
 
         if not isinstance(beam, Beam):
             raise TypeError("beam must be a radio_beam.Beam object.")
+
+        if self.unit.is_equivalent(u.Jy/u.beam) and self.beam is not None:
+
+            if raise_error_jybm:
+                raise BeamUnitsError("Attempting to change the beams of a cube with Jy/beam units."
+                                     " To ignore this error, set `raise_error_jybm=False`.")
+            else:
+                warnings.warn("Changing the beams of a cube with Jy/beam units. The brightness units may be wrong!", BeamWarning)
 
         meta = self._meta.copy()
         meta['beam'] = beam

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -16,7 +16,7 @@ from ..spectral_cube import SpectralCube
 from ..masks import BooleanArrayMask
 from ..lower_dimensional_structures import (Projection, Slice, OneDSpectrum,
                                             VaryingResolutionOneDSpectrum)
-from ..utils import SliceWarning, WCSCelestialError
+from ..utils import SliceWarning, WCSCelestialError, BeamUnitsError
 from . import path
 
 # set up for parametrization
@@ -425,6 +425,26 @@ def test_ldo_attach_beam(LDO, data):
 
     assert new_p.beam == newbeam
     assert new_p.meta['beam'] == newbeam
+
+
+
+@pytest.mark.xfail(raises=BeamUnitsError, strict=True)
+@pytest.mark.parametrize(('LDO', 'data'),
+                         zip(LDOs, data_twelve))
+def test_ldo_attach_beam_jybm_error(LDO, data):
+
+    exp_beam = Beam(1.0 * u.arcsec)
+    newbeam = Beam(2.0 * u.arcsec)
+
+    data = data.value * u.Jy / u.beam
+
+    p = LDO(data, copy=False, beam=exp_beam)
+
+    # Attaching with no beam should work.
+    new_p = p.with_beam(newbeam)
+
+    # Trying to change the beam should now raise a BeamUnitsError
+    new_p = new_p.with_beam(newbeam)
 
 
 @pytest.mark.parametrize(('LDO', 'data'),

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2359,6 +2359,32 @@ def test_spatial_smooth_t2d(data_adv, use_dask):
     np.testing.assert_almost_equal(cube_t2d[2].value, result2)
 
 
+@pytest.mark.openfiles_ignore
+@pytest.mark.parametrize('filename', ['point_source_5_one_beam', 'point_source_5_spectral_beams'],
+                         indirect=['filename'])
+@pytest.mark.xfail(raises=utils.BeamUnitsError, strict=True)
+def test_spatial_smooth_jybm_error(filename, use_dask):
+    '''Raise an error when Jy/beam units are getting spatially smoothed. This tests SCs and VRSCs'''
+
+    cube, data = cube_and_raw(filename, use_dask=use_dask)
+
+    # Tophat 2D smoothing test
+    t2d = Tophat2DKernel(3)
+    cube_t2d = cube.spatial_smooth(t2d)
+
+
+@pytest.mark.openfiles_ignore
+@pytest.mark.parametrize('filename', ['point_source_5_one_beam', 'point_source_5_spectral_beams'],
+                         indirect=['filename'])
+@pytest.mark.xfail(raises=utils.BeamUnitsError, strict=True)
+def test_spatial_smooth_median_jybm_error(filename, use_dask):
+    '''Raise an error when Jy/beam units are getting spatially median smoothed. This tests SCs and VRSCs'''
+
+    cube, data = cube_and_raw(filename, use_dask=use_dask)
+
+    cube_median = cube.spatial_smooth_median(3)
+
+
 def test_spatial_smooth_median(data_adv, use_dask):
 
     pytest.importorskip('scipy.ndimage')

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -1610,7 +1610,7 @@ def test_multibeam_custom(data_vda_beams, use_dask):
     new_beams = Beams([1.] * cube.shape[0] * u.deg)
 
     # Attach the beam
-    newcube = cube.with_beams(new_beams)
+    newcube = cube.with_beams(new_beams, raise_error_jybm=False)
 
     try:
         assert all(new_beams == newcube.beams)
@@ -1630,7 +1630,20 @@ def test_multibeam_custom_wrongshape(data_vda_beams, use_dask):
     new_beams = Beams([1.] * cube.shape[0] * u.deg)
 
     # Attach the beam
-    cube.with_beams(new_beams[:1])
+    cube.with_beams(new_beams[:1], raise_error_jybm=False)
+
+
+@pytest.mark.openfiles_ignore
+@pytest.mark.xfail(raises=utils.BeamUnitsError, strict=True)
+def test_multibeam_jybm_error(data_vda_beams, use_dask):
+
+    cube, data = cube_and_raw(data_vda_beams, use_dask=use_dask)
+
+    # Make a new set of beams that differs from the original.
+    new_beams = Beams([1.] * cube.shape[0] * u.deg)
+
+    # Attach the beam
+    newcube = cube.with_beams(new_beams, raise_error_jybm=True)
 
 
 def test_multibeam_slice(data_vda_beams, use_dask):

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2109,7 +2109,7 @@ def test_convolve_to_jybeam_onebeam(point_source_5_one_beam, use_dask):
     convolved = cube.convolve_to(Beam(10*u.arcsec))
 
     # The peak of the point source should remain constant in Jy/beam
-    np.testing.assert_allclose(convolved[:, 5, 5].value, 1., atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(convolved[:, 5, 5].value, cube[:, 5, 5].value, atol=1e-5, rtol=1e-5)
 
     assert cube.unit == u.Jy / u.beam
 
@@ -2121,7 +2121,7 @@ def test_convolve_to_jybeam_multibeams(point_source_5_spectral_beams, use_dask):
     convolved = cube.convolve_to(Beam(10*u.arcsec))
 
     # The peak of the point source should remain constant in Jy/beam
-    np.testing.assert_allclose(convolved[:, 5, 5].value, 1., atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(convolved[:, 5, 5].value, cube[:, 5, 5].value, atol=1e-5, rtol=1e-5)
 
     assert cube.unit == u.Jy / u.beam
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2103,6 +2103,29 @@ def test_convolve_to(data_vda_beams, use_dask):
                                  nan_treatment='fill')
 
 
+def test_convolve_to_jybeam_onebeam(point_source_5_one_beam, use_dask):
+    cube, data = cube_and_raw(point_source_5_one_beam, use_dask=use_dask)
+
+    convolved = cube.convolve_to(Beam(10*u.arcsec))
+
+    # The peak of the point source should remain constant in Jy/beam
+    np.testing.assert_allclose(convolved[:, 5, 5].value, 1., atol=1e-5, rtol=1e-5)
+
+    assert cube.unit == u.Jy / u.beam
+
+
+def test_convolve_to_jybeam_multibeams(point_source_5_spectral_beams, use_dask):
+    cube, data = cube_and_raw(point_source_5_spectral_beams, use_dask=use_dask)
+
+
+    convolved = cube.convolve_to(Beam(10*u.arcsec))
+
+    # The peak of the point source should remain constant in Jy/beam
+    np.testing.assert_allclose(convolved[:, 5, 5].value, 1., atol=1e-5, rtol=1e-5)
+
+    assert cube.unit == u.Jy / u.beam
+
+
 def test_convolve_to_with_bad_beams(data_vda_beams, use_dask):
     cube, data = cube_and_raw(data_vda_beams, use_dask=use_dask)
 

--- a/spectral_cube/utils.py
+++ b/spectral_cube/utils.py
@@ -105,3 +105,6 @@ class FITSReadError(Exception):
 
 class NoBeamError(Exception):
     pass
+
+class BeamUnitsError(Exception):
+    pass


### PR DESCRIPTION
From #673: Operation like convolution when the data is in Jy/beam were not accounting for the unit change when the beam is altered. This PR adds correct handling for the units in these operations.

* [x] `convolve_to` Correction for beam ratios.

Otherwise, Jy/beam conversions cannot be predicted easily for general smoothing kernels. I've assed raising an error (or option to suppress into a warning) when Jy/beam units are defined and the spatial resolution will be changed, or `with_beam` to append a different sized beam(s).
* [x] `spatial_smooth_median`
* [x] `spatial_smooth`
* [x] `with_beam`. 

Pixel size changes **To be moved to a separate PR**:
* `downsample_axis` (pixel scale altered?)
* `reproject`