### PR TITLE
mosaic_cubes: slice weight cubes by their own channels (fix NaN stripes)

### DIFF
--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -1050,7 +1050,10 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                           for (ch1, ch2), slices, cube in std_tqdm(zip(chans, mincube_slices, cubes),
                                                                    delay=5, desc='Subcubes')]
                 # only keep cubes that are in range; the rest get excluded
-                keep = [cube.shape[0] > 1 for cube in scubes]
+                keep = [(cube.shape[0] > 1) and
+                        (cube.spectral_axis.min() < channel) and
+                        (cube.spectral_axis.max() > channel)
+                        for cube in scubes]
                 if sum(keep) < len(keep):
                     log.warn(f"Dropping {len(keep)-sum(keep)} cubes out of {len(keep)} because they're out of range")
                     scubes = [cube for cube, kp in zip(scubes, keep) if kp]
@@ -1058,7 +1061,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                 if weightcubes is not None:
                     sweightcubes = [cube[ch1:ch2, slices[1], slices[2]]
                                     for (ch1, ch2), slices, cube, kp
-                                    in std_tqdm(zip(chans, mincube_slices, weightcubes, kp),
+                                    in std_tqdm(zip(chans, mincube_slices, weightcubes, keep),
                                                 delay=5, desc='Subweight')
                                     if kp
                                     ]

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -862,7 +862,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
 
     # Prepare an array and mask for the final cube
     shape_opt = (target_header['NAXIS3'], target_header['NAXIS2'], target_header['NAXIS1'])
-    dtype = f"float{target_header['BITPIX']}"
+    dtype = f"float{int(abs(target_header['BITPIX']))}"
 
     if output_file is not None:
         if not output_file.endswith('.fits'):

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -879,7 +879,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                       (np.prod(shape_opt) * np.abs(target_header['BITPIX']//8)) - 1)
             fobj.write(b'\0')
 
-        hdu = fits.open(output_file, mode='rb+', overwrite=True)
+        hdu = fits.open(output_file, mode='update', overwrite=True)
         final_array = hdu.data
 
         # use memmap - not a FITS file - for the footprint

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -865,7 +865,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
     mask_opt = np.zeros(shape_opt[1:])
 
     # check that the beams are deconvolvable
-    if commonbeam:
+    if commonbeam is not None:
         for cube in cubes:
             try:
                 commonbeam.deconvolve(cube.beam)
@@ -875,7 +875,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                                            f"{ex}")
 
     for cube in cubes:
-        if commonbeam:
+        if commonbeam is not None:
             cube = cube.convolve_to(commonbeam, save_to_tmp_dir=save_to_tmp_dir)
         # Reproject cubes to the target_header
         try:

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -879,7 +879,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                       (np.prod(shape_opt) * np.abs(target_header['BITPIX']//8)) - 1)
             fobj.write(b'\0')
 
-        hdu = fits.open(output_file, mode='rb+')
+        hdu = fits.open(output_file, mode='rb+', overwrite=True)
         final_array = hdu.data
 
         # use memmap - not a FITS file - for the footprint

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -881,6 +881,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
 
         hdu = fits.open(output_file, mode='update', overwrite=True)
         output_array = hdu[0].data
+        hdu.flush() # make sure the header gets written right
 
         # use memmap - not a FITS file - for the footprint
         ntf2 = tempfile.NamedTemporaryFile()

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -19,7 +19,7 @@ from astropy.io.fits import BinTableHDU, Column
 from astropy import units as u
 import itertools
 import re
-from radio_beam import Beam
+from radio_beam import Beam, BeamError
 
 
 def _fix_spectral(wcs):
@@ -869,10 +869,10 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
         for cube in cubes:
             try:
                 commonbeam.deconvolve(cube.beam)
-            except radio_beam.BeamError as ex:
-                raise radio_beam.BeamError("One or more beams could not be "
-                                           "deconvolved from the common beam: "
-                                           f"{ex}")
+            except BeamError as ex:
+                raise BeamError("One or more beams could not be "
+                                "deconvolved from the common beam: "
+                                f"{ex}")
 
     for cube in cubes:
         if commonbeam is not None:

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -826,6 +826,7 @@ def _getdata(cube):
 def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                  target_header=None,
                  commonbeam=None,
+                 weightcubes=None,
                  save_to_tmp_dir=True,
                  use_memmap=True,
                  output_file=None,
@@ -847,6 +848,8 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
     commonbeam : Beam
         If specified, will smooth the data to this common beam before
         reprojecting.
+    weightcubes : None
+        Cubes with same shape as input cubes containing the weights
     save_to_tmp_dir : bool
         Default is to set `save_to_tmp_dir=True` because we expect cubes to be
         big.
@@ -975,6 +978,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
             output_array, output_footprint = reproject_and_coadd(
                 [cube.hdu for cube in cubes],
                 target_header,
+                weights_in=[cube.hdu for cube in weightcubes] if weightcubes is None else None,
                 output_array=output_array,
                 output_footprint=output_footprint,
                 reproject_function=reproject_interp,
@@ -990,6 +994,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
             output_array, output_footprint = reproject_and_coadd(
                 [cube.hdu for cube in cubes],
                 target_header,
+                weights_in=[cube.hdu for cube in weightcubes] if weightcubes is None else None,
                 output_array=output_array,
                 output_footprint=output_footprint,
                 reproject_function=reproject_interp,
@@ -1049,6 +1054,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                     output_array=output_array[ii:ii+1,:,:],
                     output_footprint=output_footprint[ii:ii+1,:,:],
                     reproject_function=reproject_interp,
+                    weights_in=weightcubes[ii:ii+1].hdu if weightcubes is not None else None,
                     progressbar=partial(tqdm, desc='coadd') if verbose else False,
                 )
 

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -929,4 +929,9 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
 
     # Create Cube
     cube = cube1.__class__(data=output_array * cube1.unit, wcs=WCS(target_header))
+
+    if output_file is not None:
+        hdu.flush()
+        hdu.close()
+
     return cube

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -880,19 +880,19 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
             fobj.write(b'\0')
 
         hdu = fits.open(output_file, mode='update', overwrite=True)
-        final_array = hdu[0].data
+        output_array = hdu[0].data
 
         # use memmap - not a FITS file - for the footprint
         ntf2 = tempfile.NamedTemporaryFile()
-        final_footprint = np.memmap(ntf2, mode='w+', shape=shape_opt, dtype=dtype)
+        output_footprint = np.memmap(ntf2, mode='w+', shape=shape_opt, dtype=dtype)
     elif use_memmap:
         ntf = tempfile.NamedTemporaryFile()
-        final_array = np.memmap(ntf, mode='w+', shape=shape_opt, dtype=dtype)
+        output_array = np.memmap(ntf, mode='w+', shape=shape_opt, dtype=dtype)
         ntf2 = tempfile.NamedTemporaryFile()
-        final_footprint = np.memmap(ntf2, mode='w+', shape=shape_opt, dtype=dtype)
+        output_footprint = np.memmap(ntf2, mode='w+', shape=shape_opt, dtype=dtype)
     else:
-        final_array = np.zeros(shape_opt)
-        final_footprint = np.zeros(shape_opt)
+        output_array = np.zeros(shape_opt)
+        output_footprint = np.zeros(shape_opt)
     mask_opt = np.zeros(shape_opt[1:])
 
     # check that the beams are deconvolvable
@@ -905,11 +905,11 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                  for cube in cubes]
 
     try:
-        final_array, final_footprint = reproject_and_coadd(
+        output_array, output_footprint = reproject_and_coadd(
             [cube.hdu for cube in cubes],
             target_header,
-            final_array=final_array,
-            final_footprint=final_footprint,
+            output_array=output_array,
+            output_footprint=output_footprint,
             reproject_function=reproject_interp,
             block_size=[(spectral_block_size, cube.shape[1], cube.shape[2])
                         for cube in cubes],
@@ -918,14 +918,14 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
         # print the exception in case we caught a different TypeError than expected
         warnings.warn("The block_size argument is not accepted by `reproject`.  "
                       f"A more recent version may be needed.  Exception was: {ex}")
-        final_array, final_footprint = reproject_and_coadd(
+        output_array, output_footprint = reproject_and_coadd(
             [cube.hdu for cube in cubes],
             target_header,
-            final_array=final_array,
-            final_footprint=final_footprint,
+            output_array=output_array,
+            output_footprint=output_footprint,
             reproject_function=reproject_interp,
         )
 
     # Create Cube
-    cube = cube1.__class__(data=final_array * cube1.unit, wcs=WCS(target_header))
+    cube = cube1.__class__(data=output_array * cube1.unit, wcs=WCS(target_header))
     return cube

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -1,5 +1,6 @@
 import contextlib
 import warnings
+import tempfile
 from copy import deepcopy
 
 import builtins

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -880,7 +880,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
             fobj.write(b'\0')
 
         hdu = fits.open(output_file, mode='update', overwrite=True)
-        final_array = hdu.data
+        final_array = hdu[0].data
 
         # use memmap - not a FITS file - for the footprint
         ntf2 = tempfile.NamedTemporaryFile()

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -1055,6 +1055,8 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                                     for (ch1, ch2), slices, cube
                                     in std_tqdm(zip(chans, mincube_slices, weightcubes),
                                                 delay=5, desc='Subweight')]
+                    wthdus = [(cube._get_filled_data(), cube.wcs)
+                              for cube in std_tqdm(sweightcubes, delay=5, desc='WeightData')]
 
 
                 # reproject_and_coadd requires the actual arrays, so this is the convolution step
@@ -1082,7 +1084,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                     output_array=output_array[ii:ii+1,:,:],
                     output_footprint=output_footprint[ii:ii+1,:,:],
                     reproject_function=reproject_interp,
-                    input_weights=sweightcubes[ii:ii+1].hdu if weightcubes is not None else None,
+                    input_weights=wthdus,
                     progressbar=partial(tqdm, desc='coadd') if verbose else False,
                 )
 

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -19,7 +19,8 @@ from astropy.io.fits import BinTableHDU, Column
 from astropy import units as u
 import itertools
 import re
-from radio_beam import Beam, BeamError
+from radio_beam import Beam
+from radio_beam.utils import BeamError
 
 
 def _fix_spectral(wcs):

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -911,8 +911,9 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
             output_array=output_array,
             output_footprint=output_footprint,
             reproject_function=reproject_interp,
-            block_size=[(spectral_block_size, cube.shape[1], cube.shape[2])
-                        for cube in cubes],
+            block_size=(None if spectral_block_size is None else
+                        [(spectral_block_size, cube.shape[1], cube.shape[2])
+                         for cube in cubes]),
         )
     except TypeError as ex:
         # print the exception in case we caught a different TypeError than expected

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -868,12 +868,8 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
     # check that the beams are deconvolvable
     if commonbeam is not None:
         for cube in cubes:
-            try:
-                commonbeam.deconvolve(cube.beam)
-            except BeamError as ex:
-                raise BeamError("One or more beams could not be "
-                                "deconvolved from the common beam: "
-                                f"{ex}")
+            # this will raise an exception if any of the cubes have bad beams
+            commonbeam.deconvolve(cube.beam)
 
     for cube in cubes:
         if commonbeam is not None:

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -873,7 +873,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                              )
         for kwd in ('NAXIS1', 'NAXIS2', 'NAXIS3'):
             hdu.header[kwd] = target_header[kwd]
-        target_header.tofile(output_file)
+        target_header.tofile(output_file, overwrite=True)
         with open(output_file, 'rb+') as fobj:
             fobj.seek(len(target_header.tostring()) +
                       (np.prod(shape_opt) * np.abs(target_header['BITPIX']//8)) - 1)

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -1049,12 +1049,19 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                            .rechunk())
                           for (ch1, ch2), slices, cube in std_tqdm(zip(chans, mincube_slices, cubes),
                                                                    delay=5, desc='Subcubes')]
+                # only keep cubes that are in range; the rest get excluded
+                keep = [cube.shape[0] > 1 for cube in scubes]
+                if sum(keep) < len(keep):
+                    log.warn(f"Dropping {len(keep)-sum(keep)} cubes out of {len(keep)} because they're out of range")
+                    scubes = [cube for cube, kp in zip(scubes, keep) if kp]
 
                 if weightcubes is not None:
                     sweightcubes = [cube[ch1:ch2, slices[1], slices[2]]
-                                    for (ch1, ch2), slices, cube
-                                    in std_tqdm(zip(chans, mincube_slices, weightcubes),
-                                                delay=5, desc='Subweight')]
+                                    for (ch1, ch2), slices, cube, kp
+                                    in std_tqdm(zip(chans, mincube_slices, weightcubes, kp),
+                                                delay=5, desc='Subweight')
+                                    if kp
+                                    ]
                     wthdus = [cube.hdu
                               for cube in std_tqdm(sweightcubes, delay=5, desc='WeightData')]
 

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -881,7 +881,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
         class tqdm:
             def __init__(self, x):
                 return x
-            def __call__(self, x)
+            def __call__(self, x):
                 return x
             def set_description(self, **kwargs):
                 pass

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -1055,7 +1055,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                                     for (ch1, ch2), slices, cube
                                     in std_tqdm(zip(chans, mincube_slices, weightcubes),
                                                 delay=5, desc='Subweight')]
-                    wthdus = [(cube._get_filled_data(), cube.wcs)
+                    wthdus = [cube.hdu
                               for cube in std_tqdm(sweightcubes, delay=5, desc='WeightData')]
 
 

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -879,7 +879,8 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                       (np.prod(shape_opt) * np.abs(target_header['BITPIX']//8)) - 1)
             fobj.write(b'\0')
 
-        final_array = fits.getdata(output_file, mode='rb+')
+        hdu = fits.open(output_file, mode='rb+')
+        final_array = hdu.data
 
         # use memmap - not a FITS file - for the footprint
         ntf2 = tempfile.NamedTemporaryFile()

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -991,9 +991,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                 input_weights=[cube.hdu for cube in weightcubes] if weightcubes is None else None,
                 output_array=output_array,
                 output_footprint=output_footprint,
-                reproject_function=reproject_interp,
-                progressbar=tqdm if verbose else False,
-                block_size=(None if spectral_block_size is None else
+                reproject_function=reproject_interp,                block_size=(None if spectral_block_size is None else
                             [(spectral_block_size, cube.shape[1], cube.shape[2])
                              for cube in cubes]),
             )
@@ -1007,9 +1005,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                 input_weights=[cube.hdu for cube in weightcubes] if weightcubes is None else None,
                 output_array=output_array,
                 output_footprint=output_footprint,
-                reproject_function=reproject_interp,
-                progressbar=tqdm if verbose else False,
-            )
+                reproject_function=reproject_interp,            )
     elif method == 'channel':
         log_("Using Channel method")
         # Channel method: manually downselect to go channel-by-channel in the
@@ -1119,9 +1115,7 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                     output_array=output_array[ii:ii+1,:,:],
                     output_footprint=output_footprint[ii:ii+1,:,:],
                     reproject_function=reproject_interp,
-                    input_weights=wthdus,
-                    progressbar=partial(tqdm, desc='coadd') if verbose else False,
-                )
+                    input_weights=wthdus,                )
 
             pbar.set_description(f"Channel {ii}={channel} done")
 

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -1080,12 +1080,22 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={},
                     scubes = [cube for cube, kp in zip(scubes, keep) if kp]
 
                 if weightcubes is not None:
-                    sweightcubes = [cube[ch1:ch2, slices[1], slices[2]]
-                                    for (ch1, ch2), slices, cube, kp
-                                    in std_tqdm(zip(chans, mincube_slices, weightcubes, keep),
-                                                delay=5, desc='Subweight')
-                                    if kp
-                                    ]
+                    # Slice each weight cube by ITS OWN two closest channels to
+                    # the target velocity, not the data cube's channel indices.
+                    # A weight cube can be on a different spectral (and spatial)
+                    # grid than its data cube (e.g. a different nchan / reference);
+                    # reusing the data cube's indices then yields a weight slab
+                    # that does not bracket the target velocity, so reprojecting
+                    # the weight HDU extrapolates to 0 and the pixel is dropped
+                    # (footprint 0), producing spurious NaN stripes that beat with
+                    # the data-vs-weight grid offset.
+                    sweightcubes = []
+                    for wcube, kp in zip(weightcubes, keep):
+                        if not kp:
+                            continue
+                        wc1, wc2 = two_closest_channels(wcube, channel)
+                        wc1, wc2 = (wc1, wc2 + 1) if wc1 < wc2 else (wc2, wc1 + 1)
+                        sweightcubes.append(wcube[wc1:wc2])
                     wthdus = [cube.hdu
                               for cube in std_tqdm(sweightcubes, delay=5, desc='WeightData')]
 

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -1447,6 +1447,93 @@ class DaskSpectralCube(DaskSpectralCubeMixin, SpectralCube):
                                                     accepts_chunks=True,
                                                     **kwargs).with_beam(beam, raise_error_jybm=False)
 
