### PR TITLE
Pin zarr<3 until support for structured dtypes is provided

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ test =
     regions>=0.7
     numpy>=1.24.0
     astropy>=5.2.1
+    zarr<3.0.0 # Unpin if updated. See issue #936
 docs =
     sphinx-astropy
     matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ docs =
     sphinx-astropy
     matplotlib
 noviz =
-    zarr<3 # Unpin if updated. See issue #936
+    zarr<3.0.0 # Unpin if updated. See issue #936
     fsspec
     distributed
     pvextractor

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ docs =
     sphinx-astropy
     matplotlib
 noviz =
-    zarr<3 ; Unpin if updated. See issue #936
+    zarr<3 # Unpin if updated. See issue #936
     fsspec
     distributed
     pvextractor

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ docs =
     sphinx-astropy
     matplotlib
 noviz =
-    zarr
+    zarr<3 ; Unpin if updated. See issue #936
     fsspec
     distributed
     pvextractor


### PR DESCRIPTION
Addresses new test failures in #929. See description of issue with zarr 3 in #936 