### PR TITLE
Remove if statement that stops tox from running tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,6 @@ jobs:
     - name: Install testing dependencies
       run: python -m pip install tox codecov
     - name: Run tests with ${{ matrix.name }}
-      if: ${{ contains(matrix.toxenv,'-cov') }}
       run: tox -v -e ${{ matrix.toxenv }}
     - name: Upload coverage to codecov
       if: ${{ contains(matrix.toxenv,'-cov') }}


### PR DESCRIPTION
Found an accidental line from https://github.com/radio-astro-tools/spectral-cube/commit/31b2df04d8ceb4c8a9efd20c641ca77c2b542362 stopping tests from running without coverage enabled.