### PR TITLE
Fix issue 819: allow comparison to unitless scalar numbers

### DIFF
--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2210,7 +2210,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         cube's unit.  If it doesn't, raise an exception.
         """
         if isinstance(value, BaseSpectralCube):
-            if self.unit.is_equivalent(value.unit) or self.unit.is_equivalent(u.dimensionless_unscaled):
+            if self.unit.is_equivalent(value.unit):
                 return value
             else:
                 return value.to(self.unit)
@@ -2219,6 +2219,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                 return value.to(self.unit)
             else:
                 return value.to(self.unit).value
+        elif self.unit.is_equivalent(u.dimensionless_unscaled):
+            # if the value is a numpy array or scalar, and the cube has no
+            # unit, no additional conversion is needed
+            return value
         else:
             raise ValueError("Can only {operation} cube objects {tofrom}"
                              " SpectralCubes or Quantities with "

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2210,7 +2210,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         cube's unit.  If it doesn't, raise an exception.
         """
         if isinstance(value, BaseSpectralCube):
-            if self.unit.is_equivalent(value.unit):
+            if self.unit.is_equivalent(value.unit) or self.unit.is_equivalent(u.dimensionless_unscaled):
                 return value
             else:
                 return value.to(self.unit)

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2783,3 +2783,15 @@ def test_regression_719(data_adv, use_dask):
     mx_K = (mx*u.beam).to(u.K,
                           u.brightness_temperature(beam_area=beam,
                                                    frequency=cfrq))
+
+
+def test_unitless_comparison(data_adv, use_dask):
+    """
+    Issue 819: unitless cubes should be comparable to numbers
+    """
+    cube, data = cube_and_raw(data_adv, use_dask=use_dask)
+
+    # force unit for use below
+    cube._unit = u.dimensionless_unscaled
+
+    mask = cube > 1

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2794,4 +2794,5 @@ def test_unitless_comparison(data_adv, use_dask):
     # force unit for use below
     cube._unit = u.dimensionless_unscaled
 
+    # do a comparison to verify that no error occurs
     mask = cube > 1


### PR DESCRIPTION
Bugfix for #819.   Unitless cubes (those with `dimensionless_unscaled` units) should be comparable to numbers and arrays directly. 