### PR TITLE
Fix to_glue with glue-qt and run glue tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,12 @@ jobs:
         - linux: py311-test-viz
         - linux: py311-test-viz-noviz
         - linux: py312-test
+        # glue tests; Qt needs EGL/xkbcommon system libraries on Linux
+        - linux: py312-test-viz_extra
+          libraries:
+            apt:
+              - libegl1
+              - libxkbcommon0
         - linux: py313-test
         - linux: py313-test-viz-noviz-dev
         - macos: py310-test-noviz

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,10 @@
   ``Beam.pixels_per_beam``, requiring ``radio-beam>=0.3.10``.
   (radio-astro-tools/radio_beam#109) #1015
 
+- Fixed ``to_glue`` with glue-qt, and when passing ``glue_app`` for a cube
+  not previously sent to glue. The ``viz_extra`` tox environment now
+  installs glue-qt and runs in CI. #927
+
 0.6.5 (2023-12-05)
 ----------------------
 - Fixed issue with fix from #893 not getting included in the 0.6.4 tag

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,7 +65,7 @@
 
 - Fixed ``to_glue`` with glue-qt, and when passing ``glue_app`` for a cube
   not previously sent to glue. The ``viz_extra`` tox environment now
-  installs glue-qt and runs in CI. #927
+  installs glue-qt and runs in CI. #927, #1022
 
 0.6.5 (2023-12-05)
 ----------------------

--- a/docs/visualization.rst
+++ b/docs/visualization.rst
@@ -49,3 +49,8 @@ See :doc:`yt_example` for using yt as a visualization tool.
 The `spectral_cube.SpectralCube.to_glue` and
 `spectral_cube.SpectralCube.to_ds9` methods will send the whole cube to glue
 and ds9.  This approach generally requires loading the whole cube into memory.
+
+`spectral_cube.SpectralCube.to_glue` requires glue-qt and a Qt binding such as
+PyQt6, which glue-qt does not install::
+
+    pip install "spectral-cube[viz-extra]" PyQt6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,9 @@ viz = [
   "pvextractor>=0.3",
   "reproject>=0.9.1",
 ]
-viz_extra = [
+# Normalized (hyphenated) name: tox skips extras whose pyproject.toml name
+# differs from the normalized form, so "viz_extra" installed nothing.
+viz-extra = [
   "glue-qt>=0.1",
   "yt; python_version<'3.8'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,6 @@ viz = [
   "pvextractor>=0.3",
   "reproject>=0.9.1",
 ]
-# Normalized (hyphenated) name: tox skips extras whose pyproject.toml name
-# differs from the normalized form, so "viz_extra" installed nothing.
 viz-extra = [
   "glue-qt>=0.1",
   "yt; python_version<'3.8'",

--- a/spectral_cube/spectral_cube.py
+++ b/spectral_cube/spectral_cube.py
@@ -2498,17 +2498,14 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
             name = 'SpectralCube'
 
         try:
-            from glue.app.qt import GlueApplication
-        except ImportError: 
-            from glue_qt.app.application import GlueApplication
-        from glue.core import DataCollection, Data
-        from glue.core.coordinates import coordinates_from_header
-        try:
-            from glue.viewers.image.qt.data_viewer import ImageViewer
-        except ImportError:
+            from glue_qt.app import GlueApplication
             from glue_qt.viewers.image import ImageViewer
         except ImportError:
-            from glue.viewers.image.qt.viewer_widget import ImageWidget as ImageViewer
+            # Older glue versions bundled the Qt interface
+            from glue.app.qt import GlueApplication
+            from glue.viewers.image.qt.data_viewer import ImageViewer
+        from glue.core import DataCollection, Data
+        from glue.core.coordinates import coordinates_from_header
 
         if dataset is not None:
             if name in [d.label for d in dataset.components]:
@@ -2540,7 +2537,7 @@ class BaseSpectralCube(BaseNDClass, MaskableArrayMixinClass,
 
                     return self._glue_app
 
-            glue_app.add_datasets(self._glue_app.data_collection, result)
+            glue_app.add_datasets(result)
 
 
     def to_pvextractor(self):

--- a/spectral_cube/tests/test_visualization.py
+++ b/spectral_cube/tests/test_visualization.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from .test_spectral_cube import cube_and_raw
@@ -31,9 +32,32 @@ def test_mask_quicklook(data_vda_jybeam_lower, use_dask):
 
 
 def test_to_glue(data_vda_jybeam_lower, use_dask):
-    pytest.importorskip('glue')
+    pytest.importorskip('glue_qt')
     cube, data = cube_and_raw(data_vda_jybeam_lower, use_dask=use_dask)
-    cube.to_glue(start_gui=False)
+    app = cube.to_glue(start_gui=False)
+    try:
+        expected = cube.filled_data[:].value
+        glue_data = app.data_collection[0]
+        np.testing.assert_allclose(glue_data['SpectralCube'], expected)
+
+        # Add as a new component of an existing dataset
+        cube.to_glue(dataset=glue_data)
+        np.testing.assert_allclose(glue_data['SpectralCube_'], expected)
+    finally:
+        app.close()
+
+
+def test_to_glue_existing_app(data_vda_jybeam_lower, use_dask):
+    pytest.importorskip('glue_qt')
+    cube, data = cube_and_raw(data_vda_jybeam_lower, use_dask=use_dask)
+    app = cube.to_glue(start_gui=False)
+    try:
+        # A cube that has not been sent to glue before
+        cube2, _ = cube_and_raw(data_vda_jybeam_lower, use_dask=use_dask)
+        cube2.to_glue(name='cube2', glue_app=app, start_gui=False)
+        assert [d.label for d in app.data_collection] == ['SpectralCube', 'cube2']
+    finally:
+        app.close()
 
 
 def test_to_pvextractor(data_vda_jybeam_lower, use_dask):

--- a/spectral_cube/tests/test_visualization.py
+++ b/spectral_cube/tests/test_visualization.py
@@ -35,29 +35,23 @@ def test_to_glue(data_vda_jybeam_lower, use_dask):
     pytest.importorskip('glue_qt')
     cube, data = cube_and_raw(data_vda_jybeam_lower, use_dask=use_dask)
     app = cube.to_glue(start_gui=False)
-    try:
-        expected = cube.filled_data[:].value
-        glue_data = app.data_collection[0]
-        np.testing.assert_allclose(glue_data['SpectralCube'], expected)
+    glue_data = app.data_collection[0]
+    np.testing.assert_allclose(glue_data['SpectralCube'], cube.filled_data[:].value)
 
-        # Add as a new component of an existing dataset
-        cube.to_glue(dataset=glue_data)
-        np.testing.assert_allclose(glue_data['SpectralCube_'], expected)
-    finally:
-        app.close()
+    # Add as a new component of an existing dataset
+    cube.to_glue(dataset=glue_data)
+    assert 'SpectralCube_' in [c.label for c in glue_data.main_components]
+    app.close()
 
 
 def test_to_glue_existing_app(data_vda_jybeam_lower, use_dask):
-    pytest.importorskip('glue_qt')
+    glue_qt_app = pytest.importorskip('glue_qt.app')
     cube, data = cube_and_raw(data_vda_jybeam_lower, use_dask=use_dask)
-    app = cube.to_glue(start_gui=False)
-    try:
-        # A cube that has not been sent to glue before
-        cube2, _ = cube_and_raw(data_vda_jybeam_lower, use_dask=use_dask)
-        cube2.to_glue(name='cube2', glue_app=app, start_gui=False)
-        assert [d.label for d in app.data_collection] == ['SpectralCube', 'cube2']
-    finally:
-        app.close()
+    # Send to an already running glue session
+    app = glue_qt_app.GlueApplication()
+    cube.to_glue(glue_app=app)
+    assert [d.label for d in app.data_collection] == ['SpectralCube']
+    app.close()
 
 
 def test_to_pvextractor(data_vda_jybeam_lower, use_dask):

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ setenv =
     dev: UV_INDEX = https://pypi.anaconda.org/liberfa/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     dev: UV_INDEX_STRATEGY = unsafe-best-match
     dev: UV_PRERELEASE = allow
+    # Run glue's Qt interface headless
+    viz_extra: QT_QPA_PLATFORM = {env:QT_QPA_PLATFORM:offscreen}
 changedir = .tmp/{envname}
 description = run tests with pytest
 uv_resolution =
@@ -36,11 +38,13 @@ deps =
     dev: numpy>=0.0.dev0
     dev: pyerfa>=0.0.dev0
     dev: astropy>=0.0.dev0
+    # glue-qt does not install a Qt binding
+    viz_extra: PyQt6
 extras =
     test
     dev: dev
     viz: viz
-    viz_extra: viz_extra
+    viz_extra: viz-extra
     noviz: noviz
 commands =
     casa: mkdir -p .casa/data


### PR DESCRIPTION
Follow-up to #927.

- `to_glue` tries the `glue_qt` imports first, as glue recommends. `glue.app.qt` was deprecated in favor of `glue_qt.app` and removed in glue-core 1.18. This also drops the unreachable third `except ImportError` fallback.
- Fixes `to_glue(glue_app=...)` for a cube not previously sent to glue (`AttributeError: ... no attribute '_glue_app'`). Also switches to the non-deprecated `add_datasets(data)` signature.
- **CI:** the glue tests never ran, for two reasons:
  - No CI job used `viz_extra`.
  - tox (4.61.4) silently drops extras whose `pyproject.toml` key isn't in normalized form (`_load_deps_from_static`), so the `viz_extra` env never installed glue-qt.

  This PR renames the key to `viz-extra`. Built metadata already published `viz-extra`, so `pip install spectral-cube[viz_extra]` still works. It also installs PyQt6 with the offscreen Qt platform in the tox env and adds a `py312-test-viz_extra` job.
- Adds a regression test for `glue_app=` and checks the data sent to glue.

Locally, `tox -e py312-test-viz_extra` gives 1586 passed, and all 4 glue tests run and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
