### PR TITLE
MNT: Clean up _astropy_init.py

### DIFF
--- a/spectral_cube/_astropy_init.py
+++ b/spectral_cube/_astropy_init.py
@@ -1,13 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = ['__version__', '__githash__']
-
 import os
-from warnings import warn
-from astropy.config.configuration import (
-    update_default_config,
-    ConfigurationDefaultMissingError,
-    ConfigurationDefaultMissingWarning)
+
+from astropy.tests.runner import TestRunner
+
+__all__ = ['__version__', 'test']
 
 try:
     from .version import version as __version__
@@ -15,29 +12,5 @@ except ImportError:
     __version__ = ''
 
 # Create the test function for self test
-from astropy.tests.runner import TestRunner
 test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
 test.__test__ = False
-__all__ += ['test']
-
-# add these here so we only need to cleanup the namespace at the end
-config_dir = None
-
-if not os.environ.get('ASTROPY_SKIP_CONFIG_UPDATE', False):
-    config_dir = os.path.dirname(__file__)
-    config_template = os.path.join(config_dir, __package__ + ".cfg")
-    if os.path.isfile(config_template):
-        try:
-            update_default_config(
-                __package__, config_dir, version=__version__)
-        except TypeError as orig_error:
-            try:
-                update_default_config(__package__, config_dir)
-            except ConfigurationDefaultMissingError as e:
-                wmsg = (e.args[0] +
-                        " Cannot install default profile. If you are "
-                        "importing from source, this is expected.")
-                warn(ConfigurationDefaultMissingWarning(wmsg))
-                del e
-            except Exception:
-                raise orig_error


### PR DESCRIPTION
Because config stuff is unnecessary and removed in astropy v6.0, see:

* astropy/astropy#15466

And I don't think you even use it anyway?

This is failing our devdeps job in Jdaviz CI (e.g., https://github.com/spacetelescope/jdaviz/pull/2409) because even though Jdaviz does not use this package, glue-astronomy refuses to make this package optional.

cc @astrofrog @keflavich 