### PR TITLE
Bugfix: __len__ test for beams

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -667,8 +667,8 @@ class BaseOneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
             warnings.filterwarnings('ignore', category=FITSWarning)
             beam = cube_utils.try_load_beams(hdul)
             try:
-                _ = len(beams)
                 beams = beam
+                _ = len(beams)
             except TypeError:
                 # beam is scalar and has no len()
                 beams = None

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -666,9 +666,11 @@ class BaseOneDSpectrum(LowerDimensionalObject, MaskableArrayMixinClass,
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', category=FITSWarning)
             beam = cube_utils.try_load_beams(hdul)
-            if hasattr(beam, '__len__'):
+            try:
+                _ = len(beams)
                 beams = beam
-            else:
+            except TypeError:
+                # beam is scalar and has no len()
                 beams = None
 
         if beams is not None:


### PR DESCRIPTION
If you write out a non-varying-spectral-resolution spectrum, it will try to load in as a VRS because the `hasattr(beam, '__len__')` check is true, even though there is no `len`.