### PR TITLE
Update smoothing.rst

### DIFF
--- a/docs/smoothing.rst
+++ b/docs/smoothing.rst
@@ -89,7 +89,7 @@ of how you can do this::
     new_cube.write('/some_path/some_other_file.fits')
 
 ``x_stddev`` specifies the width of the `Gaussian kernel <http://docs.astropy.org/en/stable/api/astropy.convolution.Gaussian2DKernel.html>`_.
-Any `astropy convolution <kernel http://docs.astropy.org/en/stable/convolution/kernels.html>`_
+Any `astropy convolution kernel <http://docs.astropy.org/en/stable/convolution/kernels.html>`_
 is acceptable.
 
 .. _Spectral-Smoothing:


### PR DESCRIPTION
This change should fix the broken link to astropy convolution kernels. 