### PR TITLE
install with --upgrade

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -30,6 +30,7 @@ To install the latest stable release, you can type::
 
     pip install spectral-cube
 
+(you may need to add ``--upgrade`` if you already have an older version installed) 
 or you can download the latest tar file from
 `PyPI <https://pypi.python.org/pypi/spectral-cube>`_ and install it using::
 


### PR DESCRIPTION
@jmangum reported that he needed `--upgrade` to install an updated version of spectral-cube; I thought that wasn't generally needed but :shrug: