### PR TITLE
MNT: modernize yt usage

### DIFF
--- a/docs/yt_example.rst
+++ b/docs/yt_example.rst
@@ -69,7 +69,7 @@ produce a 3-d isocontour visualization using an object returned by
 
     import numpy as np
     from spectral_cube import SpectralCube
-    from yt.mods import ColorTransferFunction, write_bitmap
+    import yt
     import astropy.units as u
 
     # Read in spectral cube
@@ -87,7 +87,7 @@ produce a 3-d isocontour visualization using an object returned by
     dv = 0.02
 
     # Set up color transfer function
-    transfer = ColorTransferFunction((vmin, vmax))
+    transfer = yt.ColorTransferFunction((vmin, vmax))
     transfer.add_layers(n_v, dv, colormap='RdBu_r')
 
     # Set up the camera parameters

--- a/docs/yt_example.rst
+++ b/docs/yt_example.rst
@@ -58,7 +58,7 @@ in yt.
     following, but use of version 3.0 or later is recommended due to
     substantial improvements in support for FITS data. For more information on
     how yt handles FITS datasets, see `the yt docs
-    <http://yt-project.org/docs/3.0/examining/loading_data.html#fits-data>`_.
+    <http://yt-project.org/doc/examining/loading_data.html#fits-data>`_.
 
 Visualization example
 ---------------------
@@ -106,10 +106,10 @@ produce a 3-d isocontour visualization using an object returned by
 
     # Take a snapshot and save to a file
     snapshot = camera.snapshot()
-    write_bitmap(snapshot, 'cube_rendering.png', transpose=True)
+    yt.write_bitmap(snapshot, 'cube_rendering.png', transpose=True)
 
 You can move the camera around; see the `yt camera docs
-<http://yt-project.org/docs/dev/reference/api/generated/yt.visualization.volume_rendering.camera.Camera.html>`_.
+<https://yt-project.org/doc/reference/api/yt.visualization.volume_rendering.camera.html>`_.
 
 Movie Making
 ------------

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2318,7 +2318,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
 
         If using yt 3.0 or later, additional keyword arguments will be passed
         onto yt's ``FITSDataset`` constructor. See the yt documentation
-        (http://yt-project.org/docs/3.0/examining/loading_data.html?#fits-data)
+        (http://yt-project.org/doc/examining/loading_data.html?#fits-data)
         for details on options for reading FITS data.
         """
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2363,7 +2363,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
 
         else:
 
-            from yt.mods import load_uniform_grid
+            from yt import load_uniform_grid
 
             data = {'flux': self._get_filled_data(fill=0.).transpose()}
 


### PR DESCRIPTION
content:

- DOC: update links to current yt stable docs
- MNT: stop using discontinued yt.mods namespace

rationale: the yt.mods namespace is targetted for deprecation https://github.com/yt-project/yt/pull/3278
While I'm at it I fixed/updated a couple links to yt docs