### PR TITLE
Allow general filter use instead of just median filters

### DIFF
--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -114,7 +114,7 @@ class HeaderMixinClass(object):
 
         Parameters
         ----------
-        raise_error_jybeam : bool, optional
+        raise_error_jybm : bool, optional
             Raises a `~spectral_cube.utils.BeamUnitsError` when True (default). When False, it triggers a
             `~spectral_cube.utils.BeamWarning`.
 

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -901,9 +901,10 @@ class DaskSpectralCubeMixin:
                                                      accepts_chunks=True)
 
     @add_save_to_tmp_dir_option
-    def spectral_smooth_median(self, ksize, raise_error_jybm=True, **kwargs):
+    def spectral_smooth_median(self, ksize, raise_error_jybm=True,
+            filter=ndimage.filters.median_filter, **kwargs):
         return self.spectral_filter(ksize,
-                filter=ndimage.filters.median_filter, raise_error_jybm=True,
+                filter=filter, raise_error_jybm=True,
                 **kwargs)
 
     @add_save_to_tmp_dir_option
@@ -976,7 +977,7 @@ class DaskSpectralCubeMixin:
         return self.apply_function_parallel_spatial(convolve_wrapper, kernel=kernel.array)
 
     @add_save_to_tmp_dir_option
-    def spatial_smooth_median(self, ksize, raise_error_jybm=True, **kwargs):
+    def spatial_filter(self, ksize, filter, raise_error_jybm=True, **kwargs):
         """
         Smooth the image in each spatial-spatial plane of the cube using a median filter.
 
@@ -984,6 +985,8 @@ class DaskSpectralCubeMixin:
         ----------
         ksize : int
             Size of the median filter (scipy.ndimage.filters.median_filter)
+        filter : function
+            A filter from scipy.ndimage.filters
         raise_error_jybm : bool, optional
             Raises a `~spectral_cube.utils.BeamUnitsError` when smoothing a cube in Jy/beam units,
             since the brightness is dependent on the spatial resolution.
@@ -997,9 +1000,17 @@ class DaskSpectralCubeMixin:
         self.check_jybeam_smoothing(raise_error_jybm=raise_error_jybm)
 
         def median_filter_wrapper(data, ksize=None, **kwargs):
-            return ndimage.median_filter(data, ksize, **kwargs)
+            return filter(data, ksize, **kwargs)
 
         return self.apply_function_parallel_spatial(median_filter_wrapper, ksize=ksize)
+
+    def spatial_smooth_median(self, ksize, raise_error_jybm=True,
+            filter=ndimage.filters.median_filter, **kwargs):
+        """
+        Smooth the image in each spatial-spatial plane of the cube using a median filter.
+        """
+        return self.spatial_filter(ksize=ksize, filter=filter,
+                raise_error_jybm=raise_error_jybeam, **kwargs)
 
     def moment(self, order=0, axis=0, **kwargs):
         """

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -911,14 +911,14 @@ class DaskSpectralCubeMixin:
     def spectral_filter(self, ksize, filter, raise_error_jybm=True,
                         **kwargs):
         """
-        Smooth the cube along the spectral dimension using a filter
+        Smooth the cube along the spectral dimension using a scipy.ndimage filter.
 
         Parameters
         ----------
         ksize : int
-            Size of the median filter (scipy.ndimage.filters.median_filter)
+            Size of the median filter in spectral channels (scipy.ndimage.filters.median_filter).
         filter : function
-            A filter from scipy.ndimage.filters
+            A filter from `scipy.ndimage.filters <https://docs.scipy.org/doc/scipy/reference/ndimage.html#filters>`_.
         save_to_tmp_dir : bool
             If `True`, the computation will be carried out straight away and
             saved to a temporary directory. This can improve performance,
@@ -984,9 +984,9 @@ class DaskSpectralCubeMixin:
         Parameters
         ----------
         ksize : int
-            Size of the median filter (scipy.ndimage.filters.median_filter)
+            Size of the filter in pixels.
         filter : function
-            A filter from scipy.ndimage.filters
+            A filter from `scipy.ndimage.filters <https://docs.scipy.org/doc/scipy/reference/ndimage.html#filters>`_.
         raise_error_jybm : bool, optional
             Raises a `~spectral_cube.utils.BeamUnitsError` when smoothing a cube in Jy/beam units,
             since the brightness is dependent on the spatial resolution.

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -903,7 +903,7 @@ class DaskSpectralCubeMixin:
     @add_save_to_tmp_dir_option
     def spectral_smooth_median(self, ksize, raise_error_jybm=True, **kwargs):
         return self.spectral_filter(ksize,
-                function=ndimage.filters.median_filter, raise_error_jybm=True,
+                filter=ndimage.filters.median_filter, raise_error_jybm=True,
                 **kwargs)
 
     @add_save_to_tmp_dir_option

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -902,10 +902,10 @@ class DaskSpectralCubeMixin:
 
     @add_save_to_tmp_dir_option
     def spectral_smooth_median(self, ksize, raise_error_jybm=True,
-            filter=ndimage.filters.median_filter, **kwargs):
-        return self.spectral_filter(ksize,
-                filter=filter, raise_error_jybm=True,
-                **kwargs)
+                               filter=ndimage.filters.median_filter, **kwargs):
+        return self.spectral_filter(ksize, filter=filter,
+                                    raise_error_jybm=raise_error_jybm,
+                                    **kwargs)
 
     @add_save_to_tmp_dir_option
     def spectral_filter(self, ksize, filter, raise_error_jybm=True,
@@ -1010,7 +1010,7 @@ class DaskSpectralCubeMixin:
         Smooth the image in each spatial-spatial plane of the cube using a median filter.
         """
         return self.spatial_filter(ksize=ksize, filter=filter,
-                raise_error_jybm=raise_error_jybeam, **kwargs)
+                raise_error_jybm=raise_error_jybm, **kwargs)
 
     def moment(self, order=0, axis=0, **kwargs):
         """

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -902,13 +902,22 @@ class DaskSpectralCubeMixin:
 
     @add_save_to_tmp_dir_option
     def spectral_smooth_median(self, ksize, raise_error_jybm=True, **kwargs):
+        return self.spectral_filter(ksize,
+                function=ndimage.filters.median_filter, raise_error_jybm=True,
+                **kwargs)
+
+    @add_save_to_tmp_dir_option
+    def spectral_filter(self, ksize, filter, raise_error_jybm=True,
+                        **kwargs):
         """