+    def reproject(self, header, order='bilinear', use_memmap=False,
+                  filled=True, **kwargs):
+        """
+        Spatially reproject the cube into a new header.  Fills the data with
+        the cube's ``fill_value`` to replace bad values before reprojection.
+
+        If you want to reproject a cube both spatially and spectrally, you need
+        to use `spectral_interpolate` as well.
+
+        Parameters
+        ----------
+        header : `astropy.io.fits.Header`
+            A header specifying a cube in valid WCS
+        order : int or str, optional
+            The order of the interpolation (if ``mode`` is set to
+            ``'interpolation'``). This can be either one of the following
+            strings:
+
+                * 'nearest-neighbor'
+                * 'bilinear'
+                * 'biquadratic'
+                * 'bicubic'
+
+            or an integer. A value of ``0`` indicates nearest neighbor
+            interpolation.
+        use_memmap : bool
+            If specified, a memory mapped temporary file on disk will be
+            written to rather than storing the intermediate spectra in memory.
+        filled : bool
+            Fill the masked values with the cube's fill value before
+            reprojection?  Note that setting ``filled=False`` will use the raw
+            data array, which can be a workaround that prevents loading large
+            data into memory.
+        kwargs : dict
+            Passed to `reproject.reproject_interp`.
+        """
+
+        try:
+            from reproject.version import version
+        except ImportError:
+            raise ImportError("Requires the reproject package to be"
+                              " installed.")
+
+        reproj_kwargs = kwargs
+        # Need version > 0.2 to work with cubes, >= 0.5 for memmap
+        from distutils.version import LooseVersion
+        if LooseVersion(version) < "0.5":
+            raise Warning("Requires version >=0.5 of reproject. The current "
+                          "version is: {}".format(version))
+        elif LooseVersion(version) >= "0.6":
+            pass # no additional kwargs, no warning either
+        else:
+            reproj_kwargs['independent_celestial_slices'] = True
+
+        from reproject import reproject_interp
+
+        # TODO: Find the minimal subcube that contains the header and only reproject that
+        # (see FITS_tools.regrid_cube for a guide on how to do this)
+
+        newwcs = wcs.WCS(header)
+        shape_out = tuple([header['NAXIS{0}'.format(i + 1)] for i in
+                           range(header['NAXIS'])][::-1])
+
+        def reproject_interp_wrapper(img_slice):
+            # What exactly is the wrapper getting here?
+            # I think it is given a _cube_ that is a cutout?
+            if filled:
+                data = img_slice.filled_data[:]
+            else:
+                data = img_slice._data
+            return reproject_interp((data, img_slice.header),
+                                    newwcs, shape_out=shape_out, **kwargs)
+
+        newcube, newcube_valid = self.apply_function_parallel_spatial(
+            reproject_interp_wrapper,
+            accepts_chunks=True,
+            order=order,
+            **reproj_kwargs)
+
+        return self._new_cube_with(data=newcube,
+                                   wcs=newwcs,
+                                   mask=BooleanArrayMask(newcube_valid.astype('bool'),
+                                                         newwcs),
+                                   meta=self.meta,
+                                  )
+
+
 
 class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolutionSpectralCube):
 
