### PR TITLE
Replace distutils.LooseVersion with packaging.version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     dask[array]
     joblib
     casa-formats-io
+    packaging
 
 [options.extras_require]
 test =

--- a/spectral_cube/conftest.py
+++ b/spectral_cube/conftest.py
@@ -4,7 +4,6 @@
 from __future__ import print_function, absolute_import, division
 
 import os
-from distutils.version import LooseVersion
 from astropy.units.equivalencies import pixel_scale
 
 # Import casatools and casatasks here if available as they can otherwise

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -526,8 +526,8 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass,
                               " installed.")
 
         # Need version > 0.2 to work with cubes
-        from distutils.version import LooseVersion
-        if LooseVersion(version) < "0.3":
+        from packaging.version import Version, parse
+        if parse(version) < Version("0.3"):
             raise Warning("Requires version >=0.3 of reproject. The current "
                           "version is: {}".format(version))
 

--- a/spectral_cube/np_compat.py
+++ b/spectral_cube/np_compat.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, absolute_import, division
 
 import numpy as np
-from distutils.version import LooseVersion
 
 def allbadtonan(function):
     """
@@ -14,7 +13,7 @@ def allbadtonan(function):
             result = function(data, axis=axis)
         else:
             result = function(data, axis=axis, keepdims=keepdims)
-        if LooseVersion(np.__version__) >= LooseVersion('1.9.0') and hasattr(result, '__len__'):
+        if hasattr(result, '__len__'):
             if axis is None:
                 if np.all(np.isnan(data)):
                     return np.nan

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -57,7 +57,7 @@ from .spectral_axis import (determine_vconv_from_ctype, get_rest_value_from_wcs,
                             doppler_beta, doppler_gamma, doppler_z)
 from .io.core import SpectralCubeRead, SpectralCubeWrite
 
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 
 __all__ = ['BaseSpectralCube', 'SpectralCube', 'VaryingResolutionSpectralCube']
@@ -2343,7 +2343,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         import yt
 
         if (('dev' in yt.__version__) or
-            (LooseVersion(yt.__version__) >= LooseVersion('3.0'))):
+            (parse(yt.__version__) >= Version('3.0'))):
 
             # yt has updated their FITS data set so that only the SpectralCube
             # variant takes spectral_factor
@@ -2659,11 +2659,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
 
         reproj_kwargs = kwargs
         # Need version > 0.2 to work with cubes, >= 0.5 for memmap
-        from distutils.version import LooseVersion
-        if LooseVersion(version) < "0.5":
+        if parse(version) < Version("0.5"):
             raise Warning("Requires version >=0.5 of reproject. The current "
                           "version is: {}".format(version))
-        elif LooseVersion(version) >= "0.6":
+        elif parse(version) >= Version("0.6"):
             pass # no additional kwargs, no warning either
         else:
             reproj_kwargs['independent_celestial_slices'] = True

--- a/spectral_cube/tests/test_masks.py
+++ b/spectral_cube/tests/test_masks.py
@@ -14,7 +14,7 @@ from .. import (BooleanArrayMask, LazyMask, LazyComparisonMask,
                 FunctionMask, CompositeMask)
 from ..masks import is_broadcastable_and_smaller, dims_to_skip, view_of_subset
 
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 
 def test_spectral_cube_mask():
@@ -392,7 +392,7 @@ def test_flat_mask(data_adv, use_dask):
     assert np.all(np.isnan(mcube.sum(axis=0)[~mask_array]))
 
 
-@pytest.mark.skipif(LooseVersion(np.__version__) < LooseVersion('1.7'),
+@pytest.mark.skipif(parse(np.__version__) < Version('1.7'),
                     reason='Numpy <1.7 does not support multi-slice indexing.')
 def test_flat_mask_spectral(data_adv, use_dask):
     cube, data = cube_and_raw(data_adv, use_dask=use_dask)

--- a/spectral_cube/tests/test_moments.py
+++ b/spectral_cube/tests/test_moments.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import, division
 
 import warnings
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 import pytest
 import numpy as np
@@ -78,7 +78,7 @@ axis_order = pytest.mark.parametrize(('axis', 'order'),
                                      (1, 0), (1, 1), (1, 2),
                                      (2, 0), (2, 1), (2, 2)))
 
-if LooseVersion(astropy.__version__[:3]) >= LooseVersion('1.0'):
+if parse(astropy.__version__[:3]) >= Version('1.0'):
     # The relative error is slightly larger on astropy-dev
     # There is no obvious reason for this.
     rtol = 2e-7

--- a/spectral_cube/tests/test_performance.py
+++ b/spectral_cube/tests/test_performance.py
@@ -20,9 +20,9 @@ except ImportError:
 
 # The comparison of Quantities in test_memory_usage
 # fail with older versions of numpy
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
-NPY_VERSION_CHECK = LooseVersion(np.version.version) >= "1.13"
+NPY_VERSION_CHECK = parse(np.version.version) >= Version("1.13")
 
 from .test_moments import moment_cube
 from .helpers import assert_allclose

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -18,9 +18,9 @@ except ImportError:
 
 # The comparison of Quantities in test_memory_usage
 # fail with older versions of numpy
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
-NPY_VERSION_CHECK = LooseVersion(np.version.version) >= "1.13"
+NPY_VERSION_CHECK = parse(np.version.version) >= Version("1.13")
 
 from radio_beam import beam, Beam
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -6,8 +6,8 @@ import operator
 import itertools
 import warnings
 import mmap
-from distutils.version import LooseVersion
 import sys
+from packaging.version import Version, parse
 
 import pytest
 
@@ -65,7 +65,7 @@ warnings.filterwarnings(action='ignore', category=FutureWarning,
 try:
     import yt
     YT_INSTALLED = True
-    YT_LT_301 = LooseVersion(yt.__version__) < LooseVersion('3.0.1')
+    YT_LT_301 = parse(yt.__version__) < Version('3.0.1')
 except ImportError:
     YT_INSTALLED = False
     YT_LT_301 = False
@@ -81,7 +81,7 @@ import os
 from radio_beam import Beam, Beams
 from radio_beam.utils import BeamError
 
-NUMPY_LT_19 = LooseVersion(np.__version__) < LooseVersion('1.9.0')
+NUMPY_LT_19 = parse(np.__version__) < Version('1.9.0')
 
 
 def cube_and_raw(filename, use_dask=None):
@@ -978,7 +978,7 @@ def test_read_write_rountrip(tmpdir, data_adv, use_dask):
     assert cube.shape == cube.shape
     assert_allclose(cube._data, cube2._data)
     if (((hasattr(_wcs, '__version__')
-          and LooseVersion(_wcs.__version__) < LooseVersion('5.9'))
+          and parse(_wcs.__version__) < Version('5.9'))
          or not hasattr(_wcs, '__version__'))):
         # see https://github.com/astropy/astropy/pull/3992 for reasons:
         # we should upgrade this for 5.10 when the absolute accuracy is

--- a/spectral_cube/tests/test_subcubes.py
+++ b/spectral_cube/tests/test_subcubes.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import, division
 
 import pytest
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 from astropy import units as u
 from astropy import wcs
@@ -15,7 +15,7 @@ from ..spectral_axis import doppler_gamma, doppler_beta, doppler_z, get_rest_val
 try:
     import regions
     regionsOK = True
-    REGIONS_GT_03 = LooseVersion(regions.__version__) >= LooseVersion('0.3')
+    REGIONS_GT_03 = parse(regions.__version__) >= Version('0.3')
 except ImportError:
     regionsOK = REGIONS_GT_03 = False
 

--- a/spectral_cube/tests/test_visualization.py
+++ b/spectral_cube/tests/test_visualization.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import, division
 
 import pytest
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 from .test_spectral_cube import cube_and_raw
 
@@ -18,7 +18,7 @@ def test_proj_imshow(data_vda_jybeam_lower, use_dask):
     plt = pytest.importorskip('matplotlib.pyplot')
     cube, data = cube_and_raw(data_vda_jybeam_lower, use_dask=use_dask)
     mom0 = cube.moment0()
-    if LooseVersion(plt.matplotlib.__version__) < LooseVersion('2.1'):
+    if parse(plt.matplotlib.__version__) < Version('2.1'):
         # imshow is now only compatible with more recent versions of matplotlib
         # (apparently 2.0.2 was still incompatible)
         plt.imshow(mom0.value)


### PR DESCRIPTION
In Python 3.12, **distutils** does no longer exist. In spectral-cube it is used only for version comparison. This PR replaces it with **packaging.version.parse** resp. **packaging.version.Version**. On places where **LooseVersion** is unused, the import is just removed.

This should make the package compatible to Python 3.12; at least the [tests that we run during the Debian build](https://buildd.debian.org/status/fetch.php?pkg=spectral-cube&arch=all&ver=0.6.5-3&stamp=1707355679&raw=0) pass.