### PR TITLE
Progressbar: switch to tqdm, add description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
     joblib
     casa-formats-io
     packaging
+    tqdm
 
 [options.extras_require]
 test =

--- a/spectral_cube/analysis_utilities.py
+++ b/spectral_cube/analysis_utilities.py
@@ -3,11 +3,10 @@ import numpy as np
 from astropy import units as u
 from six.moves import zip, range
 from astropy.wcs import WCS
-from astropy.utils.console import ProgressBar
 from astropy import log
 import warnings
 
-from .utils import BadVelocitiesWarning
+from .utils import BadVelocitiesWarning, ProgressBar
 from .cube_utils import _map_context
 from .lower_dimensional_structures import VaryingResolutionOneDSpectrum, OneDSpectrum
 from .spectral_cube import VaryingResolutionSpectralCube, SpectralCube
@@ -284,7 +283,7 @@ def stack_spectra(cube, velocity_surface, v0=None,
     # Create chunks of spectra for read-out.
     chunks = get_chunks(len(xy_posns[0]), chunk_size)
     if progressbar:
-        iterat = ProgressBar(chunks)
+        iterat = ProgressBar(chunks, desc='Stack Spectra: ')
     else:
         iterat = chunks
 

--- a/spectral_cube/utils.py
+++ b/spectral_cube/utils.py
@@ -6,7 +6,10 @@ from astropy.utils.exceptions import AstropyUserWarning
 
 bigdataurl = "https://spectral-cube.readthedocs.io/en/latest/big_data.html"
 
-from tqdm.auto import tqdm as ProgressBar
+from tqdm.auto import tqdm
+
+def ProgressBar(niter, **kwargs):
+    return tqdm(total=niter, **kwargs)
 
 
 def cached(func):

--- a/spectral_cube/utils.py
+++ b/spectral_cube/utils.py
@@ -6,16 +6,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 
 bigdataurl = "https://spectral-cube.readthedocs.io/en/latest/big_data.html"
 
-try:
-    from tqdm.auto import tqdm as ProgressBar
-except (ImportError, ModuleNotFoundError):
-    from astropy.utils.console import ProgressBar as pb
-    from astropy.utils.console import get_terminal_size
-    class ProgressBar(pb):
-        def __init__(self, *args, desc=None, **kwargs):
-            # astropy progressbar won't show this
-            self.desc = desc
-            super().__init__(*args, **kwargs)
+from tqdm.auto import tqdm as ProgressBar
 
 
 def cached(func):

--- a/spectral_cube/utils.py
+++ b/spectral_cube/utils.py
@@ -10,19 +10,12 @@ try:
     from tqdm.auto import tqdm as ProgressBar
 except ImportError:
     from astropy.utils.console import ProgressBar as pb
+    from astropy.utils.console import get_terminal_size
     class ProgressBar(pb):
         def __init__(self, *args, desc=None, **kwargs):
-            super().__init__(*args, **kwargs)
+            # astropy progressbar won't show this
             self.desc = desc
-
-        def _handle_resize(self, signum=None, frame=None):
-            terminal_width = get_terminal_size().columns
-            self._bar_length = terminal_width - 37 - (len(self.desc) if self.desc else 0)
-
-        def __enter__(self):
-            if self.desc:
-                print(self.desc, end='')
-            return self
+            super().__init__(*args, **kwargs)
 
 
 def cached(func):

--- a/spectral_cube/utils.py
+++ b/spectral_cube/utils.py
@@ -6,6 +6,25 @@ from astropy.utils.exceptions import AstropyUserWarning
 
 bigdataurl = "https://spectral-cube.readthedocs.io/en/latest/big_data.html"
 
+try:
+    from tqdm.auto import tqdm as ProgressBar
+except ImportError:
+    from astropy.utils.console import ProgressBar as pb
+    class ProgressBar(pb):
+        def __init__(self, *args, desc=None, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.desc = desc
+
+        def _handle_resize(self, signum=None, frame=None):
+            terminal_width = get_terminal_size().columns
+            self._bar_length = terminal_width - 37 - (len(self.desc) if self.desc else 0)
+
+        def __enter__(self):
+            if self.desc:
+                print(self.desc, end='')
+            return self
+
+
 def cached(func):
     """
     Decorator to cache function calls

--- a/spectral_cube/utils.py
+++ b/spectral_cube/utils.py
@@ -8,7 +8,7 @@ bigdataurl = "https://spectral-cube.readthedocs.io/en/latest/big_data.html"
 
 try:
     from tqdm.auto import tqdm as ProgressBar
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     from astropy.utils.console import ProgressBar as pb
     from astropy.utils.console import get_terminal_size
     class ProgressBar(pb):

--- a/spectral_cube/visualization-tools.py
+++ b/spectral_cube/visualization-tools.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-from astropy.utils.console import ProgressBar
+from .utils import ProgressBar
 
 def check_ffmpeg(ffmpeg_cmd):
     returncode = os.system(f'{ffmpeg_cmd} > /dev/null 2&> /dev/null')
@@ -46,7 +46,7 @@ def make_rgb_movie(cube, prefix, v1, v2, vmin, vmax, ffmpeg_cmd='ffmpeg'):
     p1 = cube.closest_spectral_channel(v1)
     p2 = cube.closest_spectral_channel(v2)
 
-    for jj, ii in enumerate(ProgressBar(range(p1, p2-1))):
+    for jj, ii in enumerate(ProgressBar(range(p1, p2-1), desc='RGB: ')):
         rgb = np.array([cube[ii+2], cube[ii+1], cube[ii]]).T.swapaxes(0, 1)
 
         # in case you manually set min/max
@@ -114,7 +114,7 @@ def make_multispecies_rgb(cube_r, cube_g, cube_b, prefix, v1, v2, vmin, vmax,
     p1 = cube_r.closest_spectral_channel(v1)
     p2 = cube_r.closest_spectral_channel(v2)
 
-    for jj, ii in enumerate(ProgressBar(range(p1, p2+1))):
+    for jj, ii in enumerate(ProgressBar(range(p1, p2+1), desc='RGB multi: ')):
         rgb = np.array([cube_r[ii].value,
                         cube_g[ii].value,
                         cube_b[ii].value

--- a/spectral_cube/ytcube.py
+++ b/spectral_cube/ytcube.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import numpy as np
 import time
-from astropy.utils.console import ProgressBar
+from .utils import ProgressBar
 from astropy import log
 import warnings
 


### PR DESCRIPTION
As in the title: there are a lot of progressbars scattered throughout spectral-cube, and it can be tricky to track down where they are.  Adding labels should help.