### PR TITLE
Delegate pixels_per_beam to the radio_beam builtin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@
   non-equivalent units, e.g. a ``Jy/beam`` cube and a dimensionless
   (unitless) cube.  Additive operations still require equivalent units. #1011
 
+- ``pixels_per_beam`` now delegates to the ``radio_beam`` builtin
+  (``Beam.pixels_per_beam`` / ``Beams.pixels_per_beam``), requiring
+  ``radio-beam>=0.3.8``. (radio-astro-tools/radio_beam#109)
+
 0.6.5 (2023-12-05)
 ----------------------
 - Fixed issue with fix from #893 not getting included in the 0.6.4 tag

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,8 +60,8 @@
   ``downsample_axis``, and ``MaskBase._filled``. #973
 
 - ``pixels_per_beam`` now delegates to the ``radio_beam`` builtin
-  (``Beam.pixels_per_beam`` / ``Beams.pixels_per_beam``), requiring
-  ``radio-beam>=0.3.8``. (radio-astro-tools/radio_beam#109)
+  ``Beam.pixels_per_beam``, requiring ``radio-beam>=0.3.10``.
+  (radio-astro-tools/radio_beam#109) #1015
 
 0.6.5 (2023-12-05)
 ----------------------

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -9,7 +9,7 @@ This package has the following dependencies:
 * `Python <http://www.python.org>`_ Python 3.10 or later
 * `Numpy <http://www.numpy.org>`_ 1.24 or later
 * `Astropy <http://www.astropy.org>`__ 6.1 or later
-* `radio_beam <https://github.com/radio-astro-tools/radio_beam>`_ 0.3.5 or later, used when
+* `radio_beam <https://github.com/radio-astro-tools/radio_beam>`_ 0.3.10 or later, used when
   reading in spectral cubes that use the BMAJ/BMIN convention for specifying the beam size.
 * `Bottleneck <http://berkeleyanalytics.com/bottleneck/>`_, optional (speeds
   up median and percentile operations on cubes with missing data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "joblib>=1.3",
   "numpy>=1.24",
   "packaging>=19",
-  "radio-beam>=0.3.5",
+  "radio-beam>=0.3.8",
   "setuptools>=62.3.3",
   "tqdm>=4.64",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "joblib>=1.3",
   "numpy>=1.24",
   "packaging>=19",
-  "radio-beam>=0.3.8",
+  "radio-beam>=0.3.10",
   "setuptools>=62.3.3",
   "tqdm>=4.64",
 ]

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -4,7 +4,6 @@ import numpy as np
 import warnings
 import abc
 
-import astropy
 from astropy.io.fits import Card
 from radio_beam import Beam, Beams
 import dask.array as da
@@ -516,11 +515,7 @@ class MultiBeamMixinClass(object):
     @property
     @cached
     def pixels_per_beam(self):
-        pixels_per_beam = [(beam.sr /
-                (astropy.wcs.utils.proj_plane_pixel_area(self.wcs) *
-                 u.deg**2)).to(u.one).value for beam in self.beams]
-
-        return pixels_per_beam
+        return self.beams.pixels_per_beam(self.wcs)
 
     @property
     def unmasked_beams(self):
@@ -849,6 +844,4 @@ class BeamMixinClass(object):
     @property
     @cached
     def pixels_per_beam(self):
-        return (self.beam.sr /
-                (astropy.wcs.utils.proj_plane_pixel_area(self.wcs) *
-                 u.deg**2)).to(u.one).value
+        return self.beam.pixels_per_beam(self.wcs)

--- a/spectral_cube/base_class.py
+++ b/spectral_cube/base_class.py
@@ -515,7 +515,10 @@ class MultiBeamMixinClass(object):
     @property
     @cached
     def pixels_per_beam(self):
-        return self.beams.pixels_per_beam(self.wcs)
+        # Delegate per beam rather than via ``Beams.pixels_per_beam``: with
+        # numpy<2, the vectorized area of a float32 beam table stays float32
+        # and no longer matches the per-beam factors used by ``to()``.
+        return [beam.pixels_per_beam(self.wcs) for beam in self.beams]
 
     @property
     def unmasked_beams(self):


### PR DESCRIPTION
## Summary
- `BeamMixinClass.pixels_per_beam` and `MultiBeamMixinClass.pixels_per_beam` now delegate to `radio_beam`'s `Beam.pixels_per_beam(wcs)` instead of duplicating the beam-area/pixel-area calculation inline.
- Multi-beam cubes call `Beam.pixels_per_beam` once per beam rather than the vectorized `Beams.pixels_per_beam`. With numpy<2 value-based casting, `Beams.sr` stays float32 for a float32 beam table (as written by CASA), so the vectorized result no longer matched the float64 per-beam factors used by `to()` (`test_multibeam_jpix_checks_array` failed on numpy 1.x by ~7e-8 relative). The per-beam path gives identical float64 values on numpy 1.x and 2.x, and keeps the return type a list as before.
- Bumps the minimum `radio-beam` dependency to `>=0.3.10`, the first release that includes `pixels_per_beam` (radio-astro-tools/radio_beam#150, which closed radio-astro-tools/radio_beam#109). `docs/installing.rst` is updated to match.

This is no longer blocked: radio_beam#150 was merged and released in radio-beam 0.3.10.

Possible upstream follow-up: `Beams.sr` returns float32 on numpy<2 but float64 on numpy>=2 for float32 beam tables.

## Test plan
- [x] CI green, including `py310-test-oldestdeps` (numpy 1.24.0, radio-beam 0.3.10) and `py310-test-casa` (numpy 1.26.4, radio-beam 0.3.10)
- [x] `jpix` tests and beam/unit/convolve/jtok tests pass locally on numpy 1.26.4 and 2.2.6 with radio-beam 0.3.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
