### PR TITLE
BUG: default branch is old-school

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Run tests
 on:
   push:
     branches:
-    - main
+    - master
     tags:
     - '*'
   pull_request:


### PR DESCRIPTION
I've just noticed the lack of CI notifications after a merge.

Ideally this will be closed without merged in favour of a rename in #960, but if not, then this should go in.
