### PR TITLE
Add test for reading CASA cubes spanning multiple dask chunks

### DIFF
--- a/spectral_cube/tests/test_casafuncs.py
+++ b/spectral_cube/tests/test_casafuncs.py
@@ -350,3 +350,53 @@ def test_casa_beams_stokes(data_advs_beams_fullstokes, tmp_path):
         assert casacube_component.beams == cube_component.beams
 
         assert isinstance(casacube_component, VaryingResolutionSpectralCube)
+
+
+@pytest.mark.skipif(not CASA_INSTALLED, reason='CASA tests must be run in a CASA environment.')
+@pytest.mark.parametrize('memmap', (False, True))
+def test_casa_read_multiple_chunks(tmp_path, memmap):
+
+    # Regression test for casa-formats-io#70. Reading a CASA mask with
+    # memmap=False returned an empty array for every chunk after the first.
+    # The other tests here all use the 3x4x5 basic.image, which CASA stores as
+    # a single tile and so can never be split into more than one chunk. 64^3 is
+    # the smallest cube CASA splits into multiple tiles.
+
+    from astropy.io import fits
+    from astropy.wcs import WCS
+
+    reference = np.random.random((64, 64, 64)).astype(np.float32)
+    reference[np.isclose(reference, 0.5)] += 0.05
+
+    w = WCS(naxis=3)
+    w.wcs.ctype = ['RA---SIN', 'DEC--SIN', 'FREQ']
+    w.wcs.cdelt = [-1e-4, 1e-4, 1e6]
+    w.wcs.crpix = [1, 1, 1]
+    w.wcs.crval = [24.0, 30.0, 1.4e9]
+    w.wcs.cunit = ['deg', 'deg', 'Hz']
+
+    hdu = fits.PrimaryHDU(reference, header=w.to_header())
+    hdu.header['BUNIT'] = 'Jy/beam'
+    hdu.header['BMAJ'] = 1e-3
+    hdu.header['BMIN'] = 1e-3
+    hdu.header['BPA'] = 0.0
+
+    fits_name = str(tmp_path / 'multichunk.fits')
+    casa_name = str(tmp_path / 'multichunk.image')
+    hdu.writeto(fits_name, overwrite=True)
+
+    ia = image()
+    ia.fromfits(infile=fits_name, outfile=casa_name, overwrite=True)
+    ia.calcmask(mask=f'"{casa_name}">0.5')
+    ia.unlock()
+    ia.close()
+    ia.done()
+
+    # target_chunksize is small enough here to give more than one chunk
+    cube = SpectralCube.read(casa_name, format='casa_image', memmap=memmap,
+                             target_chunksize=50000)
+
+    assert np.prod(cube._data.numblocks) > 1
+
+    assert_allclose(cube.unmasked_data[:].value, reference)
+    assert_allclose(np.asarray(cube.mask.include()), reference > 0.5)


### PR DESCRIPTION
## Why

The CASA read tests all use the 3x4x5 `basic.image`. CASA stores that as a **single tile**, so it can never be split into more than one dask chunk. That means `test_casa_read_basic`'s `memmap` parametrization, despite covering both settings, cannot exercise any of the per-chunk offset arithmetic in casa-formats-io. `target_chunksize` is never exercised anywhere in the suite either.

That gap hid a real bug: reading a CASA mask with `memmap=False` returns an empty array for every chunk after the first, so `SpectralCube.read(..., memmap=False)` fails on any masked CASA cube big enough to need more than one chunk. At the current default `target_chunksize` that is anything over roughly 10 million elements.

## What

Adds `test_casa_read_multiple_chunks`, reading a 64^3 cube - the smallest CASA splits into multiple tiles - with a `target_chunksize` small enough to give several chunks, checking data and mask for both `memmap` settings. The cube is ~1 MB and is built from a FITS file via `ia.fromfits`, so it needs no new checked-in test data.

Verified locally against real casatools:

| | `memmap=False` | `memmap=True` |
|---|---|---|
| with casa-formats-io#70 | PASSED | PASSED |
| without it | `ValueError: cannot reshape array of size 0 into shape (32,32,32)` | PASSED |

`memmap=True` passes either way, which is correct - that path was never broken.

## Blocked on casa-formats-io#70

**This will fail in the `py310-test-casa` job until a casa-formats-io release containing radio-astro-tools/casa-formats-io#70 is on PyPI**, since `pyproject.toml` pulls `casa-formats-io>=0.1` from there. Opening as a draft for that reason; happy to mark it ready once the fix is released, or to fold it into the casa-formats-io PR instead if you would rather keep the regression test on that side only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)