### PR TITLE
Deprecation fix the 2nd: replace `mktemp` with `TemporaryDirectory`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.6.1.dev (unreleased)
 ----------------------
 - Fix memory issue when calling statistics() on FITS cubes. #752
+- Replace deprecated and insecure `mktemp` with `TemporaryDirectory` for
+  ``save_to_tmp_dir`` and add custom deletor to ensure cleanup. #796
 
 0.6 (2021-09-30)
 ----------------

--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -80,6 +80,19 @@ def test_save_to_tmp_dir(data_adv):
     assert cube_new._data.name.startswith('from-zarr')
 
 
+def test_cleanup_tmp_dir(data_adv):
+    '''Test that temporary directory is removed after deleting cube.'''
+    pytest.importorskip('zarr')
+    cube = DaskSpectralCube.read(data_adv)
+    cube_new = cube.sigma_clip_spectrally(3, save_to_tmp_dir=True)
+    tmp_dir = cube_new._tmpdir.name
+    assert os.path.exists(tmp_dir)
+    assert '.zarray' in os.listdir(tmp_dir)
+
+    del cube_new
+    assert not os.path.exists(tmp_dir)
+
+
 def test_rechunk(data_adv):
     cube = DaskSpectralCube.read(data_adv)
     assert cube._data.chunksize == (4, 3, 2)


### PR DESCRIPTION
Another go at replacing the deprecated function for the `save_to_tmp_dir` option, with an attempt to delete the temporary files along with the cube instance.
See however discussion about using `__del__` in https://github.com/radio-astro-tools/spectral-cube/pull/789#pullrequestreview-847262861.