### PR TITLE
Fix for issue 785: only warn if beam units unspecified

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ zip_safe = False
 packages = find:
 install_requires =
     astropy
-    numpy>=1.8.0
+    numpy>=1.8.0,<1.22
     radio_beam>=0.3.3
     six
     dask[array]

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ zip_safe = False
 packages = find:
 install_requires =
     astropy
-    numpy>=1.8.0,<1.22
+    numpy>=1.8.0
     radio_beam>=0.3.3
     six
     dask[array]

--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -138,6 +138,30 @@ def data_sdav(tmp_path):
 
 
 @pytest.fixture
+def data_sdav_beams_nounits(tmp_path):
+    """
+    For testing io when units are not specified
+    (they should be arcsec by default
+    """
+    d, h = prepare_advs_data()
+    d, h = transpose(d, h, [1, 2, 3, 0])
+    d, h = transpose(d, h, [1, 2, 3, 0])
+    d, h = transpose(d, h, [1, 2, 3, 0])
+    d, h = transpose(d, h, [0, 2, 1, 3])
+    del h['BMAJ'], h['BMIN'], h['BPA']
+    # want 4 spectral channels
+    np.random.seed(42)
+    d = np.random.random((4, 3, 2, 1))
+    beams = prepare_4_beams()
+    for ii in (1,2,3):
+        del beams[f'TUNIT{ii}']
+    hdul = fits.HDUList([fits.PrimaryHDU(data=d, header=h),
+                         beams])
+    hdul.writeto(tmp_path / 'sdav_beams_nounits.fits')
+    return tmp_path / 'sdav_beams_nounits.fits'
+
+
+@pytest.fixture
 def data_sdav_beams(tmp_path):
     d, h = prepare_advs_data()
     d, h = transpose(d, h, [1, 2, 3, 0])

--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -154,7 +154,7 @@ def data_sdav_beams_nounits(tmp_path):
     d = np.random.random((4, 3, 2, 1))
     beams = prepare_4_beams()
     for ii in (1,2,3):
-        del beams[f'TUNIT{ii}']
+        del beams.header[f'TUNIT{ii}']
     hdul = fits.HDUList([fits.PrimaryHDU(data=d, header=h),
                          beams])
     hdul.writeto(tmp_path / 'sdav_beams_nounits.fits')

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -102,17 +102,23 @@ def read_data_fits(input, hdu=None, mode='denywrite', **kwargs):
                     # Check that the table has the expected form for beam units:
                     # 1: BMAJ 2: BMIN 3: BPA
                     for i in range(1, 4):
-                        if not f"TUNIT{i}" in hdu_item.header:
-                            raise BeamUnitsError(f"Missing beam units keyword {key}{i}"
-                                                    " in the header.")
+                        key = f"TUNIT{i}"
+                        if key not in hdu_item.header:
+                            warnings.warn(BeamUnitsError(f"Missing beam units keyword {key}"
+                                                         " in the header."))
 
                     # Read the bmaj/bmin units from the header
                     # (we still assume BPA is degrees because we've never seen an exceptional case)
                     # this will crash if there is no appropriate header info
                     maj_kw = [kw for kw, val in hdu_item.header.items() if val == 'BMAJ'][0]
                     min_kw = [kw for kw, val in hdu_item.header.items() if val == 'BMIN'][0]
-                    maj_unit = hdu_item.header[maj_kw.replace('TTYPE', 'TUNIT')]
-                    min_unit = hdu_item.header[min_kw.replace('TTYPE', 'TUNIT')]
+                    try:
+                        maj_unit = hdu_item.header[maj_kw.replace('TTYPE', 'TUNIT')]
+                        min_unit = hdu_item.header[min_kw.replace('TTYPE', 'TUNIT')]
+                    except KeyError:
+                        # the default units, if unspecified (as from CASA <= 4.7.2, we think), are arcseconds
+                        maj_unit = u.arcsec
+                        min_unit = u.arcsec
 
                     # AIPS uses non-FITS-standard unit names; this catches the
                     # only case we've seen so far

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -27,7 +27,7 @@ from ..dask_spectral_cube import DaskSpectralCube, DaskVaryingResolutionSpectral
 from ..lower_dimensional_structures import LowerDimensionalObject
 from ..spectral_cube import BaseSpectralCube
 from .. import cube_utils
-from ..utils import BeamUnitsError, FITSWarning, FITSReadError, StokesWarning
+from ..utils import FITSWarning, FITSReadError, StokesWarning, BeamWarning
 
 
 def first(iterable):
@@ -104,8 +104,8 @@ def read_data_fits(input, hdu=None, mode='denywrite', **kwargs):
                     for i in range(1, 4):
                         key = f"TUNIT{i}"
                         if key not in hdu_item.header:
