### PR TITLE
Build the interpolated mask after reversing the output cube

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,9 +17,8 @@
   ``SpectralCube.convolve_to`` already applies, which could produce
   incorrect values. #1016
 
-- Fixed ``DaskSpectralCube.spectral_interpolate`` building the output mask
-  before reversing the data, so a decreasing output grid returned a mask in
-  the opposite spectral order to the cube it described. #1018
+- Fixed: ``DaskSpectralCube.spectral_interpolate`` was building the output mask
+  in opposite spectral order from the data when the spectrum was reversed #1018
 
 0.6.5 (2023-12-05)
 ----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@
   ``SpectralCube.convolve_to`` already applies, which could produce
   incorrect values. #1016
 
+- Fixed ``DaskSpectralCube.spectral_interpolate`` building the output mask
+  before reversing the data, so a decreasing output grid returned a mask in
+  the opposite spectral order to the cube it described. #1018
+
 0.6.5 (2023-12-05)
 ----------------------
 - Fixed issue with fix from #893 not getting included in the 0.6.4 tag

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -1364,8 +1364,6 @@ class DaskSpectralCubeMixin:
         if reverse_out:
             newcube = newcube[::-1, :, :]
 
-        # must come after the reversal above, otherwise the mask is in the
-        # opposite spectral order to the data it describes
         newbmask = BooleanArrayMask(~np.isnan(newcube), wcs=newwcs)
 
         newcube = self._new_cube_with(data=newcube, wcs=newwcs, mask=newbmask,

--- a/spectral_cube/dask_spectral_cube.py
+++ b/spectral_cube/dask_spectral_cube.py
@@ -1361,10 +1361,12 @@ class DaskSpectralCubeMixin:
             else -outdiff.value
         newwcs.wcs.set()
 
-        newbmask = BooleanArrayMask(~np.isnan(newcube), wcs=newwcs)
-
         if reverse_out:
             newcube = newcube[::-1, :, :]
+
+        # must come after the reversal above, otherwise the mask is in the
+        # opposite spectral order to the data it describes
+        newbmask = BooleanArrayMask(~np.isnan(newcube), wcs=newwcs)
 
         newcube = self._new_cube_with(data=newcube, wcs=newwcs, mask=newbmask,
                                       meta=self.meta,

--- a/spectral_cube/tests/test_regrid.py
+++ b/spectral_cube/tests/test_regrid.py
@@ -347,6 +347,53 @@ def test_spectral_interpolate_with_mask(data_522_delta, use_dask):
     hdul.close()
 
 
+def test_spectral_interpolate_with_mask_reversed_output(data_522_delta, use_dask):
+    # Ascending input axis, descending output grid, so the output is reversed
+    # while a mask is present. The mask must stay aligned with the data.
+
+    cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)
+
+    mask = np.ones(cube.shape, dtype=bool)
+    mask[:2] = False
+
+    masked_cube = cube.with_mask(mask)
+
+    # midpoint between each position, taken in decreasing order
+    sg = (cube.spectral_axis[1:] + cube.spectral_axis[:-1]) / 2.
+
+    result = masked_cube.spectral_interpolate(spectral_grid=sg[::-1])
+
+    assert result.spectral_axis[0] > result.spectral_axis[-1]
+
+    included = np.asarray(result.mask.include()[:, 0, 0])
+    values = np.asarray(result.unmasked_data[:, 0, 0].value)
+
+    # nothing that carries a value may be masked out
+    assert np.all(included[np.isfinite(values)])
+    # the last channel has no valid input on either side
+    assert not included[-1]
+
+    # the delta is at input channel 2 and channels 0 and 1 are masked out, so
+    # in decreasing spectral order the interpolated values are 0, 0.5 and then
+    # two channels with no valid input
+    np.testing.assert_almost_equal(np.asarray(result.filled_data[:, 0, 0].value),
+                                   [0.0, 0.5, np.nan, np.nan])
+
+    # the same grid in increasing order is the mirror image of the above
+    result = masked_cube.spectral_interpolate(spectral_grid=sg)
+
+    assert result.spectral_axis[0] < result.spectral_axis[-1]
+
+    included = np.asarray(result.mask.include()[:, 0, 0])
+    values = np.asarray(result.unmasked_data[:, 0, 0].value)
+
+    assert np.all(included[np.isfinite(values)])
+    assert not included[0]
+
+    np.testing.assert_almost_equal(np.asarray(result.filled_data[:, 0, 0].value),
+                                   [np.nan, np.nan, 0.5, 0.0])
+
+
 def test_spectral_interpolate_reversed(data_522_delta, use_dask):
 
     cube, data = cube_and_raw(data_522_delta, use_dask=use_dask)


### PR DESCRIPTION
`DaskSpectralCube.spectral_interpolate` built `newbmask` from the still-ascending interpolated array and then reversed only the data, so with a decreasing output grid the mask ended up in the opposite spectral order to the cube it described. The non-dask `SpectralCube.spectral_interpolate` and `BaseOneDSpectrum.spectral_interpolate` both write data and mask through the same `outslice`, so they stay aligned — the dask path is the odd one of the three.

Measured on a 10-channel cube whose first three channels are masked out, regridded onto a grid running the other way (the ordinary frequency-cube-onto-a-velocity-grid case):

```
use_dask=False -> [ 9.  8.  7.  6.  5.  4.  3. nan nan nan]
use_dask=True  -> [nan nan nan nan  5.  4. nan nan nan nan]
```

The mask is the mirror image: pre-reversal `~isnan` is `[F F F F T T T T T T]`, applied to data that has since become `[9 8 7 6 5 4 nan nan nan nan]`. Fix is to move the two lines: reverse first, then build the mask.

Why the suite does not see it. `test_spectral_interpolate_with_mask` negates `CDELT3` and passes `sg[::-1]`, which makes the *output* grid ascending, so `reverse_out` is never `True` with a mask present. `test_spectral_interpolate_reversed` is the only `reverse_out=True` case and asserts `result.spectral_axis` only. Separately, both use `result[:, 0, 0].value`, which does not apply the mask — the new test asserts `filled_data` and `mask.include()`.

Ran, same venv, Python 3.13, macOS arm64, `pytest spectral_cube`: 1542 passed / 198 skipped / 17 xfailed before, 1544 / 198 / 17 after, no failures either way. Mutants, each caught by the new test: (A) revert to building the mask first; (B) drop the mask entirely (`mask=None`) — also breaks three existing tests; (C) keep the mask where it was but reverse it unconditionally. (C) is worth noting: it passes every pre-existing test, which is why the new test covers the ascending grid as well.

Not tested: `--remote-data`, casa/glue/yt IO paths, and anything other than macOS arm64 / Python 3.13.

Left alone: the dask path uses `interp1d(fill_value=..., bounds_error=False)` where the non-dask path uses `np.interp(left=, right=)`, so the two disagree by one channel at the edges of the valid range. Separate change.

Implementation, tests and this description were drafted with Claude Opus 5.

