### PR TITLE
Fix dev tox factor not installing nightly builds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,9 +32,11 @@
 
 - Fixed the ``-dev`` tox test factor silently installing released
   astropy/numpy/pyerfa from PyPI instead of the intended dev/nightly
-  builds, because uv's default index-strategy stops at the first index
-  (PyPI) that satisfies a dependency and never checks the nightly-wheel
-  index. #994
+  builds: uv does not read the pip-style ``PIP_EXTRA_INDEX_URL`` env var
+  the nightly indexes were configured through, and even once pointed at
+  the right indexes (via ``UV_INDEX``), uv does not implicitly allow
+  pre-release versions the way pip does, so it kept selecting the latest
+  released version. #994
 
 0.6.5 (2023-12-05)
 ----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,12 @@
   returns ``None``, consistent with how a missing mask is already handled
   elsewhere.  #1014
 
+- Fixed the ``-dev`` tox test factor silently installing released
+  astropy/numpy/pyerfa from PyPI instead of the intended dev/nightly
+  builds, because uv's default index-strategy stops at the first index
+  (PyPI) that satisfies a dependency and never checks the nightly-wheel
+  index. #994
+
 0.6.5 (2023-12-05)
 ----------------------
 - Fixed issue with fix from #893 not getting included in the 0.6.4 tag

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,11 @@ setenv =
     MPLBACKEND=Agg
     CASASITECONFIG={toxinidir}/.tmp/{envname}/config.py
     dev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    # uv's default index-strategy is "first-index", so it stops at PyPI (which
+    # already has a released astropy/numpy/pyerfa) and never consults the
+    # nightly-wheel index above. unsafe-best-match makes uv compare versions
+    # across all indexes and pick the highest, which is the dev/nightly build.
+    dev: UV_INDEX_STRATEGY = unsafe-best-match
 changedir = .tmp/{envname}
 description = run tests with pytest
 uv_resolution =

--- a/tox.ini
+++ b/tox.ini
@@ -15,12 +15,21 @@ passenv = HOME,DISPLAY,LC_ALL,LC_CTYPE,ON_TRAVIS
 setenv =
     MPLBACKEND=Agg
     CASASITECONFIG={toxinidir}/.tmp/{envname}/config.py
-    dev: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-    # uv's default index-strategy is "first-index", so it stops at PyPI (which
-    # already has a released astropy/numpy/pyerfa) and never consults the
-    # nightly-wheel index above. unsafe-best-match makes uv compare versions
-    # across all indexes and pick the highest, which is the dev/nightly build.
+    # uv does not read the pip-style PIP_EXTRA_INDEX_URL env var, so the
+    # nightly-wheel indexes below were previously silently ignored and
+    # astropy/numpy/pyerfa resolved to their released PyPI versions instead
+    # of the intended dev builds. UV_INDEX is uv's native equivalent.
+    dev: UV_INDEX = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    # uv's default index-strategy is "first-index", so it can stop at PyPI
+    # (which also has released astropy/numpy/pyerfa) before ever consulting
+    # the nightly-wheel indexes above. unsafe-best-match makes uv compare
+    # versions across all indexes and pick the highest.
     dev: UV_INDEX_STRATEGY = unsafe-best-match
+    # A specifier like astropy>=0.0.dev0 does not, on its own, make uv treat
+    # pre-releases as eligible candidates (unlike pip); without this, uv
+    # keeps resolving to the latest released version even when a newer dev
+    # build is available on the indexes above.
+    dev: UV_PRERELEASE = allow
 changedir = .tmp/{envname}
 description = run tests with pytest
 uv_resolution =

--- a/tox.ini
+++ b/tox.ini
@@ -15,20 +15,10 @@ passenv = HOME,DISPLAY,LC_ALL,LC_CTYPE,ON_TRAVIS
 setenv =
     MPLBACKEND=Agg
     CASASITECONFIG={toxinidir}/.tmp/{envname}/config.py
-    # uv does not read the pip-style PIP_EXTRA_INDEX_URL env var, so the
-    # nightly-wheel indexes below were previously silently ignored and
-    # astropy/numpy/pyerfa resolved to their released PyPI versions instead
-    # of the intended dev builds. UV_INDEX is uv's native equivalent.
+    # See #994: uv needs UV_INDEX (not PIP_EXTRA_INDEX_URL), unsafe-best-match,
+    # and explicit prerelease allowance to actually install dev/nightly builds.
     dev: UV_INDEX = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-    # uv's default index-strategy is "first-index", so it can stop at PyPI
-    # (which also has released astropy/numpy/pyerfa) before ever consulting
-    # the nightly-wheel indexes above. unsafe-best-match makes uv compare
-    # versions across all indexes and pick the highest.
     dev: UV_INDEX_STRATEGY = unsafe-best-match
-    # A specifier like astropy>=0.0.dev0 does not, on its own, make uv treat
-    # pre-releases as eligible candidates (unlike pip); without this, uv
-    # keeps resolving to the latest released version even when a newer dev
-    # build is available on the indexes above.
     dev: UV_PRERELEASE = allow
 changedir = .tmp/{envname}
 description = run tests with pytest


### PR DESCRIPTION
## Summary

Fixes #994. The `-dev` tox test factor was not actually installing dev/nightly
builds of astropy/numpy/pyerfa — CI was silently testing against the current
stable releases instead.

## Root cause (two stacked bugs)

1. **`PIP_EXTRA_INDEX_URL` isn't read by uv at all.** It's a pip-only
   compatibility env var; uv's native equivalent is `UV_INDEX`. So the
   nightly-wheel indexes configured for the `dev` factor were silently never
   consulted, and every install just came from the default PyPI index.

2. **uv's pre-release policy doesn't treat `astropy>=0.0.dev0` as "explicit"
   the way pip does.** Even after pointing at the right indexes (`UV_INDEX`),
   uv kept resolving to the latest *released* version, because a lower-bound
   specifier like `>=0.0.dev0` doesn't, on its own, make uv consider
   pre-release candidates. `UV_PRERELEASE=allow` is required.

(`UV_INDEX_STRATEGY=unsafe-best-match` from the first commit on this branch
is also kept — needed so uv compares versions across all three configured
indexes rather than stopping at whichever one it checks first.)

## Fix

```ini
dev: UV_INDEX = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
dev: UV_INDEX_STRATEGY = unsafe-best-match
dev: UV_PRERELEASE = allow
```

## Test plan

- [x] Reproduced the bug locally with `uv pip install --dry-run` against the
      real nightly indexes, isolating both root causes independently.
- [x] Verified locally that the full fix combo resolves dev builds correctly.
- [x] Confirmed on this PR's own CI run
      ([33795919307](https://github.com/radio-astro-tools/spectral-cube/actions/runs/33795919307)):
      - `py311-test-dev` / `py311-test-noviz-dev`: `astropy==8.1.0.devNNN`,
        `pyerfa==2.0.1.7.devNNN` (numpy stays at the released `2.4.6`, since
        numpy's nightly wheels are presently only built for `cp312+` — not a
        bug in this config).
      - `py313-test-viz-noviz-dev` (ubuntu/macos/windows): astropy, numpy,
        and pyerfa all resolve to their dev/nightly builds.