### PR TITLE
Fix uneven chunks with spectral_interpolate and dask

### DIFF
--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -1284,7 +1284,7 @@ class DaskSpectralCubeMixin:
             cubedata = cubedata[::-1, :, :]
 
         cubedata = cubedata.rechunk((-1, 'auto', 'auto'))
-        chunkshape = (len(spectral_grid),) + cubedata.chunksize[1:]
+        chunkshape = (len(spectral_grid),) + cubedata.chunks[1:]
 
         def interp_wrapper(y, args):
             if y.size == 1:

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -249,6 +249,23 @@ def test_spectral_interpolate_varying_chunksize(data_255_delta):
     assert result._data.chunks[1] == (2, 2, 1)
 
 
+def test_spectral_interpolate_rechunk_fail(data_255_delta):
+
+    cube, data = cube_and_raw(data_255_delta, use_dask=True)
+
+    orig_wcs = cube.wcs.deepcopy()
+
+    # midpoint between each position
+    sg = (cube.spectral_axis[1:] + cube.spectral_axis[:-1])/2.
+
+    # Force >1 chunk in spectral dimension
+    cube = cube.rechunk((1, -1, -1))
+
+    with pytest.raises(ValueError,
+                       match=("The cube currently has 2 chunks along")):
+        cube.spectral_interpolate(spectral_grid=sg, force_rechunk=False)
+
+
 def test_spectral_interpolate_with_fillvalue(data_522_delta, use_dask):
 
     cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -225,6 +225,30 @@ def test_spectral_interpolate(data_522_delta, use_dask):
     assert cube.wcs.wcs.compare(orig_wcs.wcs)
 
 
+def test_spectral_interpolate_varying_chunksize(data_255_delta):
+
+    cube, data = cube_and_raw(data_255_delta, use_dask=True)
+
+    orig_wcs = cube.wcs.deepcopy()
+
+    # midpoint between each position
+    sg = (cube.spectral_axis[1:] + cube.spectral_axis[:-1])/2.
+
+    # Force unequal chunks
+    cube = cube.rechunk((-1, 2, 2))
+
+    result = cube.spectral_interpolate(spectral_grid=sg, force_rechunk=False)
+
+    np.testing.assert_almost_equal(result[:,2,2].value,
+                                   [0.5])
+
+    assert cube.wcs.wcs.compare(orig_wcs.wcs)
+
+    # Ensure the spatial chunk sizes vary
+    assert cube._data.chunks[1] == (2, 2, 1)
+    assert result._data.chunks[1] == (2, 2, 1)
+
+
 def test_spectral_interpolate_with_fillvalue(data_522_delta, use_dask):
 
     cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)


### PR DESCRIPTION
This fixes #815.

Spectral interpolation changes the output cube dimensions, so `DaskSpectralCube.spectral_interpolation` has a direct call
 to the `map_blocks` function where we specify the output chunk size. If the array shape is not an exact multiple of the chunk size, a tuple of chunk sizes needs to be given to `map_blocks` to reflect that same chunks will be smaller or otherwise vary, and that information is needed to inform file writing routines (zarr, to FITS) before they create the output files. This causes the mismatched shape errors in #815.

In the original cube, this is stored in the dask array as `cube._data.chunks`, and we're only changing the 0th spectral size for spectral interpolation.

This may come up in other places for routines that change the original shape of the cube on output. I think `spectral_interpolate` is the only place where this currently needs to be handled here (downsampling uses a dask built in).