### PR TITLE
Allow multiplicative operations between cubes with non-equivalent units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 
 - Avoid deprecation warning with astropy>=8 #991
 
+- Allow multiplicative operations (multiply, divide) between cubes with
+  non-equivalent units, e.g. a ``Jy/beam`` cube and a dimensionless
+  (unitless) cube.  Additive operations still require equivalent units. #1011
+
 0.6.5 (2023-12-05)
 ----------------------
 - Fixed issue with fix from #893 not getting included in the 0.6.4 tag

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -961,6 +961,15 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         Apply an operation between two cubes.  Inherits the metadata of the
         left cube.
 
+        Units do not need to be equivalent for this to succeed: additive
+        operations (add, subtract) still require equivalent units (e.g., you
+        cannot add a K cube to a Jy/beam cube), but multiplicative operations
+        (multiply, divide, power) are allowed between cubes with different,
+        non-equivalent units, since their units simply combine algebraically
+        (e.g., a Jy/beam cube multiplied by a dimensionless weight cube
+        yields a Jy/beam cube).  ``astropy.units`` enforces this distinction
+        for us via the ``test_result`` computation below.
+
         Parameters
         ----------
         function : function
@@ -973,32 +982,34 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             Passed to np.testing.assert_almost_equal
         """
         assert cube.shape == self.shape
-        if not self.unit.is_equivalent(cube.unit, equivalencies=equivalencies):
-            raise u.UnitsError("{0} is not equivalent to {1}"
-                               .format(self.unit, cube.unit))
         if not wcs_utils.check_equality(self.wcs, cube.wcs, warn_missing=True,
                                         **kwargs):
             warnings.warn("Cube WCSs do not match, but their shapes do",
                           WCSMismatchWarning)
+
+        if self.unit.is_equivalent(cube.unit, equivalencies=equivalencies):
+            # units are directly comparable (e.g., both K, or Jy and mJy):
+            # convert the second cube into the first cube's units before
+            # combining the underlying data arrays
+            cube = cube.to(self.unit)
+
         try:
             test_result = function(np.ones([1,1,1])*self.unit,
-                                   np.ones([1,1,1])*self.unit)
+                                   np.ones([1,1,1])*cube.unit)
             # First, check that function returns same # of dims?
             assert test_result.shape == (1,1,1)
+        except u.UnitsError:
+            # units are not equivalent and the operation requires them to be
+            # (e.g., adding a K cube to a dimensionless cube)
+            raise
         except Exception as ex:
             raise AssertionError("Function {1} could not be applied to a "
                                  "pair of simple "
                                  "cube.  The error was: {0}".format(ex,
                                                                     function))
 
-        cube = cube.to(self.unit)
         data = function(self._data, cube._data)
-        try:
-            # multiplication, division, etc. are valid inter-unit operations
-            unit = function(self.unit, cube.unit)
-        except TypeError:
-            # addition, subtraction are not
-            unit = self.unit
+        unit = test_result.unit
 
         return self._new_cube_with(data=data, unit=unit)
 

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -968,7 +968,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         non-equivalent units, since their units simply combine algebraically
         (e.g., a Jy/beam cube multiplied by a dimensionless weight cube
         yields a Jy/beam cube).  ``astropy.units`` enforces this distinction
-        for us via the ``test_result`` computation below.
+        via the ``test_result`` computation below.
 
         Parameters
         ----------

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -961,7 +961,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         Apply an operation between two cubes.  Inherits the metadata of the
         left cube.
 
-        Units do not need to be equivalent for this to succeed: additive
+        Units do not need to be equivalent for some operations: additive
         operations (add, subtract) still require equivalent units (e.g., you
         cannot add a K cube to a Jy/beam cube), but multiplicative operations
         (multiply, divide, power) are allowed between cubes with different,

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -962,7 +962,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         left cube.
 
         Units do not need to be equivalent for some operations: additive
-        operations (add, subtract) still require equivalent units (e.g., you
+        operations (add, subtract) require equivalent units (e.g., you
         cannot add a K cube to a Jy/beam cube), but multiplicative operations
         (multiply, divide, power) are allowed between cubes with different,
         non-equivalent units, since their units simply combine algebraically

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -528,6 +528,36 @@ class TestArithmetic(object):
         assert c2.unit == u.one
         self.c1 = self.d1 = None
 
+    def test_mul_div_unitless_cube(self):
+        # regression test for issue #1011: multiplicative operations
+        # between cubes with non-equivalent units (e.g. K and dimensionless)
+        # should be allowed, since the units combine algebraically
+        unitless = self.c1._new_cube_with(data=self.d1,
+                                          unit=u.dimensionless_unscaled)
+
+        c2 = self.c1 * unitless
+        assert np.all(c2.filled_data[:].value == self.d1 * self.d1)
+        assert c2.unit == u.K
+
+        c3 = self.c1 / unitless
+        assert np.all((c3.filled_data[:].value == self.d1 / self.d1) | (np.isnan(c3.filled_data[:])))
+        assert c3.unit == u.K
+
+        self.c1 = self.d1 = None
+
+    def test_add_sub_unitless_cube_raises(self):
+        # additive operations still require equivalent units
+        unitless = self.c1._new_cube_with(data=self.d1,
+                                          unit=u.dimensionless_unscaled)
+
+        with pytest.raises(u.UnitsError):
+            self.c1 + unitless
+
+        with pytest.raises(u.UnitsError):
+            self.c1 - unitless
+
+        self.c1 = self.d1 = None
+
     @pytest.mark.parametrize(('value'),(1,1.0,2,2.0))
     def test_floordiv(self, value):
         with pytest.raises(NotImplementedError,


### PR DESCRIPTION
## Summary
- Fixes #1011: multiplying/dividing two cubes previously raised `UnitsError` whenever the two cubes' units weren't equivalent, e.g. a `Jy/beam` flux cube and a dimensionless weight cube (a common case for linear mosaicking). Multiplicative operations don't require equivalent units — `astropy.units` already supports combining them algebraically — so this restriction was unnecessarily strict.
- `_cube_on_cube_operation` (which backs `__add__`/`__sub__`/`__mul__`/`__truediv__`/`__pow__` for cube-on-cube arithmetic) no longer performs an upfront blanket `is_equivalent` check. Instead:
  - If the two cubes' units *are* equivalent, the second cube is converted into the first's units before combining data, exactly as before (so e.g. `K * K -> K**2`, `K + K -> K` behavior is unchanged).
  - If the units are *not* equivalent, the raw data is combined directly and the resulting unit is derived by actually performing the operation on `astropy.units.Quantity` instances of shape `(1,1,1)` — `astropy.units` itself enforces that additive operations require equivalent units (raising `UnitsError` otherwise) while multiplicative operations combine units algebraically without that constraint.
- Added regression tests `test_mul_div_unitless_cube` and `test_add_sub_unitless_cube_raises` to `TestArithmetic` in `spectral_cube/tests/test_spectral_cube.py`.
- Added a `CHANGES.rst` entry.

## Test plan
- [x] `pytest spectral_cube/tests/test_spectral_cube.py` — 826 passed, 139 skipped, 12 xfailed (no regressions vs. pre-change baseline of 822 passed)
- [x] Manually verified: `Jy` cube `*`/`/` dimensionless cube now succeeds and returns `Jy`; `+`/`-` between them still correctly raises `UnitsError`; same-unit arithmetic (`K*K`, `K+K`, `K/K`) unchanged
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HF4bi35KXWULhB7ah8ychA
