### PR TITLE
Refactor: use data * unit rather than u.Quantity(data, unit)

### DIFF
--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -850,6 +850,14 @@ def lazy_quantity(data, unit, **kwargs):
             conversion = data.unit.to(unit)
             datacopy = copy.copy(data)
             datacopy.unit = unit
+            datacopy._unit = unit
             return datacopy * conversion
     else:
-        return data * unit
+        mul = data * unit
+
+        # dask arrays don't get the attribute
+        if not hasattr(mul, 'unit'):
+            mul.unit = unit
+            mul._unit = unit
+
+        return mul

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -850,7 +850,6 @@ def lazy_quantity(data, unit, **kwargs):
             conversion = data.unit.to(unit)
             datacopy = copy.copy(data)
             datacopy.unit = unit
-            datacopy._unit = unit
             return datacopy * conversion
     else:
         mul = data * unit
@@ -858,6 +857,5 @@ def lazy_quantity(data, unit, **kwargs):
         # dask arrays don't get the attribute
         if not hasattr(mul, 'unit'):
             mul.unit = unit
-            mul._unit = unit
 
         return mul

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -930,8 +930,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             raise AssertionError("Function could not be applied to a simple "
                                  "cube.  The error was: {0}".format(ex))
 
-        data = function(lazy_quantity(self._get_filled_data(fill=self._fill_value), self.unit),
-                        *args)
+        ldata = lazy_quantity(self._get_filled_data(fill=self._fill_value), self.unit)
+
+        data = function(ldata, *args)
+        assert hasattr(data, 'unit')
 
         return self._new_cube_with(data=data, unit=data.unit)
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -183,6 +183,8 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                 self._unit = cube_utils.convert_bunit(self._meta["BUNIT"])
             elif hasattr(data, 'unit'):
                 self._unit = data.unit
+            elif hasattr(data, '_meta'):
+                self._unit = getattr(data._meta, 'unit', None)
             else:
                 self._unit = None
         else:


### PR DESCRIPTION
It appears that `u.Quantity(data, unit)` triggers a full file read, which is disastrous as the whole point of spectral-cube is _not_ to trigger unnecessary IO.

My preference for using that construct came from some very old insight gained when performance testing code for `pyradex`.  If you're adding units a lot of time in a loop, `data * unit` is expensive.  But, we're not expecting to add the units many times - that's not a likely bottleneck.  Instead, IO is a bottleneck. It makes more sense to have:

```python
data_with_unit = cube._data * u.K
```
than
```python
data_with_unit = u.Quantity(cube._data, unit=u.K, copy=False)
```
for our use cases; we often want to stitch units onto dask arrays, which doesn't play well with `u.Quantity`'s constructor.

(caveat: I haven't tested this yet, so it's possible there's some astropy version dependence)