### PR TITLE
cleanup unused pkg_resources import

### DIFF
--- a/spectral_cube/__init__.py
+++ b/spectral_cube/__init__.py
@@ -2,8 +2,6 @@
 
 from ._astropy_init import __version__, test
 
-from pkg_resources import get_distribution, DistributionNotFound
-
 from .spectral_cube import (SpectralCube, VaryingResolutionSpectralCube)
 from .dask_spectral_cube import (DaskSpectralCube, DaskVaryingResolutionSpectralCube)
 from .stokes_spectral_cube import StokesSpectralCube


### PR DESCRIPTION
`pkg_resources` is now deprecated https://setuptools.pypa.io/en/latest/history.html#v67-5-0
these imports are not used anyway so this is a noop cleanup