### PR TITLE
Fix get_mask_array() crash when no mask is attached

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@
   silently omitting the ``Jy/beam`` scaling by the change in beam area that
   ``SpectralCube.convolve_to`` already applies, which could produce
   incorrect values. #1016
+- Fixed ``get_mask_array()`` raising ``AttributeError`` on a cube with no
+  mask attached (e.g. one with no blanked/NaN values on read); it now
+  returns an all-``True`` array, consistent with "no mask" meaning every
+  element is included. #1014
 
 0.6.5 (2023-12-05)
 ----------------------

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -552,7 +552,16 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
     def get_mask_array(self):
         """
         Convert the mask to a boolean numpy array
+
+        If no mask is attached to the cube, this returns a read-only
+        array of all `True` (i.e., every element is included) rather
+        than materializing a new writable array, so that the memory
+        footprint stays constant even for large (dask-backed) cubes.
         """
+        if self._mask is None:
+            if isinstance(self._data, da.Array):
+                return da.broadcast_to(True, self._data.shape).rechunk(self._data.chunksize)
+            return np.broadcast_to(True, self._data.shape)
         return self._mask.include(data=self._data, wcs=self._wcs,
                                   wcs_tolerance=self._wcs_tolerance)
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2876,6 +2876,13 @@ def test_mask_none(use_dask):
     assert_quantity_allclose(cube[:, 0, 0],
                              [0, 12] * u.Jy / u.beam)
 
+    # Regression test for issue #1014: get_mask_array() used to raise
+    # AttributeError when no mask was attached to the cube.
+    mask = cube.get_mask_array()
+    assert mask.shape == data.shape
+    assert mask.dtype == bool
+    assert np.all(np.asarray(mask))
+
 
 @pytest.mark.parametrize('filename', ['data_vda', 'data_vda_beams'],
                          indirect=['filename'])


### PR DESCRIPTION
## Summary

Closes #1014.

`SpectralCube.get_mask_array()` assumed `self._mask` is always a `MaskBase` instance:

```python
def get_mask_array(self):
    return self._mask.include(data=self._data, wcs=self._wcs,
                              wcs_tolerance=self._wcs_tolerance)
```

When a cube has no mask attached (e.g. reading in a cube with no NaN/blanked values, such as the CASA-generated PSF in the original report), `self._mask` is `None` and this raises `AttributeError: 'NoneType' object has no attribute 'include'`.

Every other place in `spectral_cube.py` that touches `self._mask` (`with_mask`, `__getitem__`, `with_spectral_unit`, `spectral_slab`, `minimal_subcube`, and their `VaryingResolutionSpectralCube` counterparts) already treats "no mask" as a no-op/passthrough. This fixes `get_mask_array()` to match: if there's no mask, everything is included, so it returns an all-`True` array.

```python
if self._mask is None:
    if isinstance(self._data, da.Array):
        return da.broadcast_to(True, self._data.shape).rechunk(self._data.chunksize)
    return np.broadcast_to(True, self._data.shape)
return self._mask.include(data=self._data, wcs=self._wcs,
                          wcs_tolerance=self._wcs_tolerance)
```

`get_mask_array()` is shared by both `SpectralCube` and `DaskSpectralCube` (defined once on `BaseSpectralCube`), so `np.ones(...)` was deliberately avoided in favor of `broadcast_to`: it keeps the no-mask case at O(1) memory instead of materializing a full array, which matters most for `DaskSpectralCube`, where the whole point of the class is to avoid pulling large cubes into memory.

The only in-tree caller of `get_mask_array()` is `mosaic_cubes()` in `cube_utils.py`, which uses the result purely as `mask.astype(float)` (a read, which copies) — unaffected by the change.

## Points for discussion

A few tradeoffs came up while looking at this that are worth a second opinion on:

1. **Read-only return value.** `broadcast_to` returns a non-writable view (stride-0 on the broadcast axis), whereas every real `MaskBase.include()` implementation returns a normal writable array (they're all built from elementwise comparisons/indexing). So the no-mask branch is the only case where `get_mask_array()`'s output can't be mutated in place (`arr[...] = x` raises `ValueError: assignment destination is read-only`). No current caller mutates the result, but this is a public method, so it's a small, silent behavior difference from the general case. Options: leave as is (my preference — a defensive `.copy()` would reintroduce the exact memory cost this fix is meant to avoid, for a case nothing in-tree needs), or return a writable copy and accept the extra allocation for the no-mask path only.

2. **Loses "no mask" as a distinguishable signal downstream.** Once `get_mask_array()` returns, an all-`True` array from "no mask attached" is indistinguishable from a real mask that happens to be `True` everywhere. `self._mask` itself is untouched (still `None`), so every other method that checks `self._mask is None` directly is unaffected — this only affects the derived array `get_mask_array()` hands back. I don't see an existing or likely consumer that needs to tell these apart (the alternative, raising, is what caused #1014 in the first place), but flagging in case there's a use case I'm missing.

## Test plan

- Extended the existing `test_mask_none` regression test (added when #1014-adjacent issues were fixed previously) to call `get_mask_array()` on a mask-less cube and check shape/dtype/values, parametrized over `use_dask` (covers both `SpectralCube` and `DaskSpectralCube`).
- `pytest spectral_cube/tests/test_spectral_cube.py -k mask` — 150 passed.
- Full `pytest spectral_cube/tests/test_spectral_cube.py` — 838 passed, no new failures.
- `mosaic_cubes` tests in `test_regrid.py` are skipped locally (no `reproject` install) — not exercised here, but the call site is a straight read (`.astype(float)`) so should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)