### PR TITLE
Avoid deprecation warning with dev astropy/astropy>=8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
 
 - Fixed compatibility with dask>=2024.12.0 #968
 
+- Avoid deprecation warning with astropy>=8 #991
+
 0.6.5 (2023-12-05)
 ----------------------
 - Fixed issue with fix from #893 not getting included in the 0.6.4 tag

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -22,10 +22,16 @@ from astropy import convolution
 from astropy import stats
 from astropy.constants import si
 from astropy.io.registry import UnifiedReadWriteMethod
-try:
-    from astropy.utils.compat import COPY_IF_NEEDED
-except ImportError:
-    COPY_IF_NEEDED = False
+from astropy.utils import minversion
+if not minversion('astropy', '8.0.0.dev'):
+    # Astropy 8.0 pins numpy >=2, so this is no longer needed and will raise a
+    # deprecation warning
+    try:
+        from astropy.utils.compat import COPY_IF_NEEDED
+    except ImportError:
+        COPY_IF_NEEDED = False
+else:
+    COPY_IF_NEEDED = None
 
 import numpy as np
 


### PR DESCRIPTION
https://github.com/astropy/astropy/pull/18986 was merged 3 days ago and is causing failures in our dev versions CI tests due to `spectral-cube` using `COPY_IF_NEEDED`. I think this is a reasonable fix for now.