### PR TITLE
Avoid redundant full-cube-passes when region submasking

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
 
 [options.extras_require]
 test =
+    mock
     pytest-astropy
     pytest-cov
 docs =
@@ -37,6 +38,10 @@ novis =
     reproject
     scipy
 all =
+    mock
+    pytest-astropy
+    pytest-cov
+    sphinx-astropy
     zarr
     fsspec
     distributed

--- a/spectral_cube/analysis_utilities.py
+++ b/spectral_cube/analysis_utilities.py
@@ -245,7 +245,7 @@ def stack_spectra(cube, velocity_surface, v0=None,
     pix_shifts = vdiff_sign * ((velocity_surface.to(vel_unit) -
                                 v0.to(vel_unit)) / vdiff).value[xy_posns]
 
-    # May a header copy so we can start altering
+    # Make a header copy so we can start altering
     new_header = cube[:, 0, 0].header.copy()
 
     if pad_edges:

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2064,9 +2064,11 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             If this is False, an exception will be raised if the region
             contains no overlap with the cube. Default is False.
         minimize : bool
-            Run `minimal_subcube`?  This should be redundant, since the
-            bounding box of the region is already used, but it might slice off
-            an extra few pixels depending on the details of the region shape.
+            Run `minimal_subcube`?  This is mostly redundant, since the
+            bounding box of the region is already used, but it will sometimes
+            slice off a one-pixel rind depending on the details of the region
+            shape.  If minimize is disabled, there will potentially be a ring
+            of NaN values around the outside.
         """
         import regions
 
@@ -2128,7 +2130,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         maskarray = np.zeros(subcube.shape[1:], dtype='bool')
         maskarray[:] = mask.data[slices_small]
 
-        BAM = BooleanArrayMask(maskarray, subcube.wcs.celestial, shape=subcube.shape[1:])
+        BAM = BooleanArrayMask(maskarray, subcube.wcs, shape=subcube.shape)
         masked_subcube = subcube.with_mask(BAM)
         # by using ceil / floor above, we potentially introduced a NaN buffer
         # that we can now crop out

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2064,7 +2064,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             If this is False, an exception will be raised if the region
             contains no overlap with the cube. Default is False.
         minimize : bool
-            Run `minimal_subcube`?  This is mostly redundant, since the
+            Run :meth:`~SpectralCube.minimal_subcube`.  This is mostly redundant, since the
             bounding box of the region is already used, but it will sometimes
             slice off a one-pixel rind depending on the details of the region
             shape.  If minimize is disabled, there will potentially be a ring

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2051,7 +2051,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         return self.subcube_from_regions(region_list, allow_empty)
 
     def subcube_from_regions(self, region_list, allow_empty=False,
-                             minimize=False):
+                             minimize=True):
         """
         Extract a masked subcube from a list of ``regions.Region`` object
         (only functions on celestial dimensions)


### PR DESCRIPTION
Region sub-masking has been using `minimal_subcube`, which shouldn't be necessary b/c we already downselect to the minimal bounding box.

Also, it was creating 3D masks when only 2D is needed - the broadcasting might therefore not have been done lazily.