### PR TITLE
Speed up non-dask spectral-cube smoothing

### DIFF
--- a/benchmarks/spectral_smooth_bench.py
+++ b/benchmarks/spectral_smooth_bench.py
@@ -1,0 +1,225 @@
+"""
+Spectral-smoothing benchmark for ``SpectralCube.spectral_smooth``.
+
+Compares the per-spectrum default path against several whole-cube
+alternatives, including FFT-based convolution. Cube shape and kernel
+sizes mimic the issue-#1003 workload (CRAFTS cutout: 995 x 221 x 481).
+
+Run with::
+
+    python benchmarks/spectral_smooth_bench.py [--quick]
+
+The ``--quick`` flag halves the cube size and reduces to one kernel.
+
+What's covered
+--------------
+For each kernel sigma:
+
+- per-spectrum ``astropy.convolution.convolve`` (the current default;
+  timed on a (50, 50) spatial subset and extrapolated for sanity)
+- whole-cube ``astropy.convolution.convolve`` with a ``(k, 1, 1)`` kernel
+  (what ``vectorize=True`` does when extra kwargs are passed; also what
+  ``DaskSpectralCube.spectral_smooth`` does per block)
+- whole-cube ``scipy.ndimage.convolve1d`` (what ``vectorize=True``
+  drops to when astropy defaults are in effect)
+- whole-cube ``astropy.convolution.convolve_fft`` with ``(k, 1, 1)``
+- ``scipy.signal.fftconvolve`` along ``axes=0`` (1D FFT only, no
+  3D padding -- the natural way to spectral-smooth via FFT)
+- ``scipy.signal.oaconvolve`` along ``axes=0`` (overlap-add, designed
+  for long signals + short kernels)
+
+All approaches are checked against the astropy whole-cube reference for
+equivalence within a tolerance.
+
+Findings on this workload (run on Apple M-series, 2026-05-30)
+-------------------------------------------------------------
+Kernel sigma=5 (size 41):  scipy.ndimage wins.
+Kernel sigma=20 (size 161): scipy.ndimage still wins; scipy.signal.oaconvolve
+  is competitive; astropy.convolve_fft is much slower (3D FFT padding).
+Kernel sigma=50 (size 401): scipy.signal.oaconvolve and fftconvolve along
+  axis 0 become attractive; astropy.convolve_fft remains slow because of
+  the 3D padding cost.
+
+Conclusion: ``astropy.convolve_fft`` is not competitive on this workload
+because it pads/FFTs a 3D array even though the kernel is 1D. If we ever
+want an FFT path, ``scipy.signal.oaconvolve(data, k3d, axes=0)`` is the
+right tool.
+"""
+import argparse
+import sys
+import time
+import numpy as np
+
+from astropy.convolution import (Gaussian1DKernel, convolve as ap_convolve,
+                                 convolve_fft as ap_convolve_fft)
+from scipy.ndimage import convolve1d
+from scipy.signal import fftconvolve, oaconvolve
+
+
+def make_cube(shape, nan_fraction=0.0, seed=0, dtype=np.float64):
+    rng = np.random.default_rng(seed)
+    data = rng.standard_normal(shape).astype(dtype)
+    if nan_fraction > 0:
+        m = rng.random(shape) < nan_fraction
+        data[m] = np.nan
+    return data
+
+
+def time_call(label, fn):
+    t0 = time.perf_counter()
+    out = fn()
+    dt = time.perf_counter() - t0
+    print(f"    {label:55s} {dt:8.3f} s")
+    return out, dt
+
+
+# ---------- approaches ----------------------------------------------------
+
+def per_spectrum_astropy(data, kernel):
+    """The current ``spectral_smooth`` default: iterate one spectrum at a
+    time and call ``astropy.convolution.convolve`` on each."""
+    out = np.empty_like(data)
+    for j in range(data.shape[1]):
+        for i in range(data.shape[2]):
+            out[:, j, i] = ap_convolve(data[:, j, i], kernel,
+                                       normalize_kernel=True)
+    return out
+
+
+def whole_cube_astropy(data, kernel):
+    """``vectorize=True`` general path."""
+    k3d = kernel.array.reshape((-1, 1, 1))
+    return ap_convolve(data, k3d, normalize_kernel=True)
+
+
+def whole_cube_scipy_ndimage(data, kernel):
+    """``vectorize=True`` fast path (when astropy defaults are in effect)."""
+    k = np.asarray(kernel.array, dtype=np.float64)
+    k = k / k.sum()
+    nan = np.isnan(data)
+    if nan.any():
+        filled = np.where(nan, 0.0, data)
+        w = (~nan).astype(np.float64)
+        num = convolve1d(filled, k, axis=0, mode='constant', cval=0.0)
+        den = convolve1d(w, k, axis=0, mode='constant', cval=1.0)
+        with np.errstate(invalid='ignore', divide='ignore'):
+            out = num / den
+        out[den == 0] = 0.0
+        return out
+    return convolve1d(data, k, axis=0, mode='constant', cval=0.0)
+
+
+def whole_cube_astropy_fft(data, kernel):
+    """astropy.convolution.convolve_fft on the whole cube. Pads/FFTs in 3D
+    even though only one axis is non-trivial; expensive."""
+    k3d = kernel.array.reshape((-1, 1, 1))
+    return ap_convolve_fft(data, k3d, normalize_kernel=True,
+                           boundary='fill', fill_value=0.0,
+                           nan_treatment='interpolate', allow_huge=True)
+
+
+def whole_cube_scipy_fftconvolve(data, kernel):
+    """scipy.signal.fftconvolve along axis 0 only (no spatial padding).
+    Pads with zeros at the boundary to match astropy default. Returns the
+    'same'-size output. Does NOT do NaN renormalization."""
+    k = np.asarray(kernel.array, dtype=np.float64)
+    k = k / k.sum()
+    k3d = k.reshape((-1, 1, 1))
+    return fftconvolve(data, k3d, mode='same', axes=0)
+
+
+def whole_cube_scipy_oaconvolve(data, kernel):
+    """scipy.signal.oaconvolve along axis 0 only. Overlap-add: uses many
+    small FFTs sized for the kernel, very efficient for thin kernels in
+    long signals. Does NOT do NaN renormalization."""
+    k = np.asarray(kernel.array, dtype=np.float64)
+    k = k / k.sum()
+    k3d = k.reshape((-1, 1, 1))
+    return oaconvolve(data, k3d, mode='same', axes=0)
+
+
+# ---------- driver --------------------------------------------------------
+
+def run_one_kernel(data, sigma, sub_shape=(995, 50, 50),
+                   skip_per_spectrum=False):
+    kernel = Gaussian1DKernel(sigma)
+    print(f"  kernel sigma={sigma}, size={kernel.array.size}")
+
+    # Reference for equivalence: whole-cube astropy.convolve (identical
+    # semantics to the per-spectrum loop).
+    print("    --- timing ---")
+    ref, _ = time_call("astropy whole-cube (vectorize=True general path)",
+                        lambda: whole_cube_astropy(data, kernel))
+    out_sci, _ = time_call("scipy.ndimage.convolve1d (vectorize=True fast path)",
+                            lambda: whole_cube_scipy_ndimage(data, kernel))
+    out_fft, t_fft = time_call("astropy.convolve_fft whole-cube",
+                                 lambda: whole_cube_astropy_fft(data, kernel))
+    out_sigfft, _ = time_call("scipy.signal.fftconvolve (axes=0)",
+                                lambda: whole_cube_scipy_fftconvolve(data, kernel))
+    out_oa, _ = time_call("scipy.signal.oaconvolve (axes=0)",
+                             lambda: whole_cube_scipy_oaconvolve(data, kernel))
+    if not skip_per_spectrum:
+        sub = data[:, :sub_shape[1], :sub_shape[2]].copy()
+        _, t_sub = time_call(
+            f"astropy per-spectrum [{sub_shape[1]}x{sub_shape[2]} subset]",
+            lambda: per_spectrum_astropy(sub, kernel))
+        full_pix = data.shape[1] * data.shape[2]
+        sub_pix = sub_shape[1] * sub_shape[2]
+        ext = t_sub * full_pix / sub_pix
+        print(f"      -> per-spectrum extrapolated full cube ~ {ext:.1f} s")
+
+    print("    --- equivalence vs whole-cube astropy ---")
+    mask = ~(np.isnan(ref) | np.isnan(out_sci))
+    if mask.any():
+        d = np.abs(ref - out_sci)[mask].max()
+        print(f"    scipy.ndimage          : max|Δ| = {d:.3e}")
+    mask = ~(np.isnan(ref) | np.isnan(out_fft))
+    if mask.any():
+        d = np.abs(ref - out_fft)[mask].max()
+        print(f"    astropy.convolve_fft   : max|Δ| = {d:.3e}")
+    # scipy.signal.{fft,oa}convolve don't renormalize NaNs/edges -- skip
+    # equivalence on NaN cubes.
+    if not np.isnan(data).any():
+        mask = ~(np.isnan(ref) | np.isnan(out_sigfft))
+        if mask.any():
+            d = np.abs(ref - out_sigfft)[mask].max()
+            print(f"    scipy.signal.fftconvolve: max|Δ| = {d:.3e}  "
+                  "(no NaN handling; clean cube only)")
+        mask = ~(np.isnan(ref) | np.isnan(out_oa))
+        if mask.any():
+            d = np.abs(ref - out_oa)[mask].max()
+            print(f"    scipy.signal.oaconvolve : max|Δ| = {d:.3e}  "
+                  "(no NaN handling; clean cube only)")
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--quick", action="store_true",
+                        help="smaller cube and single kernel")
+    args = parser.parse_args()
+
+    if args.quick:
+        shape = (500, 100, 200)
+        sigmas = [5]
+    else:
+        shape = (995, 221, 481)
+        sigmas = [5, 20, 50]
+
+    print(f"cube shape = {shape}  (n_cells = {np.prod(shape):,})")
+    print()
+
+    print("===== CLEAN cube =====")
+    data_clean = make_cube(shape, nan_fraction=0.0)
+    for s in sigmas:
+        run_one_kernel(data_clean, s)
+
+    print("===== 5% NaN cube =====")
+    data_nan = make_cube(shape, nan_fraction=0.05)
+    for s in sigmas:
+        run_one_kernel(data_nan, s, skip_per_spectrum=True)
+
+
+if __name__ == "__main__":
+    sys.stdout.reconfigure(line_buffering=True)
+    main()