-        Smooth the cube along the spectral dimension
+        Smooth the cube along the spectral dimension using a filter
 
         Parameters
         ----------
         ksize : int
             Size of the median filter (scipy.ndimage.filters.median_filter)
+        filter : function
+            A filter from scipy.ndimage.filters
         save_to_tmp_dir : bool
             If `True`, the computation will be carried out straight away and
             saved to a temporary directory. This can improve performance,
@@ -928,7 +937,7 @@ class DaskSpectralCubeMixin:
             raise TypeError('ksize should be an integer (got {0})'.format(ksize))
 
         def median_filter_wrapper(img, **kwargs):
-            return ndimage.median_filter(img, (ksize, 1, 1), **kwargs)
+            return filter(img, (ksize, 1, 1), **kwargs)
 
         return self.apply_function_parallel_spectral(median_filter_wrapper,
                                                      accepts_chunks=True)

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2729,7 +2729,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             Passed to the convolve function
         """
         return self.spatial_filter(ksize=ksize, filter=filter,
-                update_function=update_funciton,
+                update_function=update_function,
                 raise_error_jybeam=raise_error_jybeam, **kwargs)
 
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2729,8 +2729,8 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             Passed to the convolve function
         """
         return self.spatial_filter(ksize=ksize, filter=filter,
-                update_function=update_function,
-                raise_error_jybeam=raise_error_jybeam, **kwargs)
+                                   update_function=update_function,
+                                   raise_error_jybm=raise_error_jybm, **kwargs)
 
 
     @parallel_docstring

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2813,7 +2813,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         ksize : int
             Size of the median filter (scipy.ndimage.filters.median_filter)
         filter : function
-            A filter from scipy.ndimage.filters
+            A filter from `scipy.ndimage.filters <https://docs.scipy.org/doc/scipy/reference/ndimage.html#filters>`_.
         """
         # note: same body as spectral_smooth_median right now, but `filter`
         # is a required kwarg

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2716,9 +2716,9 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         Parameters
         ----------
         ksize : int
-            Size of the median filter (scipy.ndimage.filters.*_filter)
+            Size of the median filter in pixels (scipy.ndimage.filters.median_filter)
         filter : function
-            A filter from scipy.ndimage.filters
+            A filter from scipy.ndimage.filters. The default is the median filter.
         update_function : method
             Method that is called to update an external progressbar
             If provided, it disables the default `astropy.utils.console.ProgressBar`
@@ -2736,14 +2736,14 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
     @parallel_docstring
     def spatial_filter(self, ksize, filter, update_function=None, raise_error_jybm=True, **kwargs):
         """
-        Smooth the image in each spatial-spatial plane of the cube using a filter.
+        Smooth the image in each spatial-spatial plane of the cube using a scipy.ndimage filter.
 
         Parameters
         ----------
         ksize : int
-            Size of the median filter (scipy.ndimage.filters.*_filter)
+            Size of the filter in pixels (scipy.ndimage.filters.*_filter).
         filter : function
-            A filter from scipy.ndimage.filters
+            A filter from `scipy.ndimage.filters <https://docs.scipy.org/doc/scipy/reference/ndimage.html#filters>`_.
         update_function : method
             Method that is called to update an external progressbar
             If provided, it disables the default `astropy.utils.console.ProgressBar`
@@ -2806,7 +2806,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
     def spectral_filter(self, ksize, filter, use_memmap=True, verbose=0,
             num_cores=None, **kwargs):
         """
-        Smooth the cube along the spectral dimension using a filter
+        Smooth the cube along the spectral dimension using a scipy.ndimage filter.
 
         Parameters
         ----------

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2728,7 +2728,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         kwargs : dict
             Passed to the convolve function
         """
