### PR TITLE
Enabling subcubes from regions as well as other supported methods from BaseSpectralCube

### DIFF
--- a/spectral_cube/stokes_spectral_cube.py
+++ b/spectral_cube/stokes_spectral_cube.py
@@ -101,7 +101,6 @@ class StokesSpectralCube(object):
             # Treat as a spatial/spectral slice and apply to all components
             return self._new_cube_with(
                 stokes_data={k: self._stokes_data[k][view] for k in self._stokes_data},
-                mask=None,
             )
 
     def __setitem__(self, key, item):
@@ -324,7 +323,6 @@ class StokesSpectralCube(object):
         return self._new_cube_with(
             stokes_data={k: self._stokes_data[k].spectral_slab(lo, hi)
                          for k in self._stokes_data},
-            mask=None,
         )
 
     def subcube(self, xlo='min', xhi='max', ylo='min', yhi='max',
@@ -346,7 +344,6 @@ class StokesSpectralCube(object):
                              xlo=xlo, xhi=xhi, ylo=ylo, yhi=yhi,
                              zlo=zlo, zhi=zhi, rest_value=rest_value)
                          for k in self._stokes_data},
-            mask=None,
         )
 
     def subcube_slices_from_mask(self, region_mask, spatial_only=False):
@@ -377,7 +374,6 @@ class StokesSpectralCube(object):
         return self._new_cube_with(
             stokes_data={k: self._stokes_data[k].subcube_from_mask(region_mask)
                          for k in self._stokes_data},
-            mask=None,
         )
 
     def minimal_subcube(self, spatial_only=False):
@@ -393,7 +389,6 @@ class StokesSpectralCube(object):
             stokes_data={k: self._stokes_data[k].minimal_subcube(
                              spatial_only=spatial_only)
                          for k in self._stokes_data},
-            mask=None,
         )
 
     def subcube_from_regions(self, region_list, allow_empty=False, minimize=True):
@@ -417,7 +412,6 @@ class StokesSpectralCube(object):
                              region_list, allow_empty=allow_empty,
                              minimize=minimize)
                          for k in self._stokes_data},
-            mask=None,
         )
 
     def subcube_from_ds9region(self, ds9_region, allow_empty=False):
@@ -437,7 +431,6 @@ class StokesSpectralCube(object):
             stokes_data={k: self._stokes_data[k].subcube_from_ds9region(
                              ds9_region, allow_empty=allow_empty)
                          for k in self._stokes_data},
-            mask=None,
         )
 
     def subcube_from_crtfregion(self, crtf_region, allow_empty=False):
@@ -457,7 +450,6 @@ class StokesSpectralCube(object):
             stokes_data={k: self._stokes_data[k].subcube_from_crtfregion(
                              crtf_region, allow_empty=allow_empty)
                          for k in self._stokes_data},
-            mask=None,
         )
 
     def with_spectral_unit(self, unit, **kwargs):

--- a/spectral_cube/stokes_spectral_cube.py
+++ b/spectral_cube/stokes_spectral_cube.py
@@ -91,11 +91,18 @@ class StokesSpectralCube(object):
 
         self._mask = mask
 
-    def __getitem__(self, key):
-        if key in self._stokes_data:
-            return self._stokes_data[key]
+    def __getitem__(self, view):
+        if isinstance(view, str):
+            if view in self._stokes_data:
+                return self._stokes_data[view]
+            else:
+                raise KeyError("Key {0} does not exist in this cube.".format(view))
         else:
-            raise KeyError("Key {0} does not exist in this cube.".format(key))
+            # Treat as a spatial/spectral slice and apply to all components
+            return self._new_cube_with(
+                stokes_data={k: self._stokes_data[k][view] for k in self._stokes_data},
+                mask=None,
+            )
 
     def __setitem__(self, key, item):
         if key in self._stokes_data:
@@ -305,6 +312,154 @@ class StokesSpectralCube(object):
             raise NotImplementedError(errmsg)
 
         return StokesSpectralCube(stokes_data=data, mask=self._mask, meta=self._meta, fill_value=self._fill_value)
