### PR TITLE
Fix Projection.convolve_to missing Jy/beam scaling for beam size change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,11 @@
   non-equivalent units, e.g. a ``Jy/beam`` cube and a dimensionless
   (unitless) cube.  Additive operations still require equivalent units. #1011
 
+- Fixed ``Projection.convolve_to`` (i.e. convolving a single cube slice/plane)
+  silently omitting the ``Jy/beam`` scaling by the change in beam area that
+  ``SpectralCube.convolve_to`` already applies, which could produce
+  incorrect values. #1016
+
 0.6.5 (2023-12-05)
 ----------------------
 - Fixed issue with fix from #893 not getting included in the 0.6.4 tag

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -483,8 +483,6 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass,
         convolution_kernel = \
             beam.deconvolve(self.beam).as_kernel(pixscale)
 
-        # Scale Jy/beam units by the change in beam size, consistent with
-        # SpectralCube.convolve_to (see #1016)
         if self.unit.is_equivalent(u.Jy / u.beam):
             beam_ratio_factor = (beam.sr / self.beam.sr).value
         else:

--- a/spectral_cube/lower_dimensional_structures.py
+++ b/spectral_cube/lower_dimensional_structures.py
@@ -483,9 +483,16 @@ class Projection(LowerDimensionalObject, SpatialCoordMixinClass,
         convolution_kernel = \
             beam.deconvolve(self.beam).as_kernel(pixscale)
 
+        # Scale Jy/beam units by the change in beam size, consistent with
+        # SpectralCube.convolve_to (see #1016)
+        if self.unit.is_equivalent(u.Jy / u.beam):
+            beam_ratio_factor = (beam.sr / self.beam.sr).value
+        else:
+            beam_ratio_factor = 1.
+
         newdata = convolve(self.value, convolution_kernel,
                            normalize_kernel=True,
-                           **kwargs)
+                           **kwargs) * beam_ratio_factor
 
         self = Projection(newdata, unit=self.unit, wcs=self.wcs,
                           meta=self.meta, header=self.header,

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2222,8 +2222,7 @@ def test_convolve_to_jybeam_onebeam(point_source_5_one_beam, use_dask):
 def test_convolve_to_jybeam_onebeam_slice(point_source_5_one_beam, use_dask):
     # regression test for #1016: convolving a single cube slice/plane
     # (a Projection) in Jy/beam units must scale by the change in beam
-    # area, exactly like SpectralCube.convolve_to already does -- prior to
-    # the fix, Projection.convolve_to silently omitted this scaling.
+    # area, exactly like SpectralCube.convolve_to does
     cube, data = cube_and_raw(point_source_5_one_beam, use_dask=use_dask)
     assert cube.unit == u.Jy / u.beam
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2219,6 +2219,32 @@ def test_convolve_to_jybeam_onebeam(point_source_5_one_beam, use_dask):
     assert cube.unit == u.Jy / u.beam
 
 
+def test_convolve_to_jybeam_onebeam_slice(point_source_5_one_beam, use_dask):
+    # regression test for #1016: convolving a single cube slice/plane
+    # (a Projection) in Jy/beam units must scale by the change in beam
+    # area, exactly like SpectralCube.convolve_to already does -- prior to
+    # the fix, Projection.convolve_to silently omitted this scaling.
+    cube, data = cube_and_raw(point_source_5_one_beam, use_dask=use_dask)
+    assert cube.unit == u.Jy / u.beam
+
+    plane = cube[0]
+    target_beam = Beam(10 * u.arcsec)
+
+    convolved_cube = cube.convolve_to(target_beam)
+    convolved_plane = plane.convolve_to(target_beam)
+
+    # convolving a single plane should give the same result as convolving
+    # the whole cube and taking the same channel
+    np.testing.assert_allclose(convolved_plane.value,
+                               convolved_cube[0].value,
+                               atol=1e-5, rtol=1e-5)
+
+    # the peak of the point source should remain ~constant in Jy/beam
+    np.testing.assert_allclose(convolved_plane[5, 5].value,
+                               plane[5, 5].value,
+                               atol=1e-5, rtol=1e-5)
+
+
 def test_convolve_to_jybeam_multibeams(point_source_5_spectral_beams, use_dask):
     cube, data = cube_and_raw(point_source_5_spectral_beams, use_dask=use_dask)
 


### PR DESCRIPTION
**This PR was written by Claude Code.**

## Summary

Fixes #1016.

`Projection.convolve_to` (`spectral_cube/lower_dimensional_structures.py`) — used when convolving a single cube slice/plane, e.g. `cube[0].convolve_to(beam)` — did not scale `Jy/beam` data by the ratio of the new beam's solid angle to the old beam's solid angle:

```python
# Scale Jy/beam units by the change in beam size
if self.unit.is_equivalent(u.Jy / u.beam):
    beam_ratio_factor = (beam.sr / self.beam.sr).value
else:
    beam_ratio_factor = 1.
```

`SpectralCube.convolve_to` and `VaryingResolutionSpectralCube.convolve_to` both already apply this scaling. Since `Jy/beam` is a beam-size-dependent unit, convolving to a different beam without this correction produces values that are off by exactly that ratio — as the issue notes, "the output values can be wrong."

The fix adds the same `beam_ratio_factor` scaling to `Projection.convolve_to`, matching the existing `SpectralCube.convolve_to` implementation.

## Test plan
- Added `test_convolve_to_jybeam_onebeam_slice` to `spectral_cube/tests/test_spectral_cube.py`, using the existing `point_source_5_one_beam` fixture (a `Jy/beam` point-source cube). It checks that convolving a single plane (`cube[0].convolve_to(beam)`) gives the same result as convolving the whole cube and taking the same channel (`cube.convolve_to(beam)[0]`), and that the point source's peak stays ~constant in `Jy/beam`.
- Verified the test **fails** without the source fix (off by exactly the beam-ratio factor — confirmed by temporarily reverting just the source change and re-running) and **passes** with it.
- `pytest spectral_cube/tests/test_spectral_cube.py` — 828 passed, 139 skipped, 12 xfailed (826 baseline + 2 new, no regressions)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HF4bi35KXWULhB7ah8ychA
