### PR TITLE
Add a developing with spectral-cube docs page

### DIFF
--- a/docs/dask.rst
+++ b/docs/dask.rst
@@ -28,7 +28,8 @@ Most of the properties and methods that normally work with :class:`~spectral_cub
 should continue to work with :class:`~spectral_cube.DaskSpectralCube`.
 
 For an interactive demonstration, see the `Guide to Dask Optimization <https://github.com/radio-astro-tools/tutorials/pull/21>`_.
-.. TODO: UPDATE THE LINK TO THE TUTORIAL once merged
+..
+    TODO: UPDATE THE LINK TO THE TUTORIAL once merged
 
 Schedulers and parallel computations
 ------------------------------------

--- a/docs/dask.rst
+++ b/docs/dask.rst
@@ -1,3 +1,5 @@
+.. _doc_dask:
+
 Integration with dask
 =====================
 
@@ -25,6 +27,8 @@ To read in a FITS cube using the dask-enabled classes, you can do::
 Most of the properties and methods that normally work with :class:`~spectral_cube.SpectralCube`
 should continue to work with :class:`~spectral_cube.DaskSpectralCube`.
 
+For an interactive demonstration, see the `Guide to Dask Optimization <https://github.com/radio-astro-tools/tutorials/pull/21>`_.
+.. TODO: UPDATE THE LINK TO THE TUTORIAL once merged
 
 Schedulers and parallel computations
 ------------------------------------

--- a/docs/dask.rst
+++ b/docs/dask.rst
@@ -28,6 +28,7 @@ Most of the properties and methods that normally work with :class:`~spectral_cub
 should continue to work with :class:`~spectral_cube.DaskSpectralCube`.
 
 For an interactive demonstration, see the `Guide to Dask Optimization <https://github.com/radio-astro-tools/tutorials/pull/21>`_.
+
 ..
     TODO: UPDATE THE LINK TO THE TUTORIAL once merged
 

--- a/docs/developing_with_spectralcube.rst
+++ b/docs/developing_with_spectralcube.rst
@@ -58,7 +58,8 @@ of general usage and recommended practices, including:
 
 For an interactive demonstration of these features, see
 the `Guide to Dask Optimization <https://github.com/radio-astro-tools/tutorials/pull/21>`_.
-.. TODO: UPDATE THE LINK TO THE TUTORIAL once merged
+..
+    TODO: UPDATE THE LINK TO THE TUTORIAL once merged
 
 For further development, we highlight the ability to apply custom functions using dask.
 A :class:`DaskSpectralCube` loads the data as a `dask Array <https://docs.dask.org/en/stable/array.html>`_.
@@ -86,5 +87,6 @@ in parallel over chunks of the data. This fitting example is a guide for using
     * A change in array shape and dimensions in the output (`drop_axis` and `chunks` in `dask.array.map_blocks <https://docs.dask.org/en/stable/generated/dask.array.map_blocks.html#dask.array.map_blocks>`_)
     * Using dask's `block_info` dictionary in a custom function to track the location of a chunk in the cube
 
-.. TODO: UPDATE THE LINK TO THE TUTORIAL once merged
+..
+    TODO: UPDATE THE LINK TO THE TUTORIAL once merged
 

--- a/docs/developing_with_spectralcube.rst
+++ b/docs/developing_with_spectralcube.rst
@@ -27,7 +27,7 @@ Masking operations can be performed "lazily", where the computation is completed
 only when a view of the underlying boolean mask array is returned.
 See :ref:`doc_masking` for details on these implementations.
 
-Further strategies for handling large data is given in :ref:`_doc_handling_large_datasets`.
+Further strategies for handling large data is given in :ref:`doc_handling_large_datasets`.
 
 
 Parallelizing operations

--- a/docs/developing_with_spectralcube.rst
+++ b/docs/developing_with_spectralcube.rst
@@ -9,7 +9,7 @@ development beyond the core package's capabilities. Two significant strengths
 are the use of memory-mapping and the integration with `dask <https://dask.org/>`_
 (:ref:`doc_dask`) to efficiently handle larger than memory data.
 
-This page provides suggestions for developing using spectral-cube in other
+This page provides suggestions for software development using spectral-cube in other
 packages.
 
 The following two sections give information on standard usage of  :class:`SpectralCube`.
@@ -37,11 +37,11 @@ Several operations implemented in :class:`SpectralCube` can be parallelized
 using the `joblib <https://joblib.readthedocs.io/en/latest/>`_ package. Builtin methods
 in :class:`SpectralCube` with the `parallel` keyword will enable using joblib.
 
-New methods can take advantage of these features by using creating custom functions
+New methods can take advantage of these features by creating custom functions
 to pass to :meth:`SpectralCube.apply_function_parallel_spatial` and
