### PR TITLE
np.float is deprecated

### DIFF
--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -225,7 +225,7 @@ class MaskBase(object):
         """
         # Must convert to floating point, but should not change from inherited
         # type otherwise
-        dt = np.find_common_type([data.dtype], [np.float])
+        dt = np.find_common_type([data.dtype], [float])
 
         if use_memmap and data.size > 0:
             ntf = tempfile.NamedTemporaryFile()

--- a/spectral_cube/wcs_utils.py
+++ b/spectral_cube/wcs_utils.py
@@ -392,7 +392,7 @@ def check_equality(wcs1, wcs2, warn_missing=False,
                     else:
                         OK = False
                         log.debug("Header 1, {0}: {1} != {2}".format(key,u1,u2))
-            elif isinstance(c1[1], (float, np.float)):
+            elif isinstance(c1[1], float):
                 try:
                     if exact:
                         assert c1[1] == c2[1]


### PR DESCRIPTION
spectral_cube/wcs_utils.py:395: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`.
To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe.
If you specifically wanted the numpy scalar type, use `np.float64` here.

Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations