### PR TITLE
handle numpy.find_common_type's deprecation

### DIFF
--- a/spectral_cube/masks.py
+++ b/spectral_cube/masks.py
@@ -225,7 +225,7 @@ class MaskBase(object):
         """
         # Must convert to floating point, but should not change from inherited
         # type otherwise
-        dt = np.find_common_type([data.dtype], [float])
+        dt = np.result_type([data.dtype, 0.0])
 
         if use_memmap and data.size > 0:
             ntf = tempfile.NamedTemporaryFile()


### PR DESCRIPTION
`numpy.find_common_type` is deprecated in numpy 1.25, see https://numpy.org/devdocs/release/1.25.0-notes.html