### PR TITLE
Add function to show rendered dask array

### DIFF
--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -320,6 +320,13 @@ class DaskSpectralCubeMixin:
         lines[0] = lines[0][:-1] + ' and chunk size {0}:'.format(self._data.chunksize)
         return '\n'.join(lines)
 
+    def display_dask_array(self):
+        try:
+            from IPython.display import display
+            return display(self._data)
+        except ImportError:
+            warnings.warn("Requires IPython to display.")
+
     @add_save_to_tmp_dir_option
     def rechunk(self, chunks='auto', threshold=None, block_size_limit=None,
                 **kwargs):


### PR DESCRIPTION
Adds `cube.display_dask_array` to show the nicely rendered chunk diagram from a dask array in a jupyter notebook without needing to access the `dask.array` object (#795 ):

![image](https://user-images.githubusercontent.com/3255771/150688055-8f6117fc-3599-4274-aa4d-58f192868b57.png)
