### PR TITLE
Return None from get_mask_array() when no mask is attached

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,12 @@
   silently omitting the ``Jy/beam`` scaling by the change in beam area that
   ``SpectralCube.convolve_to`` already applies, which could produce
   incorrect values. #1016
+- Fixed ``get_mask_array()`` raising ``AttributeError`` on a cube with no
+  mask attached (e.g. one with no blanked/NaN values on read); it now
+  returns ``None``, consistent with how a missing mask is already handled
+  elsewhere in the class, rather than materializing an all-``True`` array.
+  ``mosaic_cubes()`` (the only in-tree caller) is updated to handle a
+  ``None`` result. #1014
 
 0.6.5 (2023-12-05)
 ----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,9 +28,7 @@
 - Fixed ``get_mask_array()`` raising ``AttributeError`` on a cube with no
   mask attached (e.g. one with no blanked/NaN values on read); it now
   returns ``None``, consistent with how a missing mask is already handled
-  elsewhere in the class, rather than materializing an all-``True`` array.
-  ``mosaic_cubes()`` (the only in-tree caller) is updated to handle a
-  ``None`` result. #1014
+  elsewhere.  #1014
 
 0.6.5 (2023-12-05)
 ----------------------

--- a/spectral_cube/cube_utils.py
+++ b/spectral_cube/cube_utils.py
@@ -866,9 +866,13 @@ def mosaic_cubes(cubes, spectral_block_size=100, combine_header_kwargs={}, **kwa
                           "A more recent version may be needed.")
             cube_repr = cube.reproject(header, **kwargs)
 
-        # Create weighting mask (2D)
-        mask = (cube_repr[0:1].get_mask_array()[0])
-        mask_opt += mask.astype(float)
+        # Create weighting mask (2D). get_mask_array() returns None if no
+        # mask is attached to the cube, meaning every pixel is included.
+        mask = cube_repr[0:1].get_mask_array()
+        if mask is None:
+            mask_opt += 1.
+        else:
+            mask_opt += mask[0].astype(float)
 
         # Go through each slice of the cube, add it to the final array
         for ii in range(final_array.shape[0]):

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -553,10 +553,10 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
         """
         Convert the mask to a boolean numpy array
 
-        Returns `None` if no mask is attached to the cube, consistent
-        with how the rest of the class treats a missing mask (i.e., as
-        "nothing to restrict") rather than materializing an all-`True`
-        array, which would use memory unnecessarily.
+        Returns
+        -------
+        mask : `~numpy.ndarray` or None
+            Boolean array, or `None` if no mask is attached to the cube
         """
         if self._mask is None:
             return None

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -552,7 +552,14 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
     def get_mask_array(self):
         """
         Convert the mask to a boolean numpy array
+
+        Returns `None` if no mask is attached to the cube, consistent
+        with how the rest of the class treats a missing mask (i.e., as
+        "nothing to restrict") rather than materializing an all-`True`
+        array, which would use memory unnecessarily.
         """
+        if self._mask is None:
+            return None
         return self._mask.include(data=self._data, wcs=self._wcs,
                                   wcs_tolerance=self._wcs_tolerance)
 

--- a/spectral_cube/tests/test_spectral_cube.py
+++ b/spectral_cube/tests/test_spectral_cube.py
@@ -2876,6 +2876,11 @@ def test_mask_none(use_dask):
     assert_quantity_allclose(cube[:, 0, 0],
                              [0, 12] * u.Jy / u.beam)
 
+    # Regression test for issue #1014: get_mask_array() used to raise
+    # AttributeError when no mask was attached to the cube; it should
+    # return None instead.
+    assert cube.get_mask_array() is None
+
 
 @pytest.mark.parametrize('filename', ['data_vda', 'data_vda_beams'],
                          indirect=['filename'])


### PR DESCRIPTION
## Summary

Closes #1014. Supersedes #1019 (closed) with the approach agreed on in the issue discussion: return `None` rather than an all-`True` array.

`SpectralCube.get_mask_array()` assumed `self._mask` is always a `MaskBase` instance:

```python
def get_mask_array(self):
    return self._mask.include(data=self._data, wcs=self._wcs,
                              wcs_tolerance=self._wcs_tolerance)
```

When a cube has no mask attached (e.g. reading in a cube with no NaN/blanked values, such as the CASA-generated PSF in the original report), `self._mask` is `None` and this raises `AttributeError: 'NoneType' object has no attribute 'include'`.

As discussed on #1014, `get_mask_array()` now returns `None` in this case, matching how the rest of `spectral_cube.py` already treats a missing mask as "nothing to restrict" (`with_mask`, `__getitem__`, `with_spectral_unit`, `spectral_slab`, `minimal_subcube`, and their `VaryingResolutionSpectralCube` counterparts all branch on `self._mask is None`). This also sidesteps the memory concern @keflavich raised: no array is allocated at all, which matters most for `DaskSpectralCube` (`get_mask_array()` is defined once on `BaseSpectralCube` and shared by both classes, so this keeps large out-of-core cubes from being forced into memory).

```python
def get_mask_array(self):
    if self._mask is None:
        return None
    return self._mask.include(data=self._data, wcs=self._wcs,
                              wcs_tolerance=self._wcs_tolerance)
```

### Updated the one in-tree caller

`mosaic_cubes()` in `cube_utils.py` was the only place in the package calling `get_mask_array()`, and it indexed straight into the result (`cube_repr[0:1].get_mask_array()[0]`), which would now raise on `None`. Updated it to treat a `None` mask as full coverage for that cube (equivalent behavior to before, computed at the call site instead of inside `get_mask_array()`):

```python
mask = cube_repr[0:1].get_mask_array()
if mask is None:
    mask_opt += 1.
else:
    mask_opt += mask[0].astype(float)
```

## Test plan

- `test_mask_none` in `test_spectral_cube.py` now asserts `cube.get_mask_array() is None` for a mask-less cube, parametrized over `use_dask` (covers both `SpectralCube` and `DaskSpectralCube`).
- `pytest spectral_cube/tests/test_spectral_cube.py -k mask` — 150 passed.
- `pytest spectral_cube/tests/test_spectral_cube.py spectral_cube/tests/test_regrid.py` — 874 passed, no new failures.
- `mosaic_cubes` tests in `test_regrid.py` are skipped in this environment (no `reproject` install), so the `cube_utils.py` change isn't exercised by CI-equivalent tests locally, but the logic is a direct, minimal branch on the documented `None` return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)