### PR TITLE
BUG: fix command in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands =
     casa: cp {toxinidir}/casa_config_template.py config.py
     casa: python -m casaconfig --update-all
     casa: python -m casaconfig --current-data
-    pip freeze
+    uv pip freeze
     !cov: pytest --pyargs spectral_cube {toxinidir}/docs {posargs}
     cov: pytest --pyargs spectral_cube {toxinidir}/docs --cov spectral_cube --cov-config={toxinidir}/pyproject.toml {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands =
     casa: cp {toxinidir}/casa_config_template.py config.py
     casa: python -m casaconfig --update-all
     casa: python -m casaconfig --current-data
-    uv pip freeze
+    {list_dependencies_command}
     !cov: pytest --pyargs spectral_cube {toxinidir}/docs {posargs}
     cov: pytest --pyargs spectral_cube {toxinidir}/docs --cov spectral_cube --cov-config={toxinidir}/pyproject.toml {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml


### PR DESCRIPTION
Most of the dependencies are now installed with `uv pip`, thus they are currently not listed out in the CI logs making debugging harder than necessary