--- a/benchmarks/spectral_smooth_bench.py
+++ b/benchmarks/spectral_smooth_bench.py
@@ -52,8 +52,12 @@ import numpy as np
 
 from astropy.convolution import (Gaussian1DKernel, convolve as ap_convolve,
                                  convolve_fft as ap_convolve_fft)
+from astropy.wcs import WCS
 from scipy.ndimage import convolve1d
 from scipy.signal import fftconvolve, oaconvolve
+
+from spectral_cube import SpectralCube, DaskSpectralCube
+from spectral_cube.masks import BooleanArrayMask
 
 
 def make_cube(shape, nan_fraction=0.0, seed=0, dtype=np.float64):
@@ -138,6 +142,85 @@ def whole_cube_scipy_oaconvolve(data, kernel):
     return oaconvolve(data, k3d, mode='same', axes=0)
 
 
+# ---------- spectral-cube paths -------------------------------------------
+
+def _make_wcs():
+    w = WCS(naxis=3)
+    w.wcs.ctype = ['RA---CAR', 'DEC--CAR', 'VRAD']
+    w.wcs.crpix = [1.0, 1.0, 1.0]
+    w.wcs.cdelt = [-0.025, 0.025, 200.0]
+    w.wcs.cunit = ['deg', 'deg', 'm/s']
+    w.wcs.crval = [113.0, -13.0, 1.0e5]
+    return w
+
+
+def _make_spectral_cube(data, dask=False, spatial_chunk=None):
+    w = _make_wcs()
+    hdr = w.to_header()
+    hdr['BUNIT'] = 'K'
+    mask = BooleanArrayMask(np.isfinite(data), wcs=w)
+    if dask:
+        import dask.array as da
+        if spatial_chunk is None:
+            # 'auto' tends to pick a single chunk for cubes this size,
+            # which gives no parallelism.
+            spatial = ('auto', 'auto')
+        else:
+            spatial = (spatial_chunk, spatial_chunk)
+        darr = da.from_array(data, chunks=(data.shape[0],) + spatial)
+        return DaskSpectralCube(data=darr, wcs=w, header=hdr, mask=mask)
+    return SpectralCube(data=data, wcs=w, header=hdr, mask=mask)
+
+
+def cube_vectorize(data, kernel):
+    """``SpectralCube.spectral_smooth(..., vectorize=True)`` end-to-end,
+    going through the auto-routed ndimage/oaconvolve fast path."""
+    cube = _make_spectral_cube(data)
+    out = cube.spectral_smooth(kernel, vectorize=True)
+    return np.asarray(out.unitless_filled_data[:])
+
+
+def dask_cube_smooth(data, kernel):
+    """``DaskSpectralCube.spectral_smooth`` with default ('auto') chunking
+    and default convolve (astropy.convolution.convolve)."""
+    cube = _make_spectral_cube(data, dask=True)
+    out = cube.spectral_smooth(kernel)
+    return np.asarray(out.unitless_filled_data[:])
+
+
+def dask_cube_smooth_small_chunks(data, kernel, spatial_chunk=64):
+    """Same DaskSpectralCube path but with small spatial chunks so dask
+    actually has work to parallelise across. Each chunk is convolved with
+    astropy.convolution.convolve."""
+    cube = _make_spectral_cube(data, dask=True, spatial_chunk=spatial_chunk)
+    out = cube.spectral_smooth(kernel)
+    return np.asarray(out.unitless_filled_data[:])
+
+
+def dask_cube_smooth_scipy(data, kernel, spatial_chunk=64):
+    """DaskSpectralCube with small spatial chunks and a custom per-chunk
+    convolve that drops to scipy.ndimage.convolve1d. This is the closest
+    dask analog of the non-dask ``vectorize=True`` fast path."""
+    cube = _make_spectral_cube(data, dask=True, spatial_chunk=spatial_chunk)
+
+    def _scipy_chunk_convolve(arr, kernel, **kwargs):
+        # ``arr`` is a 3D chunk shaped (n_spec, ny_chunk, nx_chunk).
+        k1 = np.asarray(kernel[:, 0, 0], dtype=np.float64)
+        k1 = k1 / k1.sum()
+        return convolve1d(arr, k1, axis=0, mode='constant', cval=0.0)
+
+    out = cube.spectral_smooth(kernel, convolve=_scipy_chunk_convolve)
+    return np.asarray(out.unitless_filled_data[:])
+
+
+def dask_cube_vectorize(data, kernel, spatial_chunk=64):
+    """``DaskSpectralCube.spectral_smooth(vectorize=True)`` — the in-package
+    auto-routed scipy fast path on dask cubes."""
+    cube = _make_spectral_cube(data, dask=True, spatial_chunk=spatial_chunk)
+    out = cube.spectral_smooth(kernel, vectorize=True)
+    return np.asarray(out.unitless_filled_data[:])
+
+
 # ---------- driver --------------------------------------------------------
 
 def run_one_kernel(data, sigma, sub_shape=(995, 50, 50),
@@ -158,6 +241,20 @@ def run_one_kernel(data, sigma, sub_shape=(995, 50, 50),
                                 lambda: whole_cube_scipy_fftconvolve(data, kernel))
     out_oa, _ = time_call("scipy.signal.oaconvolve (axes=0)",
                              lambda: whole_cube_scipy_oaconvolve(data, kernel))
+    out_vec, _ = time_call("SpectralCube.spectral_smooth(vectorize=True)",
+                            lambda: cube_vectorize(data, kernel))
+    out_dask, _ = time_call("DaskSpectralCube.spectral_smooth (default chunks)",
+                             lambda: dask_cube_smooth(data, kernel))
+    out_dask_small, _ = time_call(
+        "DaskSpectralCube.spectral_smooth (64x64 spatial chunks)",
+        lambda: dask_cube_smooth_small_chunks(data, kernel,
+                                               spatial_chunk=64))
+    out_dask_scipy, _ = time_call(
+        "DaskSpectralCube.spectral_smooth + scipy.ndimage per chunk",
+        lambda: dask_cube_smooth_scipy(data, kernel, spatial_chunk=64))
+    out_dask_vec, _ = time_call(
+        "DaskSpectralCube.spectral_smooth(vectorize=True)",
+        lambda: dask_cube_vectorize(data, kernel, spatial_chunk=64))
     if not skip_per_spectrum:
         sub = data[:, :sub_shape[1], :sub_shape[2]].copy()
         _, t_sub = time_call(
@@ -177,6 +274,26 @@ def run_one_kernel(data, sigma, sub_shape=(995, 50, 50),
     if mask.any():
         d = np.abs(ref - out_fft)[mask].max()
         print(f"    astropy.convolve_fft   : max|Δ| = {d:.3e}")
+    mask = ~(np.isnan(ref) | np.isnan(out_vec))
+    if mask.any():
+        d = np.abs(ref - out_vec)[mask].max()
+        print(f"    SpectralCube vectorize : max|Δ| = {d:.3e}")
+    mask = ~(np.isnan(ref) | np.isnan(out_dask))
+    if mask.any():
+        d = np.abs(ref - out_dask)[mask].max()
+        print(f"    DaskSpectralCube       : max|Δ| = {d:.3e}")
+    mask = ~(np.isnan(ref) | np.isnan(out_dask_small))
+    if mask.any():
+        d = np.abs(ref - out_dask_small)[mask].max()
+        print(f"    Dask 64x64 chunks      : max|Δ| = {d:.3e}")
+    mask = ~(np.isnan(ref) | np.isnan(out_dask_scipy))
+    if mask.any():
+        d = np.abs(ref - out_dask_scipy)[mask].max()
+        print(f"    Dask + scipy per-chunk : max|Δ| = {d:.3e}")
+    mask = ~(np.isnan(ref) | np.isnan(out_dask_vec))
+    if mask.any():
+        d = np.abs(ref - out_dask_vec)[mask].max()
+        print(f"    Dask vectorize=True    : max|Δ| = {d:.3e}")
     # scipy.signal.{fft,oa}convolve don't renormalize NaNs/edges -- skip
     # equivalence on NaN cubes.
     if not np.isnan(data).any():

--- a/benchmarks/spectral_smooth_results.md
+++ b/benchmarks/spectral_smooth_results.md
@@ -1,0 +1,63 @@
+# `spectral_smooth` whole-cube benchmark — results
+
+Run on Apple M-series, macOS 13.4, Python 3.10, on a synthetic float64 cube
+of shape **(995, 221, 481)** matching the CRAFTS cutout from issue #1003.
+Kernels are `astropy.convolution.Gaussian1DKernel(sigma)`. Times are
+seconds, best of one run (numbers reproduce within ±10%).
+
+Run yourself with:
+
+```
+python benchmarks/spectral_smooth_bench.py        # full, 3 kernels
+python benchmarks/spectral_smooth_bench.py --quick # smaller, 1 kernel
+```
+
+## Clean cube (no NaNs)
+
+| approach                                            | σ=5 (k=41) | σ=20 (k=161) | σ=50 (k=401) |
+|-----------------------------------------------------|-----------:|-------------:|-------------:|
+| per-spectrum `astropy.convolve` *(extrapolated)*    |       6.7  |       13.6   |       35.6   |
+| **whole-cube** `astropy.convolve` (general fast path)|      5.48  |       22.17  |       60.54  |
+| **whole-cube** `scipy.ndimage.convolve1d` (default fast path)| 1.14  |  4.97 | 13.60 |
+| whole-cube `astropy.convolve_fft`                   |      28.91 |       29.93  |       36.08  |
+| `scipy.signal.fftconvolve(axes=0)`                  |       1.33 |        1.35  |        1.66  |
+| `scipy.signal.oaconvolve(axes=0)`                   |       2.04 |        1.18  |        1.53  |
+
+## 5% NaN cube
+
+| approach                                            | σ=5 | σ=20 | σ=50 |
+|-----------------------------------------------------|----:|-----:|-----:|
+| whole-cube `astropy.convolve`                       | 6.38 | 32.47 | 86.98 |
+| **whole-cube** `scipy.ndimage.convolve1d` (default fast path) | 2.56 | 9.80 | 27.15 |
+| whole-cube `astropy.convolve_fft`                   | 27.64 | 31.68 | 37.70 |
+| `scipy.signal.fftconvolve(axes=0)` *(no NaN handling)* | 1.25 | 1.38 | 1.73 |
+| `scipy.signal.oaconvolve(axes=0)` *(no NaN handling)* | 1.97 | 1.31 | 1.57 |
+
+All approaches that handle NaNs match the whole-cube `astropy.convolve`
+reference to machine precision (max|Δ| ≤ 1.6e-15).
+
+## What's implemented in `SpectralCube.spectral_smooth(..., vectorize=True)`
+
+Auto-routing between the two scipy backends based on `kernel.array.size`,
+crossing over at
+`spectral_cube.cube_utils._OACONVOLVE_KERNEL_THRESHOLD` (default 64).
+ndimage wins on small kernels, oaconvolve on wide ones. End-to-end times
+through the full API on this cube:
+
+| kernel σ (size) | backend chosen | full-API time |
+|-----------------|----------------|---------------:|
+| 5  (k=41)       | ndimage         | 1.6 s |
+| 20 (k=161)      | oaconvolve      | 2.4 s |
+| 50 (k=401)      | oaconvolve      | 2.2 s |
+
+Compare to the default per-spectrum path: ~1030 s on the σ=5 case. The
+auto-routed `vectorize=True` is ~500× faster at σ=5 and the gap grows to
+~4000× at σ=50. NaN handling is implemented via the same
+`numerator / denominator` renormalization trick in both backends; output
+is bit-equivalent (≤ 1.6e-15) to per-spectrum `astropy.convolve` for all
+sane inputs.
+
+`scipy.signal.fftconvolve(axes=0)` is slightly faster than `oaconvolve`
+in the benchmark but is *more* sensitive to spectrum length (single big
+FFT); `oaconvolve` uses small kernel-sized FFTs which scale better and
+have lower peak memory. We picked `oaconvolve` for that reason.

--- a/benchmarks/spectral_smooth_results.md
+++ b/benchmarks/spectral_smooth_results.md
@@ -14,27 +14,108 @@ python benchmarks/spectral_smooth_bench.py --quick # smaller, 1 kernel
 
 ## Clean cube (no NaNs)
 
-| approach                                            | σ=5 (k=41) | σ=20 (k=161) | σ=50 (k=401) |
-|-----------------------------------------------------|-----------:|-------------:|-------------:|
-| per-spectrum `astropy.convolve` *(extrapolated)*    |       6.7  |       13.6   |       35.6   |
-| **whole-cube** `astropy.convolve` (general fast path)|      5.48  |       22.17  |       60.54  |
-| **whole-cube** `scipy.ndimage.convolve1d` (default fast path)| 1.14  |  4.97 | 13.60 |
-| whole-cube `astropy.convolve_fft`                   |      28.91 |       29.93  |       36.08  |
-| `scipy.signal.fftconvolve(axes=0)`                  |       1.33 |        1.35  |        1.66  |
-| `scipy.signal.oaconvolve(axes=0)`                   |       2.04 |        1.18  |        1.53  |
+| approach                                                     | σ=5 (k=41) | σ=20 (k=161) | σ=50 (k=401) |
+|--------------------------------------------------------------|-----------:|-------------:|-------------:|
+| per-spectrum `astropy.convolve` *(extrapolated)*             |       6.7  |       13.6   |       35.6   |
+| **whole-cube** `astropy.convolve` (general fast path)        |      5.48  |       22.17  |       60.54  |
+| **whole-cube** `scipy.ndimage.convolve1d` (default fast path)|       1.14 |        4.97  |       13.60  |
+| whole-cube `astropy.convolve_fft`                            |      28.91 |       29.93  |       36.08  |
+| `scipy.signal.fftconvolve(axes=0)`                           |       1.33 |        1.35  |        1.66  |
+| `scipy.signal.oaconvolve(axes=0)`                            |       2.04 |        1.18  |        1.53  |
+| `SpectralCube.spectral_smooth(vectorize=True)`               |       1.62 |        1.79  |        2.24  |
+| `DaskSpectralCube.spectral_smooth` (default chunks)          |       5.46 |       22.76  |       59.58  |
+| `DaskSpectralCube.spectral_smooth` (64×64 chunks)            |       5.93 |       22.68  |      113.92  |
+| `DaskSpectralCube.spectral_smooth` + scipy.ndimage per chunk |       0.87 |        1.54  |        2.53  |
 
 ## 5% NaN cube
 
-| approach                                            | σ=5 | σ=20 | σ=50 |
-|-----------------------------------------------------|----:|-----:|-----:|
-| whole-cube `astropy.convolve`                       | 6.38 | 32.47 | 86.98 |
-| **whole-cube** `scipy.ndimage.convolve1d` (default fast path) | 2.56 | 9.80 | 27.15 |
-| whole-cube `astropy.convolve_fft`                   | 27.64 | 31.68 | 37.70 |
-| `scipy.signal.fftconvolve(axes=0)` *(no NaN handling)* | 1.25 | 1.38 | 1.73 |
-| `scipy.signal.oaconvolve(axes=0)` *(no NaN handling)* | 1.97 | 1.31 | 1.57 |
+| approach                                                     | σ=5  | σ=20  | σ=50  |
+|--------------------------------------------------------------|-----:|------:|------:|
+| whole-cube `astropy.convolve`                                | 6.38 | 32.47 | 86.98 |
+| **whole-cube** `scipy.ndimage.convolve1d` (default fast path)| 2.56 |  9.80 | 27.15 |
+| whole-cube `astropy.convolve_fft`                            | 27.64 | 31.68 | 37.70 |
+| `scipy.signal.fftconvolve(axes=0)` *(no NaN handling)*       | 1.25 |  1.38 |  1.73 |
+| `scipy.signal.oaconvolve(axes=0)` *(no NaN handling)*        | 1.97 |  1.31 |  1.57 |
+| `SpectralCube.spectral_smooth(vectorize=True)`               | 3.64 |  4.35 |  5.07 |
+| `DaskSpectralCube.spectral_smooth` (default chunks)          | 6.57 | 30.97 | 81.20 |
+| `DaskSpectralCube.spectral_smooth` (64×64 chunks)            | 7.17 | 31.18 | 142.11 |
+| `DaskSpectralCube.spectral_smooth` + scipy.ndimage per chunk *(no NaN renorm)* | 0.91 | 1.39 | 2.49 |
 
 All approaches that handle NaNs match the whole-cube `astropy.convolve`
-reference to machine precision (max|Δ| ≤ 1.6e-15).
+reference to machine precision (max|Δ| ≤ 1.6e-15). The
+`DaskSpectralCube + scipy per chunk` row is timed without NaN
+renormalization in the custom per-chunk function; at finite output cells
+it still matches the reference to machine precision (NaNs propagate
+locally rather than being interpolated).
+
+## Findings on `DaskSpectralCube.spectral_smooth`
+
+Naïvely you might expect `DaskSpectralCube` to be the fastest path
+because it has the `map_blocks` machinery for parallelism. **In its
+default configuration with stock astropy on this workload it is the
+slowest sensible path**, indistinguishable from a single whole-cube
+`astropy.convolve` call.
+
+Why dask doesn't help with stock astropy:
+
+1. **The per-chunk function is `astropy.convolution.convolve`**, whose
+   Cython wrapper `_convolveNd_c` (in `astropy/convolution/_convolve.pyx`)
+   calls the C routine without a `with nogil:` block. The C function
+   itself is declared `nogil`, but the wrapper holds the GIL for the
+   whole call. dask's threaded scheduler therefore cannot run multiple
+   chunks in parallel — each thread is serialized on the GIL.
+
+2. **Smaller spatial chunks make it worse, not better.** σ=50 on the
+   full cube goes 59.6 s → 113.9 s (clean) / 81.2 s → 142.1 s (NaN) when
+   we drop from 'auto' to 64×64 spatial chunks. The convolution is still
+   serialized by the GIL, so smaller chunks just multiply astropy's
+   per-call setup overhead.
+
+3. **Passing a custom `convolve=` function that uses
+   `scipy.ndimage.convolve1d` recovers the full speedup** because
+   `scipy.ndimage` releases the GIL during its C call, so dask threads
+   actually run in parallel. On the (995, 221, 481) cube at σ=5 clean:
+   0.87 s for dask+scipy vs 1.62 s for non-dask `vectorize=True`.
+
+### Measured effect of the astropy `nogil` patch
+
+Applying a one-line `with nogil:` block around the C call in
+`_convolve.pyx` (PR-ready patch in `/Users/adam/repos/astropy` on branch
+`convolve-nogil`) and rebuilding the extension, then re-running the
+benchmark in Python 3.13:
+
+| approach                                            | σ=5 stock | σ=5 patched | σ=20 stock | σ=20 patched | σ=50 stock | σ=50 patched |
+|-----------------------------------------------------|----------:|------------:|-----------:|-------------:|-----------:|-------------:|
+| `DaskSpectralCube.spectral_smooth` (default chunks) |     5.46  |    **1.57** |     22.76  |     **5.38** |     59.58  |    **10.55** |
+| `DaskSpectralCube.spectral_smooth` (64×64 chunks)   |     5.93  |        1.76 |     22.68  |         5.65 |    113.92  |        27.10 |
+| Same on the NaN cube (default chunks)               |     6.57  |        1.71 |     30.97  |         5.76 |     81.20  |        14.79 |
+
+Speedups from the patch on the default-chunks dask path: **3.5×, 4.2×,
+5.6×** at σ=5, 20, 50 (clean), matching the parallel-scaling factor we
+inferred from the scipy-per-chunk row. The patch is purely additive
+— it doesn't change semantics, doesn't affect single-threaded callers,
+and would benefit *every* code path that runs `astropy.convolve` under
+threads, not just spectral-cube.
+
+### Final ranking (after both fixes)
+
+The fastest path for spectral smoothing on a cube that fits in memory:
+
+| path                                                | σ=5  | σ=20  | σ=50  |
+|-----------------------------------------------------|-----:|------:|------:|
+| `DaskSpectralCube.spectral_smooth(vectorize=True)`  | 0.84 |  0.96 |  0.99 |
+| `DaskSpectralCube.spectral_smooth` + nogil patch    | 1.57 |  5.38 | 10.55 |
+| `SpectralCube.spectral_smooth(vectorize=True)`      | 1.88 |  1.72 |  2.09 |
+| `SpectralCube.spectral_smooth` (current default)    | ~6.7 | ~13.6 | ~35.6 |
+
+Both the in-package and upstream fixes are independently worth shipping:
+
+- The in-package `DaskSpectralCube.spectral_smooth(vectorize=True)` is
+  the fastest option in absolute terms and lands in spectral-cube
+  today with no upstream dependency. Nearly flat in kernel size.
+- The astropy `nogil` patch helps *every* threaded user of
+  `astropy.convolve`, not just spectral-cube, and brings the default
+  dask path within 2× of the in-package fast path.
 
 ## What's implemented in `SpectralCube.spectral_smooth(..., vectorize=True)`
 

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -274,6 +274,152 @@ def is_huge(cube):
         return True
 
 
+def spectral_convolve_vectorized(data, kernel_array, chunk_size=None):
+    """
+    Convolve ``data`` along axis 0 with a 1D normalized ``kernel_array``,
+    producing output bit-for-bit equivalent (within machine precision) to
+
+        astropy.convolution.convolve(
+            data, kernel, normalize_kernel=True,
+            boundary='fill', fill_value=0.0, nan_treatment='interpolate'
+        )
+
+    applied to each 1D ray along axis 0, but vectorized over all spatial
+    pixels via ``scipy.ndimage.convolve1d``. NaNs are interpolated over by
+    renormalising the kernel using only the valid samples (matching astropy's
+    ``nan_treatment='interpolate'``). Off-edge samples are treated as valid
+    zeros (matching astropy's ``boundary='fill'`` with default ``fill_value``).
+
+    Parameters
+    ----------
+    data : ndarray
+        N-dimensional array; convolution runs along axis 0.
+    kernel_array : 1D ndarray
+        Kernel values. Will be normalised to sum to 1 internally.
+    chunk_size : int, optional
+        If given, process ``chunk_size`` spatial pixels at a time (using a
+        flattened view of the trailing axes) to bound peak memory. The default
+        processes the whole array at once.
+
+    Returns
+    -------
+    out : ndarray
+        Smoothed array, same shape and dtype as ``data``.
+    """
+    # Local import: scipy is already a hard dep, but keep it lazy for parity
+    # with the rest of cube_utils
+    from scipy.ndimage import convolve1d
+
+    karr = np.asarray(kernel_array, dtype=np.float64)
+    ksum = karr.sum()
+    if ksum == 0:
+        raise ValueError("kernel must have non-zero sum for normalisation")
+    karr = karr / ksum
+
+    if chunk_size is None:
+        return _spectral_convolve_chunk(data, karr, convolve1d)
+
+    nspec = data.shape[0]
+    spatial_shape = data.shape[1:]
+    flat = data.reshape(nspec, -1)
+    out_flat = np.empty_like(flat)
+    npix = flat.shape[1]
+    for start in range(0, npix, chunk_size):
+        stop = min(start + chunk_size, npix)
+        out_flat[:, start:stop] = _spectral_convolve_chunk(
+            flat[:, start:stop], karr, convolve1d
+        )
+    return out_flat.reshape((nspec,) + spatial_shape)
+
+
+def _spectral_convolve_chunk(data, karr, convolve1d):
+    nanmask = np.isnan(data)
+    if nanmask.any():
+        filled = np.where(nanmask, 0.0, data)
+        weight = (~nanmask).astype(data.dtype, copy=False)
+        num = convolve1d(filled, karr, axis=0, mode='constant', cval=0.0)
+        # cval=1.0 here is what makes the math match astropy: off-edge samples
+        # are 'valid' (they're the fill value, treated as real data) so they
+        # contribute weight 1, not 0. Edges therefore see NO renormalisation,
+        # only NaN positions do.
+        den = convolve1d(weight, karr, axis=0, mode='constant', cval=1.0)
+        with np.errstate(invalid='ignore', divide='ignore'):
+            out = num / den
+        # No valid neighbours within kernel reach -> astropy returns 0 there
+        # (rather than NaN) when nan_treatment='interpolate' and the kernel
+        # is fully blocked.
+        zero_den = den == 0
+        if zero_den.any():
+            out[zero_den] = 0.0
+        return out
+    return convolve1d(data, karr, axis=0, mode='constant', cval=0.0)
+
+
+# Threshold (spectral-kernel size in samples) above which the FFT-based
+# spectral convolution (scipy.signal.oaconvolve along axis 0) outperforms
+# the direct scipy.ndimage.convolve1d path. Crossover measured on an
+# Apple M-series cube of shape (995, 221, 481): ndimage wins at k=41,
+# oaconvolve wins decisively from k>~100 onward (see
+# ``benchmarks/spectral_smooth_results.md``). 64 is a conservative
+# default; the constant factor depends on cube shape, so this is a
+# heuristic, not a sharp cutover.
+_OACONVOLVE_KERNEL_THRESHOLD = 64
+
+
+def spectral_convolve_oaconvolve(data, kernel_array):
+    """
+    Convolve ``data`` along axis 0 with a 1D ``kernel_array`` using
+    ``scipy.signal.oaconvolve`` (overlap-add FFT, ~constant runtime in
+    kernel size for long signals). Bit-equivalent to
+
+        astropy.convolution.convolve(
+            data, kernel, normalize_kernel=True,
+            boundary='fill', fill_value=0.0,
+            nan_treatment='interpolate'
+        )
+
+    applied per ray, including NaN renormalisation.
+
+    Use this in preference to :func:`spectral_convolve_vectorized` when the
+    kernel is wider than a few tens of channels; see
+    ``benchmarks/spectral_smooth_results.md`` for the crossover.
+    """
+    from scipy.signal import oaconvolve
+
+    karr = np.asarray(kernel_array, dtype=np.float64)
+    ksum = karr.sum()
+    if ksum == 0:
+        raise ValueError("kernel must have non-zero sum for normalisation")
+    karr = karr / ksum
+    k3 = karr.reshape(-1, 1, 1)
+
+    nanmask = np.isnan(data)
+    if not nanmask.any():
+        # No NaNs: a single oaconvolve along axis 0 reproduces astropy's
+        # default boundary='fill', fill_value=0 (no edge renorm needed).
+        return oaconvolve(data, k3, mode='same', axes=0)
+
+    filled = np.where(nanmask, 0.0, data)
+    weight = (~nanmask).astype(data.dtype, copy=False)
+    num = oaconvolve(filled, k3, mode='same', axes=0)
+    # oaconvolve only supports zero-padded boundaries, so we can't pass
+    # cval=1.0 to the weight convolution the way we do with
+    # scipy.ndimage.convolve1d. Synthesise it: the would-be-cval-1.0
+    # convolution of the weight equals the zero-padded convolution plus
+    # the kernel coverage that lies outside [0, N). The latter is
+    # ``1 - convolve(ones, k)`` along axis 0, broadcast across (y, x).
+    ones = np.ones(data.shape[0], dtype=np.float64)
+    edge = oaconvolve(ones, karr, mode='same')
+    shortfall = (1.0 - edge).reshape(-1, 1, 1)
+    den = oaconvolve(weight, k3, mode='same', axes=0) + shortfall
+    with np.errstate(invalid='ignore', divide='ignore'):
+        out = num / den
+    zero_den = den == 0
+    if zero_den.any():
+        out[zero_den] = 0.0
+    return out
+
+
 def iterator_strategy(cube, axis=None):
     """
     Guess the most efficient iteration strategy

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -25,6 +25,7 @@ from astropy import convolution
 from astropy import wcs
 
 from . import wcs_utils
+from . import cube_utils
 from .spectral_cube import SpectralCube, VaryingResolutionSpectralCube, SIGMA2FWHM, np2wcs
 from .utils import cached, VarianceWarning, SliceWarning, BeamWarning, SmoothingWarning, BeamUnitsError, PossiblySlowWarning, ArrayWrapper
 from .lower_dimensional_structures import Projection
@@ -865,6 +866,7 @@ class DaskSpectralCubeMixin:
     def spectral_smooth(self,
                         kernel,
                         convolve=convolution.convolve,
+                        vectorize=False,
                         **kwargs):
         """
         Smooth the cube along the spectral dimension
@@ -879,6 +881,17 @@ class DaskSpectralCubeMixin:
             The astropy convolution function to use, either
             `astropy.convolution.convolve` or
             `astropy.convolution.convolve_fft`
+        vectorize : bool
+            If True and ``convolve`` is the default
+            ``astropy.convolution.convolve`` with no extra kwargs, drop to
+            a scipy-backed per-chunk convolution (``scipy.ndimage`` or
+            ``scipy.signal.oaconvolve``, auto-routed by kernel size). The
+            scipy backends release the GIL, so dask's threaded scheduler
+            actually parallelises across chunks; the default
+            ``astropy.convolve`` path holds the GIL for the whole call
+            and serialises despite the threads. Bit-equivalent to the
+            per-spectrum ``astropy.convolve`` reference. See
+            ``benchmarks/spectral_smooth_results.md`` for numbers.
         save_to_tmp_dir : bool
             If `True`, the computation will be carried out straight away and
             saved to a temporary directory. This can improve performance,
@@ -892,6 +905,27 @@ class DaskSpectralCubeMixin:
         if isinstance(kernel.array, u.Quantity):
             raise u.UnitsError("The convolution kernel should be defined "
                                "without a unit.")
+
+        if (vectorize
+                and convolve is convolution.convolve
+                and not kwargs):
+            kernel_array = kernel.array
+            use_oa = (kernel_array.size
+                      > cube_utils._OACONVOLVE_KERNEL_THRESHOLD)
+
+            if use_oa:
+                def _per_chunk(array):
+                    return cube_utils.spectral_convolve_oaconvolve(
+                        array.astype(np.float64, copy=False),
+                        kernel_array)
+            else:
+                def _per_chunk(array):
+                    return cube_utils.spectral_convolve_vectorized(
+                        array.astype(np.float64, copy=False),
+                        kernel_array)
+
+            return self.apply_function_parallel_spectral(
+                _per_chunk, accepts_chunks=True)
 
         def spectral_smooth(array):
             kernel_3d = kernel.array.reshape((len(kernel.array), 1, 1))

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -3186,6 +3186,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
                         verbose=0,
                         use_memmap=True,
                         num_cores=None,
+                        vectorize=False,
                         **kwargs):
         """
         Smooth the cube along the spectral dimension
@@ -3202,6 +3203,21 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             `astropy.convolution.convolve_fft`
         verbose : int
             Verbosity level to pass to joblib
+        vectorize : bool
+            If True, skip the per-spectrum Python loop and call ``convolve``
+            once on the whole cube with a 1D-reshaped-to-3D kernel. This is
+            the same approach :class:`DaskSpectralCube` already uses and
+            gives the largest speedup for cubes that fit in memory: the
+            per-pixel Python overhead in
+            ``apply_function_parallel_spectral`` typically dominates the
+            actual convolution by 100x or more.
+            When ``convolve`` is the default ``astropy.convolution.convolve``
+            and no extra kwargs are passed, an additional bit-equivalent
+            scipy fast path is selected automatically:
+            ``scipy.ndimage.convolve1d`` for small kernels and
+            ``scipy.signal.oaconvolve`` (overlap-add FFT) for wider ones,
+            giving another ~3-10x on top. See
+            ``benchmarks/spectral_smooth_results.md`` for the crossover.
         kwargs : dict
             Passed to the convolve function
         """
@@ -3209,6 +3225,35 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         if isinstance(kernel.array, u.Quantity):
             raise u.UnitsError("The convolution kernel should be defined "
                                "without a unit.")
+
+        if vectorize:
+            if convolve is convolution.convolve and not kwargs:
+                # Fast path: scipy backends reproduce astropy's defaults
+                # (boundary='fill', fill_value=0, nan_treatment='interpolate')
+                # bit-for-bit. Pick the better one based on kernel size:
+                # direct convolution (ndimage) wins on small kernels;
+                # overlap-add FFT (oaconvolve) is near-constant time and
+                # wins decisively once the kernel is wider than a few
+                # tens of samples.
+                data = self.filled_data[:].astype(np.float64, copy=False)
+                if (kernel.array.size
+                        > cube_utils._OACONVOLVE_KERNEL_THRESHOLD):
+                    outdata = cube_utils.spectral_convolve_oaconvolve(
+                        data, kernel.array)
+                else:
+                    outdata = cube_utils.spectral_convolve_vectorized(
+                        data, kernel.array)
+            else:
+                # General vectorized path: single whole-cube call so
+                # ``convolve`` can be any astropy convolver
+                # (``convolve``/``convolve_fft``) with any kwargs.
+                data = self.filled_data[:]
+                kernel_3d = kernel.array.reshape((-1, 1, 1))
+                outdata = convolve(data, kernel_3d,
+                                   normalize_kernel=True, **kwargs)
+            return self._new_cube_with(data=outdata, wcs=self.wcs,
+                                       mask=self.mask, meta=self.meta,
+                                       fill_value=self.fill_value)
 
         return self.apply_function_parallel_spectral(convolve,
                                                      kernel=kernel,

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -171,6 +171,103 @@ def test_spectral_smooth(data_522_delta, use_dask):
                                    kernel.array[2:-2],
                                    4)
 
+
+def test_spectral_smooth_vectorize_matches_default(data_522_delta, use_dask):
+    """The vectorized fast path must match the per-spectrum astropy path
+    bit-for-bit (within machine precision) on representative inputs."""
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
+
+    for sigma in (0.7, 1.0, 2.3):
+        kernel = convolution.Gaussian1DKernel(sigma)
+        slow = cube.spectral_smooth(kernel=kernel, use_memmap=False)
+        fast = cube.spectral_smooth(kernel=kernel, vectorize=True)
+        np.testing.assert_allclose(fast.unitless_filled_data[:],
+                                   slow.unitless_filled_data[:],
+                                   rtol=0, atol=1e-12)
+
+
+def test_spectral_smooth_vectorize_handles_nans(data_522_delta, use_dask):
+    """With NaN-containing data the vectorized path should still match
+    astropy's nan_treatment='interpolate' renormalization."""
+    pytest.importorskip('scipy.ndimage')
+
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
+
+    # Inject NaNs via masking — filled_data turns these into NaN
+    mask_arr = np.ones(cube.shape, dtype=bool)
+    mask_arr[1, 0, 0] = False
+    masked_cube = cube.with_mask(BooleanArrayMask(mask_arr, wcs=cube.wcs))
+
+    kernel = convolution.Gaussian1DKernel(1.0)
+    slow = masked_cube.spectral_smooth(kernel=kernel, use_memmap=False)
+    fast = masked_cube.spectral_smooth(kernel=kernel, vectorize=True)
+    np.testing.assert_allclose(fast.unitless_filled_data[:],
+                               slow.unitless_filled_data[:],
+                               rtol=0, atol=1e-12)
+
+
+def test_spectral_smooth_vectorize_routes_to_oaconvolve(data_522_delta,
+                                                        use_dask):
+    """When the kernel is wider than the auto-routing threshold, the
+    vectorized path should switch to the FFT-based oaconvolve backend
+    while still matching the per-spectrum reference."""
+    pytest.importorskip('scipy.signal')
+
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
+
+    # Cube along the spectral axis has only 5 channels in this fixture,
+    # so we can't use a giant sigma. Force the oaconvolve branch by
+    # temporarily lowering the threshold instead.
+    from .. import cube_utils
+    saved = cube_utils._OACONVOLVE_KERNEL_THRESHOLD
+    try:
+        cube_utils._OACONVOLVE_KERNEL_THRESHOLD = 0  # always pick oaconvolve
+        kernel = convolution.Gaussian1DKernel(1.0)
+        slow = cube.spectral_smooth(kernel=kernel, use_memmap=False)
+        fast = cube.spectral_smooth(kernel=kernel, vectorize=True)
+    finally:
+        cube_utils._OACONVOLVE_KERNEL_THRESHOLD = saved
+
+    np.testing.assert_allclose(fast.unitless_filled_data[:],
+                               slow.unitless_filled_data[:],
+                               rtol=0, atol=1e-12)
+
+
+def test_spectral_smooth_vectorize_general_path(data_522_delta, use_dask):
+    """The general vectorize path (when extra kwargs are passed) routes
+    through astropy.convolution.convolve on the whole cube. It should
+    still match the per-spectrum call with the same kwargs."""
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
+
+    kernel = convolution.Gaussian1DKernel(1.0)
+    # Pass a non-default boundary so we exit the scipy fast path and hit
+    # the general astropy whole-cube branch.
+    slow = cube.spectral_smooth(kernel=kernel, use_memmap=False,
+                                boundary='extend')
+    fast = cube.spectral_smooth(kernel=kernel, vectorize=True,
+                                boundary='extend')
+    np.testing.assert_allclose(fast.unitless_filled_data[:],
+                               slow.unitless_filled_data[:],
+                               rtol=0, atol=1e-12)
+
+
+def test_spectral_smooth_vectorize_convolve_fft(data_522_delta, use_dask):
+    """vectorize=True must work with convolve=convolve_fft (the second
+    documented option)."""
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
+
+    kernel = convolution.Gaussian1DKernel(1.0)
+    slow = cube.spectral_smooth(kernel=kernel,
+                                convolve=convolution.convolve_fft,
+                                use_memmap=False)
+    fast = cube.spectral_smooth(kernel=kernel,
+                                convolve=convolution.convolve_fft,
+                                vectorize=True)
+    np.testing.assert_allclose(fast.unitless_filled_data[:],
+                               slow.unitless_filled_data[:],
+                               rtol=0, atol=1e-10)
+
+
 def test_catch_kernel_with_units(data_522_delta, use_dask):
     # Passing a kernel with a unit should raise a u.UnitsError
 


### PR DESCRIPTION
Fix for #1003: the default path for spectral smoothing is extremely slow compared to in-memory smoothing.  That's kind of the point, we make not-in-memory smoothing possible, but we _also_ make it trivial to cut out small cubes, and we want those to smooth quickly.