-:meth:`SpectralCube.apply_function_parallel_spectral`. These methods expect
-functions with a data and mask array input, with optional `**kwargs` that can be
-passed and expect an output array of the same shape as the input.
+:meth:`SpectralCube.apply_function_parallel_spectral`. These methods accept
+functions that take a data and mask array input, with optional `**kwargs`, 
+and that return an output array of the same shape as the input.
 
 
 Unifying large-data handling and parallelization with dask

--- a/docs/developing_with_spectralcube.rst
+++ b/docs/developing_with_spectralcube.rst
@@ -1,0 +1,89 @@
+.. _doc_developersnotes:
+
+Notes for development using spectral-cube
+=========================================
+.. currentmodule:: spectral_cube
+
+spectral-cube is flexible and can used within other packages for
+development beyond the core package's capabilities. Two significant strengths
+are the use of memory-mapping and  the integration with `dask <https://dask.org/>`_
+(:ref:`doc_dask`) to efficiently larger than memory data.
+
+This page provides suggestions for developing using spectral-cube in other
+packages.
+
+The following two sections give information on standard usage of  :class:`SpectralCube`.
+The third discusses usage with dask integration.
+
+Handling large data cubes
+-------------------------
+
+spectral-cube is specifically designed for handling larger-than-memory data
+and minimizes creating copies of the data. :class:`SpectralCube` uses memory-mapping
+and provides options for executing operations with only subsets of the data
+(for example, the `how` keyword in `~SpectralCube.moment`).
+
+Masking operations can be performed "lazily", where the computation is completed
+only when a view of the underlying boolean mask array is returned (:ref:`doc_masking`).
+
+Further strategies for handling large data is given in :ref:`_doc_handling_large_datasets`.
+
+
+Parallelizing operations
+------------------------
+
+Several operations implemented in :class:`SpectralCube` can be parallelized
+using the `joblib <https://joblib.readthedocs.io/en/latest/>`_ package. Builtin methods
+in :class:`SpectralCube` with the `parallel` keyword will enable using joblib.
+
+New methods can take advantage of these features by using creating custom functions
+to pass to :meth:`SpectralCube.apply_function_parallel_spatial` and
+:meth:`SpectralCube.apply_function_parallel_spectral`. These methods expect
+functions with a data and mask array input, with optional `**kwargs` that can be
+passed, and expect an output array of the same shape as the input.
+
+
+Unifying large-data handling and parallelization with dask
+----------------------------------------------------------
+
+spectral-cube's dask integration unifies many of the above features and further
+options leveraging the dask ecosystem. The :ref:`doc_dask` page provides an overview
+of general usage and recommended practices, including:
+
+    * Using different dask schedulers (synchronous, threads, and distributed)
+    * Triggering dask executions and saving intermediate results to disk
+    * Efficiently rechunking large data for parallel operations
+    * Loading cubes in CASA image format
+
+For an interactive demonstration of these features, see
+the `Guide to Dask Optimization <https://github.com/radio-astro-tools/tutorials/pull/21>`_.
+.. TODO: UPDATE THE LINK TO THE TUTORIAL once merged
+
+For further development, we highlight the ability to apply custom functions using dask.
+A :class:`DaskSpectralCube` loads the data as a `dask Array <https://docs.dask.org/en/stable/array.html>`_.
+Similar to the non-dask :class:`SpectralCube`, custom function can be used with
+:meth:`DaskSpectralCube.apply_function_parallel_spectral` and
+:meth:`DaskSpectralCube.apply_function_parallel_spatial`. Effectively these are
+wrappers on `dask.array.map_blocks <https://docs.dask.org/en/stable/generated/dask.array.map_blocks.html#dask.array.map_blocks>`_
+and accept common kwargs.
+
+.. note::
+    The dask array can be accessed with `DaskSpectralCube._data` but we discourage
+    this as the builtin functions include checks, such as applying the mask to the
+    data.
+
+    If you have a use case needing on of dask array's other `operation tools <https://docs.dask.org/en/stable/array-best-practices.html#build-your-own-operations>`_
+    please raise an `issue on GitHub <https://github.com/radio-astro-tools/spectral-cube/issues>`_
+    so we can add this support!
+
+The :ref:`doc_dask` page gives a basic example of using a custom function. A more
+advanced example is shown in the `parallel fitting with dask tutorial <https://github.com/radio-astro-tools/tutorials/pull/12>`_.
+This tutorial demonstrates fitting a spectral model to every spectrum in a cube, applied
+in parallel over chunks of the data. This fitting example is a guide for using
+:meth:`DaskSpectralCube.apply_function_parallel_spectral` with:
+
+    * A change in array shape and dimensions in the output (`drop_axis` and `chunks` in `dask.array.map_blocks <https://docs.dask.org/en/stable/generated/dask.array.map_blocks.html#dask.array.map_blocks>`_)
+    * Using dask's `block_info` dictionary in a custom function to track the location of a chunk in the cube
+
+.. TODO: UPDATE THE LINK TO THE TUTORIAL once merged
+