@@ -1632,90 +1719,3 @@ class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolution
                                               chunks=self._data.chunksize),
                                 wcs=self.wcs,
                                 shape=self.shape)
-
-    def reproject(self, header, order='bilinear', use_memmap=False,
-                  filled=True, **kwargs):
-        """
-        Spatially reproject the cube into a new header.  Fills the data with
-        the cube's ``fill_value`` to replace bad values before reprojection.
-
-        If you want to reproject a cube both spatially and spectrally, you need
-        to use `spectral_interpolate` as well.
-
-        Parameters
-        ----------
-        header : `astropy.io.fits.Header`
-            A header specifying a cube in valid WCS
-        order : int or str, optional
-            The order of the interpolation (if ``mode`` is set to
-            ``'interpolation'``). This can be either one of the following
-            strings:
-
-                * 'nearest-neighbor'
-                * 'bilinear'
-                * 'biquadratic'
-                * 'bicubic'
-
-            or an integer. A value of ``0`` indicates nearest neighbor
-            interpolation.
-        use_memmap : bool
-            If specified, a memory mapped temporary file on disk will be
-            written to rather than storing the intermediate spectra in memory.
-        filled : bool
-            Fill the masked values with the cube's fill value before
-            reprojection?  Note that setting ``filled=False`` will use the raw
-            data array, which can be a workaround that prevents loading large
-            data into memory.
-        kwargs : dict
-            Passed to `reproject.reproject_interp`.
-        """
-
-        try:
-            from reproject.version import version
-        except ImportError:
-            raise ImportError("Requires the reproject package to be"
-                              " installed.")
-
-        reproj_kwargs = kwargs
-        # Need version > 0.2 to work with cubes, >= 0.5 for memmap
-        from distutils.version import LooseVersion
-        if LooseVersion(version) < "0.5":
-            raise Warning("Requires version >=0.5 of reproject. The current "
-                          "version is: {}".format(version))
-        elif LooseVersion(version) >= "0.6":
-            pass # no additional kwargs, no warning either
-        else:
-            reproj_kwargs['independent_celestial_slices'] = True
-
-        from reproject import reproject_interp
-
-        # TODO: Find the minimal subcube that contains the header and only reproject that
-        # (see FITS_tools.regrid_cube for a guide on how to do this)
-
-        newwcs = wcs.WCS(header)
-        shape_out = tuple([header['NAXIS{0}'.format(i + 1)] for i in
-                           range(header['NAXIS'])][::-1])
-
-        def reproject_interp_wrapper(img_slice):
-            # What exactly is the wrapper getting here?
-            # I think it is given a _cube_ that is a cutout?
-            if filled:
-                data = img_slice.filled_data[:]
-            else:
-                data = img_slice._data
-            return reproject_interp((data, img_slice.header),
-                                    newwcs, shape_out=shape_out, **kwargs)
-
-        newcube, newcube_valid = self.apply_function_parallel_spatial(
-            reproject_interp_wrapper,
-            accepts_chunks=True,
-            order=order,
-            **reproj_kwargs)
-
-        return self._new_cube_with(data=newcube,
-                                   wcs=newwcs,
-                                   mask=BooleanArrayMask(newcube_valid.astype('bool'),
-                                                         newwcs),
-                                   meta=self.meta,
-                                  )
-

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -1642,11 +1642,6 @@ class DaskVaryingResolutionSpectralCube(DaskSpectralCubeMixin, VaryingResolution
         If you want to reproject a cube both spatially and spectrally, you need
         to use `spectral_interpolate` as well.
 
-        .. warning::
-            The current implementation of ``reproject`` requires that the whole
-            cube be loaded into memory.  Issue #506 notes that this is a
-            problem, and it is on our to-do list to fix.
-
         Parameters
         ----------
         header : `astropy.io.fits.Header`


### PR DESCRIPTION
`mosaic_cubes` (channel method) sliced the per-target-velocity **weight** slab using the **data** cube's `two_closest_channels` indices (and spatial `mincube_slices`), then passed it as an HDU to `reproject_and_coadd`. When a weight cube is on a different spectral grid than its data cube (different nchan / reference), those indices select a weight slab that does **not bracket** the target velocity, so reprojecting the weight HDU extrapolates to 0 -> the pixel has zero footprint and is dropped -> spurious NaN stripes that beat with the data-vs-weight grid offset.

Found in ALMA-ACES giant-cube mosaics: fields whose weight cube had a different nchan than their data cube (e.g. 3840 vs 3839) showed regular ~28-channel NaN blocks in single-coverage regions; flat/broadcast weights (same grid as data) were immune.

Fix: slice each weight cube by its **own** `two_closest_channels(wcube, channel)` so the weight slab always brackets the target velocity. Validated end-to-end on a real ACES cube (channel plane 38.66% -> 39.83% finite; dropped pixels recovered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)