-        return self.spatial_filter(ksize, filter,
+        return self.spatial_filter(ksize=ksize, filter=filter,
                 update_function=update_funciton,
                 raise_error_jybeam=raise_error_jybeam, **kwargs)
 
@@ -2803,10 +2803,37 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         return newcube
 
     @parallel_docstring
+    def spectral_filter(self, ksize, filter, use_memmap=True, verbose=0,
+            num_cores=None, **kwargs):
+        """
+        Smooth the cube along the spectral dimension using a filter
+
+        Parameters
+        ----------
+        ksize : int
+            Size of the median filter (scipy.ndimage.filters.median_filter)
+        filter : function
+            A filter from scipy.ndimage.filters
+        """
+        # note: same body as spectral_smooth_median right now, but `filter`
+        # is a required kwarg
+
+        if not scipyOK:
+            raise ImportError("Scipy could not be imported: this function won't work.")
+
+        return self.apply_function_parallel_spectral(function=filter,
+                                                     size=ksize,
+                                                     verbose=verbose,
+                                                     num_cores=num_cores,
+                                                     use_memmap=use_memmap,
+                                                     **kwargs)
+
+    @parallel_docstring
     def spectral_smooth_median(self, ksize,
                                use_memmap=True,
                                verbose=0,
                                num_cores=None,
+                               filter=ndimage.filters.median_filter,
                                **kwargs):
         """
         Smooth the cube along the spectral dimension
@@ -2824,7 +2851,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         if not scipyOK:
             raise ImportError("Scipy could not be imported: this function won't work.")
 
-        return self.apply_function_parallel_spectral(ndimage.filters.median_filter,
+        return self.apply_function_parallel_spectral(function=filter,
                                                      size=ksize,
                                                      verbose=verbose,
                                                      num_cores=num_cores,

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2811,7 +2811,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         Parameters
         ----------
         ksize : int
-            Size of the median filter (scipy.ndimage.filters.median_filter)
+            Size of the filter in spectral channels.
         filter : function
             A filter from `scipy.ndimage.filters <https://docs.scipy.org/doc/scipy/reference/ndimage.html#filters>`_.
         """

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2491,6 +2491,23 @@ def test_spatial_smooth_median(data_adv, use_dask):
 
 
 @pytest.mark.parametrize('num_cores', (None, 1))
+def test_spectral_smooth_maxfilter(num_cores, data_adv, use_dask):
+
+    pytest.importorskip('scipy.ndimage')
+    from scipy import ndimage
+
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
+
+    cube_spectral_max = cube.spectral_filter(3,
+            filter=ndimage.filters.maximum_filter, num_cores=num_cores)
+
+    # Check first slice
+    result = np.array([0.90388047, 0.90388047, 0.96629004, 0.96629004])
+
+    np.testing.assert_almost_equal(cube_spectral_max[:,1,1].value, result)
+
+
+@pytest.mark.parametrize('num_cores', (None, 1))
 def test_spectral_smooth_median(num_cores, data_adv, use_dask):
 
     pytest.importorskip('scipy.ndimage')

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2498,14 +2498,15 @@ def test_spatial_smooth_maxfilter(num_cores, data_adv, use_dask):
 
     cube, data = cube_and_raw(data_adv, use_dask=use_dask)
 
-    cube_spectral_max = cube.spatial_filter([2, 2],
+    cube_spatial_max = cube.spatial_filter([3, 3],
             filter=ndimage.filters.maximum_filter, num_cores=num_cores)
 
-    # TODO: find out what is correct here
     # Check first slice
-    # result = np.array([0.90388047, 0.90388047, 0.96629004, 0.96629004])
+    result = np.array([[0.90950237, 0.90950237],
+                       [0.90950237, 0.90950237],
+                       [0.90388047, 0.90388047]])
 
-    # np.testing.assert_almost_equal(cube_spectral_max[:,1,1].value, result)
+    np.testing.assert_almost_equal(cube_spatial_max[0, :, :].value, result)
 
 
 @pytest.mark.parametrize('num_cores', (None, 1))

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2491,6 +2491,24 @@ def test_spatial_smooth_median(data_adv, use_dask):
 
 
 @pytest.mark.parametrize('num_cores', (None, 1))
+def test_spatial_smooth_maxfilter(num_cores, data_adv, use_dask):
+
+    pytest.importorskip('scipy.ndimage')
+    from scipy import ndimage
+
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
+
+    cube_spectral_max = cube.spatial_filter([2, 2],
+            filter=ndimage.filters.maximum_filter, num_cores=num_cores)
+
+    # TODO: find out what is correct here
+    # Check first slice
+    # result = np.array([0.90388047, 0.90388047, 0.96629004, 0.96629004])
+
+    # np.testing.assert_almost_equal(cube_spectral_max[:,1,1].value, result)
+
+
+@pytest.mark.parametrize('num_cores', (None, 1))
 def test_spectral_smooth_maxfilter(num_cores, data_adv, use_dask):
 
     pytest.importorskip('scipy.ndimage')


### PR DESCRIPTION
Is there a nicer way to inherit the docstrings?