### PR TITLE
Bugfix: change isinstance checks to base class

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2174,7 +2174,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         Given a value, check if it has a unit.  If it does, convert to the
         cube's unit.  If it doesn't, raise an exception.
         """
-        if isinstance(value, SpectralCube):
+        if isinstance(value, BaseSpectralCube):
             if self.unit.is_equivalent(value.unit):
                 return value
             else:
@@ -2226,7 +2226,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         return LazyComparisonMask(operator.ne, value, data=self._data, wcs=self._wcs)
 
     def __add__(self, value):
-        if isinstance(value, SpectralCube):
+        if isinstance(value, BaseSpectralCube):
             return self._cube_on_cube_operation(operator.add, value)
         else:
             value = self._val_to_own_unit(value, operation='add', tofrom='from',
@@ -2234,7 +2234,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             return self._apply_everywhere(operator.add, value)
 
     def __sub__(self, value):
-        if isinstance(value, SpectralCube):
+        if isinstance(value, BaseSpectralCube):
             return self._cube_on_cube_operation(operator.sub, value)
         else:
             value = self._val_to_own_unit(value, operation='subtract',
@@ -2242,7 +2242,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             return self._apply_everywhere(operator.sub, value)
 
     def __mul__(self, value):
-        if isinstance(value, SpectralCube):
+        if isinstance(value, BaseSpectralCube):
             return self._cube_on_cube_operation(operator.mul, value)
         else:
             return self._apply_everywhere(operator.mul, value)
@@ -2251,13 +2251,13 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         return self.__div__(value)
 
     def __div__(self, value):
-        if isinstance(value, SpectralCube):
+        if isinstance(value, BaseSpectralCube):
             return self._cube_on_cube_operation(operator.truediv, value)
         else:
             return self._apply_everywhere(operator.truediv, value)
 
     def __pow__(self, value):
-        if isinstance(value, SpectralCube):
+        if isinstance(value, BaseSpectralCube):
             return self._cube_on_cube_operation(operator.pow, value)
         else:
             return self._apply_everywhere(operator.pow, value)

--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -248,9 +248,9 @@ def test_cube_on_cube(filename, request):
 
     # regression test for #782
     # (the regression applies only to CASA .image files)
-    cube = DaskSpectralCube.read(data_adv)
+    cube = DaskSpectralCube.read(dataname)
     assert isinstance(cube, DaskSpectralCube)
-    cube2 = SpectralCube.read(data_adv, use_dask=False)
+    cube2 = SpectralCube.read(dataname, use_dask=False)
     assert not isinstance(cube, DaskSpectralCube)
 
     with patch.object(cube, '_cube_on_cube_operation') as mock:

--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -244,6 +244,8 @@ def test_apply_function_parallel_shape(accepts_chunks):
 @pytest.mark.parametrize('filename', ('data_adv', 'data_adv_beams',
     'data_vda_beams', 'data_vda_beams_image'))
 def test_cube_on_cube(filename, request):
+    if 'image' in filename and not CASA_INSTALLED:
+        pytest.skip(reason='Requires CASA to be installed')
     dataname = request.getfixturevalue(filename)
 
     # regression test for #782

--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -249,7 +249,8 @@ def test_cube_on_cube(filename, request):
     dataname = request.getfixturevalue(filename)
 
     # regression test for #782
-    # (the regression applies only to CASA .image files)
+    # the regression applies only to VaryingResolutionSpectralCubes
+    # since they are not SpectralCube subclasses
     cube = DaskSpectralCube.read(dataname)
     assert isinstance(cube, DaskSpectralCube)
     cube2 = SpectralCube.read(dataname, use_dask=False)
@@ -263,7 +264,7 @@ def test_cube_on_cube(filename, request):
         cube * cube2
     mock.assert_called_once()
 
-    with patch.object(cube, '_cube_on_cube_operation') as mock:
+    with patch.object(cube2, '_cube_on_cube_operation') as mock:
         cube2 * cube
     mock.assert_called_once()
 

--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -4,6 +4,7 @@ import os
 from numpy.core.shape_base import block
 import pytest
 import numpy as np
+from mock import patch
 
 from numpy.testing import assert_allclose
 from astropy.tests.helper import assert_quantity_allclose
@@ -206,6 +207,7 @@ def test_apply_function_parallel_spectral_noncube_withblockinfo(data_adv):
     # Test all True
     assert np.all(test.compute())
 
+
 @pytest.mark.parametrize(('accepts_chunks'),
                          ((True, False)))
 def test_apply_function_parallel_shape(accepts_chunks):
@@ -237,6 +239,15 @@ def test_apply_function_parallel_shape(accepts_chunks):
                                    rslt2.filled_data[:].value)
     np.testing.assert_almost_equal(rslt.filled_data[:].value,
                                    rslt3.filled_data[:].value)
+
+
+def test_cube_on_cube(data_adv):
+    # regression test for #782
+    cube = DaskSpectralCube.read(data_adv)
+
+    with patch.object(cube, '_cube_on_cube_operation') as mock:
+        cube * cube
+    mock.assert_called_once()
 
 
 if DISTRIBUTED_INSTALLED:

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
+    mock
 isolated_build = true
 indexserver =
     NRAO = https://casa-pip.nrao.edu/repository/pypi-group/simple

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ changedir =
 description =
     run tests with pytest
 deps =
+    mock
     dev: git+https://github.com/radio-astro-tools/pvextractor#egg=pvextractor
     dev: git+https://github.com/radio-astro-tools/radio-beam#egg=radio-beam
     dev: git+https://github.com/astropy/astropy#egg=astropy


### PR DESCRIPTION
Right now, `cube*cube` will trigger `_apply_everywhere` instead of `_cube_on_cube_operation` if `cube` is a DaskSpectralCube.  This should fix that mistake.