-                            warnings.warn(BeamUnitsError(f"Missing beam units keyword {key}"
-                                                         " in the header."))
+                            warnings.warn(BeamWarning(f"Missing beam units keyword {key}"
+                                                      " in the header."))
 
                     # Read the bmaj/bmin units from the header
                     # (we still assume BPA is degrees because we've never seen an exceptional case)

--- a/spectral_cube/tests/test_io.py
+++ b/spectral_cube/tests/test_io.py
@@ -96,6 +96,8 @@ def test_3d_beams_roundtrip(tmpdir, data_vda_beams, use_dask):
 
     np.testing.assert_almost_equal(c2.beams[0].major.value, 0.4)
     np.testing.assert_almost_equal(c2.beams[0].minor.value, 0.1)
+    assert c2.beams[0].major.unit == u.arcsec
+    assert c2.beams[0].minor.unit == u.arcsec
 
 
 def test_4d_beams_roundtrip(tmpdir, data_sdav_beams, use_dask):
@@ -112,6 +114,9 @@ def test_4d_beams_roundtrip(tmpdir, data_sdav_beams, use_dask):
 
     np.testing.assert_almost_equal(c2.beams[0].major.value, 0.4)
     np.testing.assert_almost_equal(c2.beams[0].minor.value, 0.1)
+    assert c2.beams[0].major.unit == u.arcsec
+    assert c2.beams[0].minor.unit == u.arcsec
+
 
 def test_1d(data_5_spectral):
     hdul = pyfits.open(data_5_spectral)

--- a/spectral_cube/tests/test_io.py
+++ b/spectral_cube/tests/test_io.py
@@ -75,6 +75,14 @@ def test_4d_beams(data_sdav_beams, use_dask):
     np.testing.assert_almost_equal(c.beams[0].minor.value, 0.1)
 
 
+def test_4d_beams_nounits(data_sdav_beams_nounits, use_dask):
+    c = SpectralCube.read(data_sdav_beams_nounits, use_dask=use_dask)
+    np.testing.assert_almost_equal(c.beams[0].major.value, 0.4)
+    np.testing.assert_almost_equal(c.beams[0].minor.value, 0.1)
+    assert c.beams[0].major.unit == u.arcsec
+    assert c.beams[0].minor.unit == u.arcsec
+
+
 def test_3d_beams_roundtrip(tmpdir, data_vda_beams, use_dask):
     c = SpectralCube.read(data_vda_beams, use_dask=use_dask)
     np.testing.assert_almost_equal(c.beams[0].major.value, 0.4)

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -708,9 +708,12 @@ def test_1d_slice_reductions(method, data_255_delta, use_dask):
     sp = cube[:,0,0]
 
     if hasattr(cube, method):
-        assert getattr(sp, method)() == getattr(cube, method)(axis=0)[0,0]
+        spmethod = getattr(sp, method)
+        cubemethod = getattr(cube, method)
+        assert spmethod() == cubemethod(axis=0)[0,0]
     else:
-        getattr(sp, method)()
+        method = getattr(sp, method)
+        result = method()
 
     assert hasattr(sp, '_fill_value')
 

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -19,6 +19,10 @@ from ..lower_dimensional_structures import (Projection, Slice, OneDSpectrum,
 from ..utils import SliceWarning, WCSCelestialError, BeamUnitsError
 from . import path
 
+# needed for regression in numpy
+import sys
+from astropy.utils.compat import NUMPY_LT_1_22
+
 # set up for parametrization
 LDOs = (Projection, Slice, OneDSpectrum)
 LDOs_2d = (Projection, Slice,)
@@ -697,6 +701,9 @@ def test_1d_slices(data_255_delta, use_dask):
     assert not isinstance(sp.max(), OneDSpectrum)
 
 
+# TODO: Unpin when Numpy bug is resolved.
+@pytest.mark.skipif(not NUMPY_LT_1_22 and sys.platform == 'win32',
+                    reason='https://github.com/numpy/numpy/issues/20699')
 @pytest.mark.parametrize('method',
                          ('min', 'max', 'std', 'mean', 'sum', 'cumsum',
                           'nansum', 'ptp', 'var'),

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -21,7 +21,12 @@ from . import path
 
 # needed for regression in numpy
 import sys
-from astropy.utils.compat import NUMPY_LT_1_22
+try:
+    from astropy.utils.compat import NUMPY_LT_1_22
+except ImportError:
+    # if astropy is an old version, we'll just skip the test
+    # (this is only used in one place)
+    NUMPY_LT_1_22 = False
 
 # set up for parametrization
 LDOs = (Projection, Slice, OneDSpectrum)


### PR DESCRIPTION
We assume the default unit is arcseconds