### PR TITLE
Handle beam tables with >1 stokes component: fix for #825

### DIFF
--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -81,6 +81,39 @@ def prepare_4_beams():
     return beams
 
 
+def prepare_4_beams_withfullpol():
+
+    nchan = 4
+    npol = 4
+
+    beams = np.recarray(nchan*npol, dtype=[('BMAJ', '>f4'), ('BMIN', '>f4'),
+                                           ('BPA', '>f4'), ('CHAN', '>i4'),
+                                           ('POL', '>i4')])
+    beams['BMAJ'] = [0.4,0.3,0.3,0.4] * npol # arcseconds
+    beams['BMIN'] = [0.1,0.2,0.2,0.1] * npol
+    beams['BPA'] = [0,45,60,30] * npol # degrees
+    beams['CHAN'] = [0,1,2,3] * npol
+
+    pol_codes = []
+    for i in range(npol):
+        pol_codes.extend([i] * nchan)
+
+    beams['POL'] = pol_codes
+
+    beams = fits.BinTableHDU(beams)
+
+    beams.header['TTYPE1'] = 'BMAJ'
+    beams.header['TUNIT1'] = 'arcsec'
+    beams.header['TTYPE2'] = 'BMIN'
+    beams.header['TUNIT2'] = 'arcsec'
+    beams.header['TTYPE3'] = 'BPA'
+    beams.header['TUNIT3'] = 'deg'
+    beams.header['TTYPE4'] = 'CHAN'
+    beams.header['TTYPE5'] = 'POL'
+
+    return beams
+
+
 def prepare_advs_data():
     # Single Stokes
     h = fits.header.Header.fromtextfile(HEADER_FILENAME)
@@ -91,6 +124,27 @@ def prepare_advs_data():
     h['NAXIS4'] = 1
     np.random.seed(42)
     d = np.random.random((1, 2, 3, 4))
+    return d, h
+
+
+def prepare_advs_fullstokes_data():
+    # Full Stokes
+    h = fits.header.Header.fromtextfile(HEADER_FILENAME)
+    h['BUNIT'] = 'K' # Kelvins are a valid unit, JY/BEAM are not: they should be tested separately
+    h['NAXIS1'] = 2
+    h['NAXIS2'] = 3
+    h['NAXIS3'] = 4
+    h['NAXIS4'] = 4
+
+    # Add the most basic stokes information to the header
+    h['CTYPE4'] = 'STOKES'
+    h['CRVAL4'] = 1.0
+    h['CDELT4'] = 1.0
+    h['CRPIX4'] = 1.0
+    h['CUNIT4'] = ''
+
+    np.random.seed(42)
+    d = np.random.random((4, 4, 3, 2))
     return d, h
 
 
@@ -187,6 +241,21 @@ def data_advs_nobeam(tmp_path):
     del h['BPA']
     fits.writeto(tmp_path / 'advs_nobeam.fits', d, h)
     return tmp_path / 'advs_nobeam.fits'
+
+
+@pytest.fixture
+def data_advs_beams_fullstokes(tmp_path):
+    d, h = prepare_advs_fullstokes_data()
+
+    beams = prepare_4_beams_withfullpol()
+
+    hdu = fits.HDUList()
+    hdu.append(fits.PrimaryHDU(d, h))
+    hdu.append(beams)
+
+    hdu.writeto(tmp_path / 'advs_beams_fullstokes.fits')
+
+    return tmp_path / 'advs_beams_fullstokes.fits'
 
 
 def prepare_adv_data():

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -135,7 +135,7 @@ def _split_stokes(array, wcs, beam_table=None):
         stokes_arrays['I'] = array
         beam_tables['I'] = beam_tables
 
-    if beam_tables is not None:
+    if beam_table is not None:
         return stokes_arrays, wcs_slice, beam_tables
     else:
         return stokes_arrays, wcs_slice

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -51,7 +51,7 @@ def _fix_spectral(wcs):
 
     return wcs
 
