### PR TITLE
Small fix: don't check meta if it's None

### DIFF
--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -41,7 +41,7 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass, HeaderMixinClass):
             hdu = PrimaryHDU(self.value, header=self.header)
         hdu.header['BUNIT'] = self.unit.to_string(format='fits')
 
-        if 'beam' in self.meta:
+        if self.meta is not None 'beam' in self.meta:
             hdu.header.update(self.meta['beam'].to_header_keywords())
 
         return hdu

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -41,7 +41,7 @@ class LowerDimensionalObject(u.Quantity, BaseNDClass, HeaderMixinClass):
             hdu = PrimaryHDU(self.value, header=self.header)
         hdu.header['BUNIT'] = self.unit.to_string(format='fits')
 
-        if self.meta is not None 'beam' in self.meta:
+        if self.meta is not None and 'beam' in self.meta:
             hdu.header.update(self.meta['beam'].to_header_keywords())
 
         return hdu

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -932,7 +932,7 @@ def test_spatial_world(view, data_adv, use_dask):
 @pytest.mark.parametrize(('LDO', 'data'),
                          zip(LDOs, data_twelve))
 def test_unit_division(LDO, data):
-    # regression: ...
+    # regression: 871
 
     image = data
     p = LDO(image, copy=False)

--- a/spectral_cube/tests/test_projection.py
+++ b/spectral_cube/tests/test_projection.py
@@ -928,3 +928,16 @@ def test_spatial_world(view, data_adv, use_dask):
     for result, expected in zip(w2_flat, world):
         print(result.shape, expected.flatten().shape)
         assert_allclose(result, expected.flatten())
+
+@pytest.mark.parametrize(('LDO', 'data'),
+                         zip(LDOs, data_twelve))
+def test_unit_division(LDO, data):
+    # regression: ...
+
+    image = data
+    p = LDO(image, copy=False)
+
+    p._meta = None
+
+    # check that this does not raise an Exception
+    p.hdu


### PR DESCRIPTION
Could get errors like:
```python
    if 'beam' in self.meta:
TypeError: argument of type 'NoneType' is not iterable
```
before this