--- a/docs/developing_with_spectralcube.rst
+++ b/docs/developing_with_spectralcube.rst
@@ -21,7 +21,7 @@ Handling large data cubes
 spectral-cube is specifically designed for handling larger-than-memory data
 and minimizes creating copies of the data. :class:`SpectralCube` uses memory-mapping
 and provides options for executing operations with only subsets of the data
-(for example, the `how` keyword in `~SpectralCube.moment`).
+(for example, the `how` keyword in :meth:`SpectralCube.moment`).
 
 Masking operations can be performed "lazily", where the computation is completed
 only when a view of the underlying boolean mask array is returned.

--- a/docs/developing_with_spectralcube.rst
+++ b/docs/developing_with_spectralcube.rst
@@ -58,6 +58,7 @@ of general usage and recommended practices, including:
 
 For an interactive demonstration of these features, see
 the `Guide to Dask Optimization <https://github.com/radio-astro-tools/tutorials/pull/21>`_.
+
 ..
     TODO: UPDATE THE LINK TO THE TUTORIAL once merged
 

--- a/docs/developing_with_spectralcube.rst
+++ b/docs/developing_with_spectralcube.rst
@@ -6,14 +6,14 @@ Notes for development using spectral-cube
 
 spectral-cube is flexible and can used within other packages for
 development beyond the core package's capabilities. Two significant strengths
-are the use of memory-mapping and  the integration with `dask <https://dask.org/>`_
-(:ref:`doc_dask`) to efficiently larger than memory data.
+are the use of memory-mapping and the integration with `dask <https://dask.org/>`_
+(:ref:`doc_dask`) to efficiently handle larger than memory data.
 
 This page provides suggestions for developing using spectral-cube in other
 packages.
 
 The following two sections give information on standard usage of  :class:`SpectralCube`.
-The third discusses usage with dask integration.
+The third discusses usage with dask integration in :class:`DaskSpectralCube`.
 
 Handling large data cubes
 -------------------------
@@ -24,7 +24,8 @@ and provides options for executing operations with only subsets of the data
 (for example, the `how` keyword in `~SpectralCube.moment`).
 
 Masking operations can be performed "lazily", where the computation is completed
-only when a view of the underlying boolean mask array is returned (:ref:`doc_masking`).
+only when a view of the underlying boolean mask array is returned.
+See :ref:`doc_masking` for details on these implementations.
 
 Further strategies for handling large data is given in :ref:`_doc_handling_large_datasets`.
 
@@ -40,7 +41,7 @@ New methods can take advantage of these features by using creating custom functi
 to pass to :meth:`SpectralCube.apply_function_parallel_spatial` and
 :meth:`SpectralCube.apply_function_parallel_spectral`. These methods expect
 functions with a data and mask array input, with optional `**kwargs` that can be
-passed, and expect an output array of the same shape as the input.
+passed and expect an output array of the same shape as the input.
 
 
 Unifying large-data handling and parallelization with dask
@@ -61,7 +62,7 @@ the `Guide to Dask Optimization <https://github.com/radio-astro-tools/tutorials/
 
 For further development, we highlight the ability to apply custom functions using dask.
 A :class:`DaskSpectralCube` loads the data as a `dask Array <https://docs.dask.org/en/stable/array.html>`_.
-Similar to the non-dask :class:`SpectralCube`, custom function can be used with
+Similar to the non-dask :class:`SpectralCube`, custom functions can be used with
 :meth:`DaskSpectralCube.apply_function_parallel_spectral` and
 :meth:`DaskSpectralCube.apply_function_parallel_spatial`. Effectively these are
 wrappers on `dask.array.map_blocks <https://docs.dask.org/en/stable/generated/dask.array.map_blocks.html#dask.array.map_blocks>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,4 +119,5 @@ Advanced
    dask.rst
    yt_example.rst
    big_data.rst
+   developing_with_spectralcube.rst
    api.rst

--- a/docs/masking.rst
+++ b/docs/masking.rst
@@ -1,3 +1,5 @@
+.. _doc_masking:
+
 Masking
 =======
 


### PR DESCRIPTION
Adding a page that lists out suggestions for incorporating spectral-cube in new packages, or adding custom functions to apply to cubes.

Also adds a bit more detail into how we use `dask.Array` under the hood.