### PR TITLE
Expand setup.cfg requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ install_requires =
 
 [options.extras_require]
 test =
-    mock
     pytest-astropy
     pytest-cov
 docs =
@@ -38,7 +37,6 @@ novis =
     reproject
     scipy
 all =
-    mock
     pytest-astropy
     pytest-cov
     sphinx-astropy

--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -4,7 +4,7 @@ import os
 from numpy.core.shape_base import block
 import pytest
 import numpy as np
-from mock import patch
+from unittest.mock import patch
 
 from numpy.testing import assert_allclose
 from astropy.tests.helper import assert_quantity_allclose

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
-    mock
 isolated_build = true
 indexserver =
     NRAO = https://casa-pip.nrao.edu/repository/pypi-group/simple
@@ -23,7 +22,6 @@ changedir =
 description =
     run tests with pytest
 deps =
-    mock
     dev: git+https://github.com/radio-astro-tools/pvextractor#egg=pvextractor
     dev: git+https://github.com/radio-astro-tools/radio-beam#egg=radio-beam
     dev: git+https://github.com/astropy/astropy#egg=astropy


### PR DESCRIPTION
Running tests requires `mock`, which was left out.

`all` should cover tests + docs