+    def spectral_slab(self, lo, hi):
+        """
+        Extract a new cube between two spectral coordinates.
+
+        Parameters
+        ----------
+        lo, hi : :class:`~astropy.units.Quantity`
+            The lower and upper spectral coordinate for the slab range.
+        """
+        return self._new_cube_with(
+            stokes_data={k: self._stokes_data[k].spectral_slab(lo, hi)
+                         for k in self._stokes_data},
+            mask=None,
+        )
+
+    def subcube(self, xlo='min', xhi='max', ylo='min', yhi='max',
+                zlo='min', zhi='max', rest_value=None):
+        """
+        Extract a sub-cube spatially and spectrally.
+
+        Parameters
+        ----------
+        xlo, xhi, ylo, yhi, zlo, zhi : int or :class:`~astropy.units.Quantity` or ``min``/``max``
+            The endpoints to extract. Quantity values are interpreted as world
+            coordinates; plain ints or ``'min'``/``'max'`` strings as pixel
+            coordinates.
+        rest_value : :class:`~astropy.units.Quantity`, optional
+            The rest frequency/wavelength for spectral conversions.
+        """
+        return self._new_cube_with(
+            stokes_data={k: self._stokes_data[k].subcube(
+                             xlo=xlo, xhi=xhi, ylo=ylo, yhi=yhi,
+                             zlo=zlo, zhi=zhi, rest_value=rest_value)
+                         for k in self._stokes_data},
+            mask=None,
+        )
+
+    def subcube_slices_from_mask(self, region_mask, spatial_only=False):
+        """
+        Given a mask, return the slices corresponding to the minimum subcube
+        that encloses the mask.
+
+        Parameters
+        ----------
+        region_mask : :class:`~spectral_cube.masks.MaskBase` or boolean `numpy.ndarray`
+            The mask with appropriate WCS or an ndarray with matched coordinates.
+        spatial_only : bool
+            Return only slices that affect the spatial dimensions; the spectral
+            dimension will be left unchanged.
+        """
+        reference = self._stokes_data[self.components[0]]
+        return reference.subcube_slices_from_mask(region_mask, spatial_only=spatial_only)
+
+    def subcube_from_mask(self, region_mask):
+        """
+        Given a mask, return the minimal subcube that encloses the mask.
+
+        Parameters
+        ----------
+        region_mask : :class:`~spectral_cube.masks.MaskBase` or boolean `numpy.ndarray`
+            The mask with appropriate WCS or an ndarray with matched coordinates.
+        """
+        return self._new_cube_with(
+            stokes_data={k: self._stokes_data[k].subcube_from_mask(region_mask)
+                         for k in self._stokes_data},
+            mask=None,
+        )
+
+    def minimal_subcube(self, spatial_only=False):
+        """
+        Return the minimum enclosing subcube where the mask is valid.
+
+        Parameters
+        ----------
+        spatial_only : bool
+            Only compute the minimal subcube in the spatial dimensions.
+        """
+        return self._new_cube_with(
+            stokes_data={k: self._stokes_data[k].minimal_subcube(
+                             spatial_only=spatial_only)
+                         for k in self._stokes_data},
+            mask=None,
+        )
+
+    def subcube_from_regions(self, region_list, allow_empty=False, minimize=True):
+        """
+        Extract a masked subcube from a list of ``regions.Region`` objects
+        (only functions on celestial dimensions).
+
+        Parameters
+        ----------
+        region_list : list of ``regions.Region``
+            The region(s) to extract.
+        allow_empty : bool, optional
+            If False, raise an exception when the region has no overlap with
+            the cube. Default is False.
+        minimize : bool, optional
+            Run :meth:`~SpectralCube.minimal_subcube` after masking. Default
+            is True.
+        """
+        return self._new_cube_with(
+            stokes_data={k: self._stokes_data[k].subcube_from_regions(
+                             region_list, allow_empty=allow_empty,
+                             minimize=minimize)
+                         for k in self._stokes_data},
+            mask=None,
+        )
+
+    def subcube_from_ds9region(self, ds9_region, allow_empty=False):
+        """
+        Extract a masked subcube from a DS9 region string
+        (only functions on celestial dimensions).
+
+        Parameters
+        ----------
+        ds9_region : str
+            The DS9 region(s) to extract.
+        allow_empty : bool, optional
+            If False, raise an exception when the region has no overlap with
+            the cube. Default is False.
+        """
+        return self._new_cube_with(
+            stokes_data={k: self._stokes_data[k].subcube_from_ds9region(
+                             ds9_region, allow_empty=allow_empty)
+                         for k in self._stokes_data},
+            mask=None,
+        )
+
+    def subcube_from_crtfregion(self, crtf_region, allow_empty=False):
+        """
+        Extract a masked subcube from a CRTF region string
+        (only functions on celestial dimensions).
+
+        Parameters
+        ----------
+        crtf_region : str
+            The CRTF region(s) string to extract.
+        allow_empty : bool, optional
+            If False, raise an exception when the region has no overlap with
+            the cube. Default is False.
+        """
+        return self._new_cube_with(
+            stokes_data={k: self._stokes_data[k].subcube_from_crtfregion(
+                             crtf_region, allow_empty=allow_empty)
+                         for k in self._stokes_data},
+            mask=None,
+        )
+
     def with_spectral_unit(self, unit, **kwargs):
 
         stokes_data = {k: self._stokes_data[k].with_spectral_unit(unit, **kwargs)

--- a/spectral_cube/tests/test_stokes_spectral_cube.py
+++ b/spectral_cube/tests/test_stokes_spectral_cube.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from astropy.wcs import WCS
+from astropy.units import units as u
 from astropy.tests.helper import pytest
 from astropy.utils import NumpyRNGContext
 from astropy.coordinates import custom_stokes_symbol_mapping, StokesSymbol
@@ -223,7 +224,6 @@ class TestStokesSpectralCube():
 
 class TestStokesSpectralCubeTransformBasis:
     def setup_class(self):
-        from astropy.wcs import WCS
         self.wcs = WCS(naxis=3)
         self.wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN', 'FREQ']
         # Simple data for easy checking, shape (4, 5, 5)
@@ -315,8 +315,6 @@ class TestStokesSubcube():
     """Tests for spatial/spectral slicing on StokesSpectralCube."""
 
     def setup_method(self, method):
-        import astropy.units as u
-
         self.wcs = WCS(naxis=3)
         self.wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN', 'FREQ']
         self.wcs.wcs.crval = [0, 0, 1.4e9]
@@ -354,7 +352,7 @@ class TestStokesSubcube():
         assert comp.shape == (5, 20, 30)
 
     def test_spectral_slab(self, use_dask):
-        import astropy.units as u
+
         cube = self._make_cube(use_dask)
         sub = cube.spectral_slab(1.401e9 * u.Hz, 1.403e9 * u.Hz)
         assert isinstance(sub, StokesSpectralCube)
@@ -363,7 +361,6 @@ class TestStokesSubcube():
         assert set(sub.components) == {'I', 'Q', 'U', 'V'}
 
     def test_spectral_slab_preserves_data(self, use_dask):
-        import astropy.units as u
         cube = self._make_cube(use_dask)
         sub = cube.spectral_slab(1.401e9 * u.Hz, 1.403e9 * u.Hz)
         assert_allclose(sub['I'].unmasked_data[:], self.data[0, 1:4])

--- a/spectral_cube/tests/test_stokes_spectral_cube.py
+++ b/spectral_cube/tests/test_stokes_spectral_cube.py
@@ -309,3 +309,93 @@ class TestStokesSpectralCubeTransformBasis:
         sky_cube = cube.transform_basis('Sky')
         for k in stokes_data:
             assert_allclose(sky_cube[k].unmasked_data[...], self.data["IQUV".index(k)][None, ...])
+
+
+class TestStokesSubcube():
+    """Tests for spatial/spectral slicing on StokesSpectralCube."""
+
+    def setup_method(self, method):
+        import astropy.units as u
+
+        self.wcs = WCS(naxis=3)
+        self.wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN', 'FREQ']
+        self.wcs.wcs.crval = [0, 0, 1.4e9]
+        self.wcs.wcs.cdelt = [1, 1, 1e6]
+        self.wcs.wcs.crpix = [1, 1, 1]
+
+        # shape: (spectral=5, y=20, x=30); each component has a distinct fill
+        self.data = np.arange(1, 5)[:, None, None, None] * np.ones((5, 20, 30))
+
+    def _make_cube(self, use_dask):
+        return StokesSpectralCube(dict(
+            I=SpectralCube(self.data[0], wcs=self.wcs, use_dask=use_dask),
+            Q=SpectralCube(self.data[1], wcs=self.wcs, use_dask=use_dask),
+            U=SpectralCube(self.data[2], wcs=self.wcs, use_dask=use_dask),
+            V=SpectralCube(self.data[3], wcs=self.wcs, use_dask=use_dask),
+        ))
+
+    def test_getitem_slice(self, use_dask):
+        cube = self._make_cube(use_dask)
+        sub = cube[1:3, 5:10, 8:15]
+        assert isinstance(sub, StokesSpectralCube)
+        assert sub.shape == (2, 5, 7)
+        assert set(sub.components) == {'I', 'Q', 'U', 'V'}
+
+    def test_getitem_slice_preserves_data(self, use_dask):
+        cube = self._make_cube(use_dask)
+        sub = cube[1:3, :, :]
+        assert_allclose(sub['I'].unmasked_data[:], self.data[0, 1:3])
+        assert_allclose(sub['Q'].unmasked_data[:], self.data[1, 1:3])
+
+    def test_getitem_string_still_works(self, use_dask):
+        # Ensure Stokes component access via string key is not broken
+        cube = self._make_cube(use_dask)
+        comp = cube['I']
+        assert comp.shape == (5, 20, 30)
+
+    def test_spectral_slab(self, use_dask):
+        import astropy.units as u
+        cube = self._make_cube(use_dask)
+        sub = cube.spectral_slab(1.401e9 * u.Hz, 1.403e9 * u.Hz)
+        assert isinstance(sub, StokesSpectralCube)
+        assert sub.shape[0] == 3
+        assert sub.shape[1:] == (20, 30)
+        assert set(sub.components) == {'I', 'Q', 'U', 'V'}
+
+    def test_spectral_slab_preserves_data(self, use_dask):
+        import astropy.units as u
+        cube = self._make_cube(use_dask)
+        sub = cube.spectral_slab(1.401e9 * u.Hz, 1.403e9 * u.Hz)
+        assert_allclose(sub['I'].unmasked_data[:], self.data[0, 1:4])
+        assert_allclose(sub['V'].unmasked_data[:], self.data[3, 1:4])
+
+    def test_subcube_pixel(self, use_dask):
+        cube = self._make_cube(use_dask)
+        sub = cube.subcube(xlo=5, xhi=15, ylo=2, yhi=12)
+        assert isinstance(sub, StokesSpectralCube)
+        assert sub.shape == (5, 10, 10)
+
+    def test_subcube_all_components_consistent(self, use_dask):
+        # All components must share shape and WCS after subcube
+        cube = self._make_cube(use_dask)
+        sub = cube.subcube(xlo=5, xhi=15, ylo=2, yhi=12)
+        shapes = [sub[k].shape for k in sub.components]
+        assert len(set(shapes)) == 1
+
+    def test_subcube_from_mask(self, use_dask):
+        cube = self._make_cube(use_dask)
+        region_mask = np.zeros((5, 20, 30), dtype=bool)
+        region_mask[:, 5:10, 8:15] = True
+        mask = BooleanArrayMask(region_mask, self.wcs)
+        sub = cube.subcube_from_mask(mask)
+        assert isinstance(sub, StokesSpectralCube)
+        assert sub.shape == (5, 5, 7)
+
+    def test_minimal_subcube(self, use_dask):
+        cube = self._make_cube(use_dask)
+        # Apply a mask that is True only in a small region
+        region_mask = np.zeros((5, 20, 30), dtype=bool)
+        region_mask[1:4, 3:8, 10:18] = True
+        masked = cube.with_mask(BooleanArrayMask(region_mask, self.wcs))
+        sub = masked.I.minimal_subcube()
+        assert sub.shape == (3, 5, 8)

--- a/spectral_cube/tests/test_stokes_spectral_cube.py
+++ b/spectral_cube/tests/test_stokes_spectral_cube.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from astropy.wcs import WCS
-from astropy.units import units as u
+from astropy import units as u
 from astropy.tests.helper import pytest
 from astropy.utils import NumpyRNGContext
 from astropy.coordinates import custom_stokes_symbol_mapping, StokesSymbol


### PR DESCRIPTION
`StokesSpectralCube` is essentially a collection of `SpectralCube` objects one per stokes value. We had not exposed the subcube methods from the class. This PR is to enable that.  @keflavich let me know if you think the tests should be in the `subcube`  tests rather than in `StokesSpectralCube`. This should enable what #998 is asking and should close the issue.