### PR TITLE
WIP fix for 821: test spectral smooth on windows

### DIFF
--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -12,7 +12,7 @@ from astropy import units as u
 from astropy.utils import data
 
 try:
-    from distributed.utils_test import client, loop, cluster_fixture  # noqa
+    from distributed.utils_test import client, loop, cluster_fixture, cleanup  # noqa
     DISTRIBUTED_INSTALLED = True
 except ImportError:
     DISTRIBUTED_INSTALLED = False

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -144,8 +144,15 @@ def test_spectral_smooth(data_522_delta, use_dask):
 
     # make sure the kernel comes out right; the convolution test will fail if this is wrong
     assert kernel.array.size == 9
-    np.testing.assert_almost_equal(kernel.array[2:-2],
-                                   np.array([0.05399097, 0.24197072, 0.39894228, 0.24197072, 0.05399097]))
+    # this was the old astropy normalization
+    # We don't actually need the kernel to match these values, but I'm leaving this here
+    # as a note for future us:
+    # https://github.com/astropy/astropy/pull/13299
+    # the error came about because we were using two different kernel sizes, which resulted in
+    # two different normalizations after the correction in 13299
+    # Before 13299, normalization was not guaranteed.
+    #np.testing.assert_almost_equal(kernel.array[2:-2],
+    #                               np.array([0.05399097, 0.24197072, 0.39894228, 0.24197072, 0.05399097]))
 
     np.testing.assert_almost_equal(result[:,0,0].value,
                                    kernel.array[2:-2],

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -183,19 +183,19 @@ def test_spectral_smooth_4cores(data_522_delta):
 
     cube, data = cube_and_raw(data_522_delta, use_dask=False)
 
-    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4, use_memmap=True)
+    kernel = convolution.Gaussian1DKernel(1.0)
+    result = cube.spectral_smooth(kernel=kernel, num_cores=4, use_memmap=True)
 
+    assert kernel.array.size == 9
     np.testing.assert_almost_equal(result[:,0,0].value,
-                                   convolution.Gaussian1DKernel(1.0,
-                                                                x_size=5).array,
+                                   kernel.array[2:-2],
                                    4)
 
     # this is one way to test non-parallel mode
-    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), num_cores=4, use_memmap=False)
+    result = cube.spectral_smooth(kernel=kernel, num_cores=4, use_memmap=False)
 
     np.testing.assert_almost_equal(result[:,0,0].value,
-                                   convolution.Gaussian1DKernel(1.0,
-                                                                x_size=5).array,
+                                   kernel.array[2:-2],
                                    4)
 
     # num_cores = 4 is a contradiction with parallel=False, so we want to make
@@ -205,12 +205,11 @@ def test_spectral_smooth_4cores(data_522_delta):
                                  "multiple cores were: these are incompatible "
                                  "options.  Either specify num_cores=1 or "
                                  "parallel=True")):
-        result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0),
+        result = cube.spectral_smooth(kernel=kernel,
                                       num_cores=4, parallel=False)
 
     np.testing.assert_almost_equal(result[:,0,0].value,
-                                   convolution.Gaussian1DKernel(1.0,
-                                                                x_size=5).array,
+                                   kernel.array[2:-2],
                                    4)
 
 

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -133,18 +133,29 @@ def test_spectral_smooth(data_522_delta, use_dask):
 
     cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
 
-    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), use_memmap=False)
+    kernel = convolution.Gaussian1DKernel(1.0)
+
+    result = cube.spectral_smooth(kernel=kernel, use_memmap=False)
+
+    # check that all values come out right from the cube creation
+    np.testing.assert_almost_equal(cube[2,:,:].value, 1.0)
+    np.testing.assert_almost_equal(cube[:2,:,:].value, 0.0)
+    np.testing.assert_almost_equal(cube[3:,:,:].value, 0.0)
+
+    # make sure the kernel comes out right; the convolution test will fail if this is wrong
+    assert kernel.array.size == 9
+    np.testing.assert_almost_equal(kernel.array[2:-2],
+                                   np.array([0.05399097, 0.24197072, 0.39894228, 0.24197072, 0.05399097]))
 
     np.testing.assert_almost_equal(result[:,0,0].value,
-                                   convolution.Gaussian1DKernel(1.0,
-                                                                x_size=5).array,
+                                   kernel.array[2:-2],
                                    4)
 
-    result = cube.spectral_smooth(kernel=convolution.Gaussian1DKernel(1.0), use_memmap=True)
+    # second test with memmap=True
+    result = cube.spectral_smooth(kernel=kernel, use_memmap=True)
 
     np.testing.assert_almost_equal(result[:,0,0].value,
-                                   convolution.Gaussian1DKernel(1.0,
-                                                                x_size=5).array,
+                                   kernel.array[2:-2],
                                    4)
 
 def test_catch_kernel_with_units(data_522_delta, use_dask):

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -139,8 +139,8 @@ def test_spectral_smooth(data_522_delta, use_dask):
 
     # check that all values come out right from the cube creation
     np.testing.assert_almost_equal(cube[2,:,:].value, 1.0)
-    np.testing.assert_almost_equal(cube[:2,:,:].value, 0.0)
-    np.testing.assert_almost_equal(cube[3:,:,:].value, 0.0)
+    np.testing.assert_almost_equal(cube.unitless_filled_data[:2,:,:], 0.0)
+    np.testing.assert_almost_equal(cube.unitless_filled_data[3:,:,:], 0.0)
 
     # make sure the kernel comes out right; the convolution test will fail if this is wrong
     assert kernel.array.size == 9


### PR DESCRIPTION
This is a WIP: no fix has been put in place, I just made the tests more granular so we can see where the failure occurs.

Sidenote: It was _extremely_ difficult to set up the testing environment to enable me to debug this.  I had to copy-paste line-by-line code from `conftest.py` and `test_regrid` to get the cubes put in place and then loaded.  This is an immense headache and makes me hate working with pytest.  Is there any sane way to interactively debug pytest-based functions?