-def _split_stokes(array, wcs):
+def _split_stokes(array, wcs, beam_table=None):
     """
     Given a 4-d data cube with 4-d WCS (spectral cube + stokes) return a
     dictionary of data and WCS objects for each Stokes component
@@ -64,6 +64,10 @@ def _split_stokes(array, wcs):
     wcs : `~astropy.wcs.WCS`
         The input 3-d WCS with two position dimensions, one spectral
         dimension, and a Stokes dimension.
+    beam_table : `~astropy.io.fits.hdu.table.BinTableHDU`
+        When multiple beams are present, a FITS table with the beam information
+        can be given to be split into the polarization components, consistent with
+        `array`.
     """
 
     if array.ndim not in (3,4):
@@ -109,6 +113,9 @@ def _split_stokes(array, wcs):
 
     stokes_arrays = {}
 
+    if beam_table is not None:
+        beam_tables = {}
+
     wcs_slice = wcs_utils.drop_axis(wcs, wcs.naxis - 1 - stokes_index)
 
     if array.ndim == 4:
@@ -118,11 +125,20 @@ def _split_stokes(array, wcs):
                            for idim in range(array.ndim)]
 
             stokes_arrays[stokes_names[i_stokes]] = array[tuple(array_slice)]
+
+            if beam_table is not None:
+                beam_pol_idx = beam_table['POL'] == i_stokes
+                beam_tables[stokes_names[i_stokes]] = beam_table[beam_pol_idx]
+
     else:
         # 3D array with STOKES as a 4th header parameter
         stokes_arrays['I'] = array
+        beam_tables['I'] = beam_tables
 
-    return stokes_arrays, wcs_slice
+    if beam_tables is not None:
+        return stokes_arrays, wcs_slice, beam_tables
+    else:
+        return stokes_arrays, wcs_slice
 
 
 def _orient(array, wcs):

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -133,7 +133,9 @@ def _split_stokes(array, wcs, beam_table=None):
     else:
         # 3D array with STOKES as a 4th header parameter
         stokes_arrays['I'] = array
-        beam_tables['I'] = beam_tables
+
+        if beam_table is not None:
+            beam_tables['I'] = beam_table
 
     if beam_table is not None:
         return stokes_arrays, wcs_slice, beam_tables

--- a/spectral_cube/io/casa_image.py
+++ b/spectral_cube/io/casa_image.py
@@ -88,7 +88,6 @@ def load_casa_image(filename, skipdata=False, memmap=True,
         beam_ = {'beams': imageinfo['perplanebeams']}
         beam_['nStokes'] = beam_['beams'].pop('nStokes')
         beam_['nChannels'] = beam_['beams'].pop('nChannels')
-        # beam_['beams'] = {key: {'*0': value} for key, value in list(beam_['beams'].items())}
     elif 'restoringbeam' in imageinfo:
         beam_ = imageinfo['restoringbeam']
     else:
@@ -108,9 +107,6 @@ def load_casa_image(filename, skipdata=False, memmap=True,
 
         stokes_params = desc['_keywords_']['coords']['stokes1']['stokes']
 
-        # if beam_['nStokes'] > 1:
-        #     raise NotImplementedError()
-
         nbeams = len(bdict)
         nchan = beam_['nChannels']
         assert nbeams == nchan * beam_['nStokes']
@@ -120,15 +116,15 @@ def load_casa_image(filename, skipdata=False, memmap=True,
         for ii, stokes_name in enumerate(stokes_params):
 
             majors = [u.Quantity(bdict[f"*{ii*nchan+chan}"]['major']['value'],
-                                bdict[f"*{ii*nchan+chan}"]['major']['unit']) for chan in range(nchan)]
+                                 bdict[f"*{ii*nchan+chan}"]['major']['unit']) for chan in range(nchan)]
             minors = [u.Quantity(bdict[f"*{ii*nchan+chan}"]['minor']['value'],
-                                bdict[f"*{ii*nchan+chan}"]['minor']['unit']) for chan in range(nchan)]
+                                 bdict[f"*{ii*nchan+chan}"]['minor']['unit']) for chan in range(nchan)]
             pas = [u.Quantity(bdict[f"*{ii*nchan+chan}"]['positionangle']['value'],
-                            bdict[f"*{ii*nchan+chan}"]['positionangle']['unit']) for chan in range(nchan)]
+                              bdict[f"*{ii*nchan+chan}"]['positionangle']['unit']) for chan in range(nchan)]
 
             beams[stokes_name] = Beams(major=u.Quantity(majors),
-                                        minor=u.Quantity(minors),
-                                        pa=u.Quantity(pas))
+                                       minor=u.Quantity(minors),
+                                       pa=u.Quantity(pas))
     else:
         warnings.warn("No beam information found in CASA image.",
                       BeamWarning)
