### PR TITLE
Add a mask-setter property

### DIFF
--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -52,6 +52,10 @@ class BaseNDClass(object):
     def mask(self):
         return self._mask
 
+    @mask.setter
+    def mask(self, value):
+        self._mask = value
+
 class HeaderMixinClass(object):
     """
     A mixin class to provide header updating from WCS objects.


### PR DESCRIPTION
This error:
https://github.com/radio-astro-tools/spectral-cube/actions/runs/4375133747/jobs/7655452694#step:5:2644
may be caused by not having a settable mask.

We really need to resolve this with the https://github.com/radio-astro-tools/spectral-cube/pull/808 refactor, but I want passing tests as a stopgap