### PR TITLE
MNT: upgrade upload/download-artifact GitHub actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         run: python -m pip install build
       - name: Build sdist
         run: python -m build --sdist --wheel --outdir dist/ .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*
 
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
Hi, version 4 of upload-artifact and download-artifact were recently released.
Staying on old version is not viable long term because GitHub will sooner or later drop support for the old versions of node that these depend on.
Since migration to v4 is not as straightfoward as bumping the version number, I'm helping all astropy-related packages byt manually performing the necessary changes.

(in this specific case it *is* actually trivial, I'm just doing them all at once so no reason to skip this repo)