@@ -174,7 +170,8 @@ def load_casa_image(filename, skipdata=False, memmap=True,
         if 'beam' in locals():
             cube = DaskSpectralCube(data, wcs_slice, mask, meta=meta, beam=beam)
         elif 'beams' in locals():
-            cube = DaskVaryingResolutionSpectralCube(data, wcs_slice, mask, meta=meta, beams=beams['I'])
+            cube = DaskVaryingResolutionSpectralCube(data, wcs_slice, mask, meta=meta,
+                                                     beams=beams['I'])
         else:
             cube = DaskSpectralCube(data, wcs_slice, mask, meta=meta)
         # with #592, this is no longer true

--- a/spectral_cube/io/fits.py
+++ b/spectral_cube/io/fits.py
@@ -230,15 +230,13 @@ def load_fits_cube(input, hdu=0, meta=None, target_cls=None, use_dask=False, **k
 
     elif wcs.wcs.naxis == 4:
 
-        data, wcs = cube_utils._split_stokes(data, wcs)
-
-        # Slice our beam table by the number of velocity channels.
-        # NOTE: we don't currently have a check for the total number of beams matching
-        # nchan * npol. This just assumes that (likely fine in most cases).
-        nchan = data['I'].shape[0]
+        if beam_table is None:
+            data, wcs = cube_utils._split_stokes(data, wcs)
+        else:
+            data, wcs, beam_tables = cube_utils._split_stokes(data, wcs, beam_table=beam_table)
 
         stokes_data = {}
-        for ii, component in enumerate(data):
+        for component in data:
             comp_data, comp_wcs = cube_utils._orient(data[component], wcs)
             comp_mask = LazyMask(np.isfinite, data=comp_data, wcs=comp_wcs)
             if beam_table is None:
@@ -249,7 +247,7 @@ def load_fits_cube(input, hdu=0, meta=None, target_cls=None, use_dask=False, **k
                 stokes_data[component] = VRSC(comp_data, wcs=comp_wcs,
                                               mask=comp_mask, meta=meta,
                                               header=header,
-                                              beam_table=beam_table[nchan*ii:nchan*(ii+1)],
+                                              beam_table=beam_tables[component],
                                               major_unit=beam_units[0],
                                               minor_unit=beam_units[1]
                                              )

--- a/spectral_cube/tests/test_io.py
+++ b/spectral_cube/tests/test_io.py
@@ -147,3 +147,15 @@ def test_aips_beams_units(tmpdir, data_455_degree_beams, use_dask):
     np.testing.assert_almost_equal(c.beams[0].minor.value, 0.1/3600)
     np.testing.assert_almost_equal(c.beams[0].major.to(u.arcsec).value, 0.4)
     np.testing.assert_almost_equal(c.beams[0].minor.to(u.arcsec).value, 0.1)
+
+
+
+def test_vrsc_fullstokes_read_fits(data_advs_beams_fullstokes):
+    '''
+    Test reading a spectral line data cube with full stokes and a beam table.
+    '''
+    c = StokesSpectralCube.read(data_advs_beams_fullstokes)
+
+    for component in ['I', 'Q', 'U', 'V']:
+        assert isinstance(c[component], VaryingResolutionSpectralCube)
+        assert hasattr(c[component], 'beams')


### PR DESCRIPTION
This PR implements fixes #825.

* [x] Fix for FITS files, where the beam table is not split into the different components
* [x] Fix for CASA images where we don't have reading beams for different components implemented.
* [x] Tests for reading/writing Stokes cubes with beam tables
