### PR TITLE
Added stokes_data public method

### DIFF
--- a/spectral_cube/stokes_spectral_cube.py
+++ b/spectral_cube/stokes_spectral_cube.py
@@ -9,7 +9,7 @@ from .spectral_cube import SpectralCube, BaseSpectralCube
 from . import wcs_utils
 from .masks import BooleanArrayMask, is_broadcastable_and_smaller
 
-__all__ = ['StokesSpectalCube']
+__all__ = ['StokesSpectralCube']
 
 VALID_STOKES = ['I', 'Q', 'U', 'V', 'RR', 'LL', 'RL', 'LR', 'XX', 'XY', 'YX', 'YY', 
                 'RX', 'RY', 'LX', 'LY', 'XR,', 'XL', 'YR', 'YL', 'PP', 'PQ', 'QP', 'QQ', 
@@ -64,6 +64,13 @@ class StokesSpectralCube(object):
     @property
     def shape(self):
         return self._shape
+
+    @property
+    def stokes_data(self):
+        """
+        The underlying data
+        """
+        return self._stokes_data
 
     @property
     def mask(self):


### PR DESCRIPTION
It was previously not possible to cleanly access the underlying data of
a `StokesSpectralCube`, which only had the `_stokes_data` method. This
commit implements a simple `StokesSpectralCube.stokes_data` method for
public access.

This implements the first suggestion in #750