### PR TITLE
Support AIPS-style unit specification

### DIFF
--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -70,6 +70,14 @@ def prepare_4_beams():
     beams['CHAN'] = [0,1,2,3]
     beams['POL'] = [0,0,0,0]
     beams = fits.BinTableHDU(beams)
+
+    beams.header['TTYPE1'] = 'BMAJ'
+    beams.header['TUNIT1'] = 'arcsec'
+    beams.header['TTYPE2'] = 'BMIN'
+    beams.header['TUNIT2'] = 'arcsec'
+    beams.header['TTYPE3'] = 'BPA'
+    beams.header['TUNIT3'] = 'deg'
+
     return beams
 
 
@@ -351,6 +359,27 @@ def data_455_delta_beams(tmp_path):
 
 
 @pytest.fixture
+def data_455_degree_beams(tmp_path):
+    """
+    Test cube for AIPS-style beam specfication
+    """
+    h = prepare_255_header()
+    d = np.zeros([4,5,5], dtype='float')
+    beams = prepare_4_beams()
+    beams.data['BMAJ'] /= 3600
+    beams.data['BMIN'] /= 3600
+    beams.header['TTYPE1'] = 'BMAJ'
+    beams.header['TUNIT1'] = 'DEGREES'
+    beams.header['TTYPE2'] = 'BMIN'
+    beams.header['TUNIT2'] = 'DEGREES'
+
+    hdul = fits.HDUList([fits.PrimaryHDU(data=d, header=h),
+                         beams])
+    hdul.writeto(tmp_path / '455_degree_beams.fits')
+    return tmp_path / '455_degree_beams.fits'
+
+
+@pytest.fixture
 def data_522_delta(tmp_path):
     h = prepare_255_header()
     d = np.zeros([5,2,2], dtype='float')
@@ -369,6 +398,12 @@ def prepare_5_beams():
     beams['CHAN'] = [0,1,2,3,4]
     beams['POL'] = [0,0,0,0,0]
     beams = fits.BinTableHDU(beams)
+    beams.header['TTYPE1'] = 'BMAJ'
+    beams.header['TUNIT1'] = 'arcsec'
+    beams.header['TTYPE2'] = 'BMIN'
+    beams.header['TUNIT2'] = 'arcsec'
+    beams.header['TTYPE3'] = 'BPA'
+    beams.header['TUNIT3'] = 'deg'
     return beams
 
 

--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -484,6 +484,14 @@ def prepare_5_beams_with_pixscale(pixel_scale):
     beams['CHAN'] = [0,1,2,3,4]
     beams['POL'] = [0,0,0,0,0]
     beams = fits.BinTableHDU(beams)
+
+    beams.header['TTYPE1'] = 'BMAJ'
+    beams.header['TUNIT1'] = 'arcsec'
+    beams.header['TTYPE2'] = 'BMIN'
+    beams.header['TUNIT2'] = 'arcsec'
+    beams.header['TTYPE3'] = 'BPA'
+    beams.header['TUNIT3'] = 'deg'
+
     return beams
 
 

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -11,6 +11,7 @@ from astropy.wcs import WCS
 from collections import OrderedDict
 from astropy.io.fits.hdu.hdulist import fitsopen as fits_open
 from astropy.io.fits.connect import FITS_SIGNATURE
+from astropy import units as u
 
 import numpy as np
 import datetime

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -101,11 +101,10 @@ def read_data_fits(input, hdu=None, mode='denywrite', **kwargs):
 
                     # Check that the table has the expected form for beam units:
                     # 1: BMAJ 2: BMIN 3: BPA
-                    for key in ['TUNIT']:
-                        for i in range(1, 4):
-                            if not f"{key}{i}" in hdu_item.header:
-                                raise BeamUnitsError(f"Missing beam units keyword {key}{i}"
-                                                     " in the header.")
+                    for i in range(1, 4):
+                        if not f"TUNIT{i}" in hdu_item.header:
+                            raise BeamUnitsError(f"Missing beam units keyword {key}{i}"
+                                                    " in the header.")
 
                     # Read the bmaj/bmin units from the header
                     # (we still assume BPA is degrees because we've never seen an exceptional case)

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -85,6 +85,8 @@ def read_data_fits(input, hdu=None, mode='denywrite', **kwargs):
 
     beam_table = None
 
+    beam_units = (u.arcsec, u.arcsec)
+
     if isinstance(input, fits.HDUList):
 
         # Parse all array objects
@@ -95,6 +97,26 @@ def read_data_fits(input, hdu=None, mode='denywrite', **kwargs):
             elif isinstance(hdu_item, fits.BinTableHDU):
                 if 'BPA' in hdu_item.data.names:
                     beam_table = hdu_item.data
+
+                    # Read the bmaj/bmin units from the header
+                    # (we still assume BPA is degrees because we've never seen an exceptional case)
+                    # this will crash if there is no appropriate header info
+                    maj_kw = [kw for kw, val in hdu_item.header.items() if val == 'BMAJ'][0]
+                    min_kw = [kw for kw, val in hdu_item.header.items() if val == 'BMIN'][0]
+                    maj_unit = hdu_item.header[maj_kw.replace('TTYPE', 'TUNIT')]
+                    min_unit = hdu_item.header[min_kw.replace('TTYPE', 'TUNIT')]
+
+                    # AIPS uses non-FITS-standard unit names; this catches the
+                    # only case we've seen so far
+                    if maj_unit == 'DEGREES':
+                        maj_unit = 'degree'
+                    if min_unit == 'DEGREES':
+                        min_unit = 'degree'
+
+                    maj_unit = u.Unit(maj_unit)
+                    min_unit = u.Unit(min_unit)
+
+                    beam_units = (maj_unit, min_unit)
 
         if len(arrays) > 1:
             if hdu is None:
@@ -131,7 +153,7 @@ def read_data_fits(input, hdu=None, mode='denywrite', **kwargs):
         with fits_open(input, mode=mode, **kwargs) as hdulist:
             return read_data_fits(hdulist, hdu=hdu)
 
-    return array_hdu.data, array_hdu.header, beam_table
+    return array_hdu.data, array_hdu.header, beam_table, beam_units
 
 
 def load_fits_cube(input, hdu=0, meta=None, target_cls=None, use_dask=False, **kwargs):
@@ -155,7 +177,7 @@ def load_fits_cube(input, hdu=0, meta=None, target_cls=None, use_dask=False, **k
         SC = SpectralCube
         VRSC = VaryingResolutionSpectralCube
 
-    data, header, beam_table = read_data_fits(input, hdu=hdu, **kwargs)
+    data, header, beam_table, beam_units = read_data_fits(input, hdu=hdu, **kwargs)
 
     if data is None:
         raise FITSReadError('No data found in HDU {0}. You can try using the hdu= '
@@ -183,7 +205,8 @@ def load_fits_cube(input, hdu=0, meta=None, target_cls=None, use_dask=False, **k
             cube = SC(data, wcs, mask, meta=meta, header=header)
         else:
             cube = VRSC(data, wcs, mask, meta=meta, header=header,
-                        beam_table=beam_table)
+                        beam_table=beam_table, major_unit=beam_units[0],
+                        minor_unit=beam_units[1])
 
         if hasattr(cube._mask, '_data'):
             # check that the shape matches if there is a shape
@@ -207,7 +230,10 @@ def load_fits_cube(input, hdu=0, meta=None, target_cls=None, use_dask=False, **k
                 stokes_data[component] = VRSC(comp_data, wcs=comp_wcs,
                                               mask=comp_mask, meta=meta,
                                               header=header,
-                                              beam_table=beam_table)
+                                              beam_table=beam_table,
+                                              major_unit=beam_units[0],
+                                              minor_unit=beam_units[1]
+                                             )
 
         cube = StokesSpectralCube(stokes_data)
 

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -27,7 +27,7 @@ from ..dask_spectral_cube import DaskSpectralCube, DaskVaryingResolutionSpectral
 from ..lower_dimensional_structures import LowerDimensionalObject
 from ..spectral_cube import BaseSpectralCube
 from .. import cube_utils
-from ..utils import FITSWarning, FITSReadError, StokesWarning
+from ..utils import BeamUnitsError, FITSWarning, FITSReadError, StokesWarning
 
 
 def first(iterable):
@@ -98,6 +98,14 @@ def read_data_fits(input, hdu=None, mode='denywrite', **kwargs):
             elif isinstance(hdu_item, fits.BinTableHDU):
                 if 'BPA' in hdu_item.data.names:
                     beam_table = hdu_item.data
+
+                    # Check that the table has the expected form for beam units:
+                    # 1: BMAJ 2: BMIN 3: BPA
+                    for key in ['TUNIT']:
+                        for i in range(1, 4):
+                            if not f"{key}{i}" in hdu_item.header:
+                                raise BeamUnitsError(f"Missing beam units keyword {key}{i}"
+                                                     " in the header.")
 
                     # Read the bmaj/bmin units from the header
                     # (we still assume BPA is degrees because we've never seen an exceptional case)

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -3607,7 +3607,7 @@ class VaryingResolutionSpectralCube(BaseSpectralCube, MultiBeamMixinClass):
         else:
             return super().__new__(cls)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, major_unit=u.arcsec, minor_unit=u.arcsec, **kwargs):
         """
         Create a SpectralCube with an associated beam table.  The new
         VaryingResolutionSpectralCube will have a ``beams`` attribute and a
@@ -3653,8 +3653,8 @@ class VaryingResolutionSpectralCube(BaseSpectralCube, MultiBeamMixinClass):
 
         if beam_table is not None:
             # CASA beam tables are in arcsec, and that's what we support
-            beams = Beams(major=u.Quantity(beam_data_table['BMAJ'], u.arcsec),
-                          minor=u.Quantity(beam_data_table['BMIN'], u.arcsec),
+            beams = Beams(major=u.Quantity(beam_data_table['BMAJ'], major_unit),
+                          minor=u.Quantity(beam_data_table['BMIN'], minor_unit),
                           pa=u.Quantity(beam_data_table['BPA'], u.deg),
                           meta=[{key: row[key] for key in beam_data_table.names
                                  if key not in ('BMAJ','BPA', 'BMIN')}

--- a/spectral_cube/tests/test_io.py
+++ b/spectral_cube/tests/test_io.py
@@ -122,3 +122,15 @@ def test_1d_beams(data_5_spectral_beams, use_dask):
     assert hasattr(spec, 'beams')
     assert len(spec.beams) == 5
     hdu.close()
+
+
+
+def test_aips_beams_units(tmpdir, data_455_degree_beams, use_dask):
+    """
+    regression test for #737, AIPS beam unit specs (degrees)
+    """
+    c = SpectralCube.read(data_455_degree_beams, use_dask=use_dask)
+    np.testing.assert_almost_equal(c.beams[0].major.value, 0.4/3600)
+    np.testing.assert_almost_equal(c.beams[0].minor.value, 0.1/3600)
+    np.testing.assert_almost_equal(c.beams[0].major.to(u.arcsec).value, 0.4)
+    np.testing.assert_almost_equal(c.beams[0].minor.to(u.arcsec).value, 0.1)


### PR DESCRIPTION
The beam units are specified in the header of the BinTableHDU; we should be reading those when they're legit.  Of course, in the first case we've seen them vary, AIPS uses non-standard unit names.