### PR TITLE
Raise test_lazy_data_loading threshold to 1s to fix Windows CI flake

### DIFF
--- a/spectral_cube/tests/test_dask.py
+++ b/spectral_cube/tests/test_dask.py
@@ -357,18 +357,23 @@ def test_lazy_data_loading(tmp_path):
 
     try:
 
-        # A slow CI filesystem can push a single read over the threshold, so
-        # take the fastest of three attempts before declaring failure.
+        # Eagerly loading the 8 GiB cube would take many seconds, so 1s
+        # cleanly separates lazy from eager. Windows CI runners have a
+        # systematic ~0.3s floor just to open the file, so the threshold
+        # cannot be much tighter. A slow CI filesystem can still push a
+        # single read over the threshold, so take the fastest of three
+        # attempts before declaring failure.
+        threshold = 1.0
         times = []
         for _ in range(3):
             time1 = time.time()
             c = SpectralCube.read(tmp_path / 'cube.fits', use_dask=True)
             time2 = time.time()
             times.append(time2 - time1)
-            if times[-1] <= 0.3:
+            if times[-1] <= threshold:
                 break
 
-        if min(times) > 0.3:
+        if min(times) > threshold:
             raise Exception(f"Reading large spectral cube took too long ({min(times):.3f}s)")
 
         assert str(c).splitlines()[0] == "DaskSpectralCube with shape=(1024, 1024, 1024) and chunk size (255, 255, 255):"


### PR DESCRIPTION
## Description

`test_dask.py::test_lazy_data_loading` asserts that lazily reading an 8 GiB cube completes within 0.3s. Windows CI runners have a systematic ~0.31s floor just to open the file — two independent runs both clocked **exactly 0.309s** as their fastest of three attempts ([example](https://github.com/radio-astro-tools/spectral-cube/actions/runs/28734449568/job/85206055685)) — so the test fails there regardless of retries.

This raises the threshold to 1s, which still cleanly separates lazy reads (<0.35s even on the slowest runners) from an eager load of 8 GiB (many seconds), and keeps the best-of-three retry from #1006 for filesystem hiccups.

Follow-up to #1006; unblocks Windows CI on all currently-open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)