### PR TITLE
Preserve singleton axes in arg world results

### DIFF
--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -550,7 +550,7 @@ def world_take_along_axis(cube, position_plane, axis):
 
     out = np.take_along_axis(world_coords[world_newaxis],
                              position_plane[plane_newaxis], axis=axis)
-    out = out.squeeze()
+    out = out.squeeze(axis=axis)
 
     return out
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -794,16 +794,18 @@ class TestNumpyMethods(BaseTest):
     @pytest.mark.parametrize('method', ('argmax_world', 'argmin_world'))
     def test_arg_world(self, method, data_adv, use_dask):
         c1, d1 = cube_and_raw(data_adv, use_dask=use_dask)
+        c1 = c1[:, :1, :]
 
         # Pixel operation is same name with "_world" removed.
         arg0_pixel = getattr(c1, method.split("_")[0])(axis=0)
 
         arg0_world = np.take_along_axis(c1.spectral_axis[:, np.newaxis, np.newaxis],
-                                        arg0_pixel[np.newaxis, :, :], axis=0).squeeze()
+                                        arg0_pixel[np.newaxis, :, :], axis=0).squeeze(axis=0)
 
         assert_allclose(getattr(c1, method)(axis=0), arg0_world)
 
         self.c = self.d = None
+
 
 class TestSlab(BaseTest):
 


### PR DESCRIPTION
## Summary

- preserve non-collapsed singleton dimensions in `world_take_along_axis`
- exercise the existing `argmax_world` and `argmin_world` oracle with a size-one cube dimension

## Root cause

`np.take_along_axis` leaves the collapsed axis with length one. Calling `out.squeeze()` removed that axis and every unrelated singleton axis, so `_argmaxmin_world` received a one-dimensional result but indexed it with a two-dimensional collapsed mask. Squeezing only the requested reduction axis keeps the result shape aligned with that mask.

## Validation

- regression test on the exact base: 4 expected failures covering NumPy/Dask and argmax/argmin
- focused regression test: 4 passed
- adjacent `arg_world` tests: 8 passed, 965 deselected
- full `spectral_cube` tests: 1,519 passed, 217 skipped, 17 xfailed
- narrow flake8 syntax/name checks and `git diff --check`
- Rafter local secrets check: no secrets detected

## AI disclosure

This fix was prepared with OpenAI Codex-assisted automation. I reviewed the issue, minimized the patch to the shared root cause and the existing test oracle, and reran the validation above before submission.

Fixes #982.
